### PR TITLE
feat: Add Source Modal Dialog + URL Extractor Crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -124,10 +124,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -139,7 +139,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower",
  "tower-layer",
@@ -155,16 +155,22 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -177,6 +183,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -277,7 +289,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -341,7 +353,7 @@ dependencies = [
  "chrono",
  "git2",
  "pgvector",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
@@ -368,6 +380,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cowiki-extractor"
+version = "0.1.0"
+dependencies = [
+ "readability",
+ "reqwest 0.12.28",
+ "scraper",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "cowiki-server"
 version = "0.1.0"
 dependencies = [
@@ -381,7 +407,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "git2",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
@@ -458,6 +484,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +515,27 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -509,7 +579,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -517,6 +587,27 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -634,6 +725,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,7 +801,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -740,6 +841,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -784,13 +894,32 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
  "openssl-probe 0.1.6",
  "openssl-sys",
  "url",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -804,7 +933,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -878,6 +1007,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,12 +1053,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -905,8 +1080,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -930,6 +1105,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -938,9 +1137,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.14",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -956,13 +1155,26 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls",
  "tokio",
  "tokio-rustls",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -973,7 +1185,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -987,19 +1199,19 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
- "system-configuration",
+ "socket2 0.6.3",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1236,7 +1448,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.5",
@@ -1304,6 +1516,49 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
+dependencies = [
+ "html5ever 0.26.0",
+ "markup5ever 0.11.0",
+ "tendril 0.4.3",
+ "xml5ever",
+]
 
 [[package]]
 name = "matchers"
@@ -1381,6 +1636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,7 +1714,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1469,7 +1730,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1556,6 +1817,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher 0.3.11",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.3",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.3",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,13 +1984,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1683,12 +2060,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "readability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56596e20a6d3cf715182d9b6829220621e6e985cec04d00410cee29821b4220"
+dependencies = [
+ "html5ever 0.26.0",
+ "lazy_static",
+ "markup5ever_rcdom",
+ "regex",
+ "reqwest 0.11.27",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1697,7 +2088,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1709,6 +2100,18 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1730,21 +2133,61 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.14",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -1756,7 +2199,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tower",
@@ -1803,12 +2246,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1826,6 +2284,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1876,12 +2343,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.39.0",
+ "precomputed-hash",
+ "selectors",
+ "tendril 0.5.0",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1896,6 +2378,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -1931,7 +2432,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1977,6 +2478,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2037,6 +2547,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2571,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2099,7 +2631,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
@@ -2139,7 +2671,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2162,7 +2694,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -2174,8 +2706,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -2218,8 +2750,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
  "byteorder",
  "chrono",
  "crc",
@@ -2283,6 +2815,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,6 +2888,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -2315,6 +2907,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -2333,7 +2931,18 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
 ]
 
 [[package]]
@@ -2342,9 +2951,19 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2371,6 +2990,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,7 +3027,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2436,7 +3076,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2449,7 +3089,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2546,7 +3186,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2559,12 +3199,12 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -2612,7 +3252,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2700,6 +3340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,6 +3374,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2856,7 +3508,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2897,7 +3549,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2911,6 +3563,18 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
@@ -2944,7 +3608,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2955,7 +3619,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3151,6 +3815,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,7 +3854,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3196,7 +3870,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3208,7 +3882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -3245,6 +3919,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xml5ever"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034e1d05af98b51ad7214527730626f019682d797ba38b51689212118d8e650"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.11.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3263,7 +3948,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3284,7 +3969,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3304,7 +3989,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3344,7 +4029,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
 resolver = "2"
-members = ["crates/server", "crates/core", "crates/db", "crates/utils"]
+members = ["crates/server", "crates/core", "crates/db", "crates/utils", "crates/extractor"]
 default-members = ["crates/server"]

--- a/crates/extractor/Cargo.toml
+++ b/crates/extractor/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cowiki-extractor"
+version = "0.1.0"
+edition = "2021"
+description = "URL content extraction library — fetch, extract, clean"
+
+[dependencies]
+reqwest = { version = "0.12", features = ["json"] }
+scraper = "0.27"
+readability = "0.3"
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+url = "2"
+serde = { version = "1", features = ["derive"] }

--- a/crates/extractor/src/clean.rs
+++ b/crates/extractor/src/clean.rs
@@ -1,0 +1,147 @@
+use std::borrow::Cow;
+
+/// Noise patterns to strip from extracted text.
+/// These are common boilerplate lines that appear in article text.
+static NOISE_PATTERNS: &[&str] = &[
+    "Cookie Policy",
+    "Privacy Policy",
+    "Terms of Service",
+    "Terms of Use",
+    "All rights reserved",
+    "Subscribe to our newsletter",
+    "Sign up for our newsletter",
+    "This site uses cookies",
+    "We use cookies",
+    "Accept cookies",
+    "Cookie settings",
+    "Read more",
+    "Click here",
+    "Share this",
+    "Follow us on",
+    "Advertisement",
+    "Sponsored content",
+    "Skip to content",
+    "Skip to main content",
+    "Back to top",
+    "Table of contents",
+];
+
+/// Clean extracted text:
+/// 1. Remove lines matching noise patterns (case-insensitive substring match).
+/// 2. Normalize whitespace within each line (collapse runs of spaces/tabs).
+/// 3. Collapse 3+ consecutive blank lines to at most 2.
+/// 4. Trim the result.
+pub fn clean_text(input: &str) -> String {
+    if input.is_empty() {
+        return String::new();
+    }
+
+    // Process line by line: filter noise, normalize inline whitespace
+    let cleaned_lines: Vec<Cow<str>> = input
+        .lines()
+        .filter(|line| !is_noise_line(line))
+        .map(|line| normalize_line(line))
+        .collect();
+
+    // Collapse 3+ consecutive newlines to 2.
+    // Since each non-blank line contributes a trailing '\n', allowing only 1
+    // blank line between content sections keeps the total at "\n\n" (2 newlines).
+    let mut result = String::with_capacity(input.len());
+    let mut consecutive_blanks: usize = 0;
+
+    for line in &cleaned_lines {
+        if line.trim().is_empty() {
+            consecutive_blanks += 1;
+            if consecutive_blanks <= 1 {
+                result.push('\n');
+            }
+        } else {
+            consecutive_blanks = 0;
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    result.trim().to_string()
+}
+
+/// Return true if the line contains a noise pattern (case-insensitive).
+fn is_noise_line(line: &str) -> bool {
+    let lower = line.to_lowercase();
+    NOISE_PATTERNS
+        .iter()
+        .any(|pat| lower.contains(&pat.to_lowercase()))
+}
+
+/// Collapse runs of spaces and tabs within a single line into a single space.
+fn normalize_line(line: &str) -> Cow<'_, str> {
+    // Fast path: if no consecutive whitespace, return as-is
+    let bytes = line.as_bytes();
+    let mut has_multi_ws = false;
+    let mut prev_ws = false;
+    for &b in bytes {
+        let is_ws = b == b' ' || b == b'\t';
+        if is_ws && prev_ws {
+            has_multi_ws = true;
+            break;
+        }
+        prev_ws = is_ws;
+    }
+
+    if !has_multi_ws {
+        return Cow::Borrowed(line);
+    }
+
+    let mut out = String::with_capacity(line.len());
+    let mut in_ws = false;
+    for ch in line.chars() {
+        if ch == ' ' || ch == '\t' {
+            if !in_ws {
+                out.push(' ');
+                in_ws = true;
+            }
+        } else {
+            in_ws = false;
+            out.push(ch);
+        }
+    }
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_removes_noise_patterns() {
+        let input = "Great article about Rust.\nCookie Policy\nMore content here.\nPrivacy Policy\nEnd.";
+        let result = clean_text(input);
+        assert!(!result.contains("Cookie Policy"), "should remove Cookie Policy");
+        assert!(!result.contains("Privacy Policy"), "should remove Privacy Policy");
+        assert!(result.contains("Great article about Rust."), "should keep real content");
+        assert!(result.contains("More content here."), "should keep real content");
+        assert!(result.contains("End."), "should keep real content");
+    }
+
+    #[test]
+    fn test_collapses_excessive_newlines() {
+        let input = "First paragraph.\n\n\n\n\nSecond paragraph.";
+        let result = clean_text(input);
+        // Should have at most 2 blank lines between paragraphs
+        assert!(!result.contains("\n\n\n"), "should not have 3+ consecutive newlines");
+        assert!(result.contains("First paragraph."), "should keep first paragraph");
+        assert!(result.contains("Second paragraph."), "should keep second paragraph");
+    }
+
+    #[test]
+    fn test_normalizes_whitespace() {
+        let input = "Word1   Word2\tWord3  Word4";
+        let result = clean_text(input);
+        assert_eq!(result, "Word1 Word2 Word3 Word4");
+    }
+
+    #[test]
+    fn test_empty_input() {
+        assert_eq!(clean_text(""), "");
+    }
+}

--- a/crates/extractor/src/fetch.rs
+++ b/crates/extractor/src/fetch.rs
@@ -1,0 +1,32 @@
+use crate::ExtractError;
+use std::time::Duration;
+
+const MAX_BODY_BYTES: usize = 10 * 1024 * 1024; // 10 MB
+const USER_AGENT: &str =
+    "Mozilla/5.0 (compatible; cowiki-extractor/0.1; +https://github.com/cowiki)";
+
+/// Fetch the HTML content at `url`, enforcing a 10 MB size limit.
+pub async fn fetch_url(url: &str) -> Result<String, ExtractError> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent(USER_AGENT)
+        .build()?;
+
+    let response = client.get(url).send().await?;
+
+    // Check Content-Length header first to avoid downloading oversized responses
+    if let Some(content_length) = response.content_length() {
+        if content_length as usize > MAX_BODY_BYTES {
+            return Err(ExtractError::TooLarge);
+        }
+    }
+
+    // Stream the body, bailing out if it exceeds the limit
+    let bytes = response.bytes().await?;
+    if bytes.len() > MAX_BODY_BYTES {
+        return Err(ExtractError::TooLarge);
+    }
+
+    let html = String::from_utf8_lossy(&bytes).into_owned();
+    Ok(html)
+}

--- a/crates/extractor/src/lib.rs
+++ b/crates/extractor/src/lib.rs
@@ -1,0 +1,69 @@
+pub mod clean;
+pub mod fetch;
+pub mod metadata;
+pub mod readability_extract;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractResult {
+    pub url: String,
+    pub title: String,
+    pub text: String,
+    pub metadata: Metadata,
+    pub headings: Vec<Heading>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Metadata {
+    pub description: Option<String>,
+    pub author: Option<String>,
+    pub domain: String,
+    pub og_title: Option<String>,
+    pub og_description: Option<String>,
+    pub og_image: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Heading {
+    pub level: u8,
+    pub text: String,
+}
+
+#[derive(Debug, Error)]
+pub enum ExtractError {
+    #[error("fetch error: {0}")]
+    Fetch(#[from] reqwest::Error),
+    #[error("URL parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+    #[error("extraction error: {0}")]
+    Extract(String),
+    #[error("content too large")]
+    TooLarge,
+}
+
+/// Orchestrates: fetch → metadata → readability → clean
+pub async fn extract_url(target_url: &str) -> Result<ExtractResult, ExtractError> {
+    // Parse URL to extract domain
+    let parsed = url::Url::parse(target_url)?;
+    let domain = parsed.host_str().unwrap_or("").to_string();
+
+    tracing::debug!(url = target_url, "fetching URL");
+    let html = fetch::fetch_url(target_url).await?;
+
+    let title = metadata::extract_title(&html);
+    let meta = metadata::extract_metadata(&html, &domain);
+    let headings = metadata::extract_headings(&html);
+
+    let raw_text = readability_extract::extract_content(&html, target_url);
+    let text = clean::clean_text(&raw_text);
+
+    Ok(ExtractResult {
+        url: target_url.to_string(),
+        title,
+        text,
+        metadata: meta,
+        headings,
+    })
+}

--- a/crates/extractor/src/metadata.rs
+++ b/crates/extractor/src/metadata.rs
@@ -1,0 +1,84 @@
+use crate::{Heading, Metadata};
+use scraper::{Html, Selector};
+
+/// Extract the page title from the `<title>` element.
+pub fn extract_title(html: &str) -> String {
+    let document = Html::parse_document(html);
+    let selector = Selector::parse("title").unwrap();
+    document
+        .select(&selector)
+        .next()
+        .map(|el| el.text().collect::<String>().trim().to_string())
+        .unwrap_or_default()
+}
+
+/// Extract meta tags (description, author) and Open Graph tags.
+pub fn extract_metadata(html: &str, domain: &str) -> Metadata {
+    let document = Html::parse_document(html);
+    let meta_selector = Selector::parse("meta").unwrap();
+
+    let mut description: Option<String> = None;
+    let mut author: Option<String> = None;
+    let mut og_title: Option<String> = None;
+    let mut og_description: Option<String> = None;
+    let mut og_image: Option<String> = None;
+
+    for el in document.select(&meta_selector) {
+        let name = el
+            .value()
+            .attr("name")
+            .or_else(|| el.value().attr("property"))
+            .map(|s| s.to_lowercase());
+        let content = el.value().attr("content").map(|s| s.trim().to_string());
+
+        match (name.as_deref(), content) {
+            (Some("description"), Some(c)) if description.is_none() => {
+                description = Some(c);
+            }
+            (Some("author"), Some(c)) if author.is_none() => {
+                author = Some(c);
+            }
+            (Some("og:title"), Some(c)) if og_title.is_none() => {
+                og_title = Some(c);
+            }
+            (Some("og:description"), Some(c)) if og_description.is_none() => {
+                og_description = Some(c);
+            }
+            (Some("og:image"), Some(c)) if og_image.is_none() => {
+                og_image = Some(c);
+            }
+            _ => {}
+        }
+    }
+
+    Metadata {
+        description,
+        author,
+        domain: domain.to_string(),
+        og_title,
+        og_description,
+        og_image,
+    }
+}
+
+/// Extract all H1–H6 headings in document order.
+pub fn extract_headings(html: &str) -> Vec<Heading> {
+    let document = Html::parse_document(html);
+    let selector = Selector::parse("h1, h2, h3, h4, h5, h6").unwrap();
+    let mut headings = Vec::new();
+
+    for el in document.select(&selector) {
+        let tag = el.value().name();
+        let level: u8 = tag
+            .chars()
+            .nth(1)
+            .and_then(|c| c.to_digit(10))
+            .unwrap_or(1) as u8;
+        let text = el.text().collect::<String>().trim().to_string();
+        if !text.is_empty() {
+            headings.push(Heading { level, text });
+        }
+    }
+
+    headings
+}

--- a/crates/extractor/src/readability_extract.rs
+++ b/crates/extractor/src/readability_extract.rs
@@ -1,0 +1,59 @@
+use scraper::{Html, Selector};
+
+/// Extract main content text from HTML.
+///
+/// Primary: use the `readability` crate's article extractor.
+/// Fallback: CSS selector heuristics to find the main content area.
+pub fn extract_content(html: &str, url: &str) -> String {
+    // Primary: readability extractor
+    if let Ok(parsed_url) = url::Url::parse(url) {
+        let mut bytes = html.as_bytes();
+        match readability::extractor::extract(&mut bytes, &parsed_url) {
+            Ok(product) => {
+                let text = product.text.trim().to_string();
+                if !text.is_empty() {
+                    return text;
+                }
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "readability extractor failed, falling back to CSS heuristics");
+            }
+        }
+    }
+
+    // Fallback: CSS selector heuristics
+    extract_via_selectors(html)
+}
+
+/// Try a series of CSS selectors in priority order and return the first non-empty text.
+fn extract_via_selectors(html: &str) -> String {
+    let document = Html::parse_document(html);
+
+    let candidates = [
+        "main",
+        "article",
+        "[role='main']",
+        ".main-content",
+        "#main-content",
+        ".content",
+        "#content",
+        ".post",
+        ".entry-content",
+        "body",
+    ];
+
+    for selector_str in &candidates {
+        let Ok(selector) = Selector::parse(selector_str) else {
+            continue;
+        };
+        if let Some(el) = document.select(&selector).next() {
+            let text: String = el.text().collect::<Vec<_>>().join(" ");
+            let text = text.trim().to_string();
+            if !text.is_empty() {
+                return text;
+            }
+        }
+    }
+
+    String::new()
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 cowiki-core = { path = "../core" }
 cowiki-db = { path = "../db" }
 cowiki-utils = { path = "../utils" }
+cowiki-extractor = { path = "../extractor" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -2,7 +2,6 @@
 //! Delegates to `cowiki_utils::CowikiConfig` for shared config,
 //! adds server-specific fields (GitHub OAuth).
 
-use clap::Parser;
 pub use cowiki_utils::CliArgs;
 
 #[derive(Debug, Clone)]

--- a/crates/server/src/routes/ingest.rs
+++ b/crates/server/src/routes/ingest.rs
@@ -55,16 +55,7 @@ async fn do_ingest(repo: &cowiki_core::git::WikiRepo, input: IngestRequest) -> R
         format!("source-{short_hash}.md")
     });
 
-    // Validate filename to prevent path traversal
-    if filename.is_empty()
-        || filename.contains("..")
-        || filename.contains('/')
-        || filename.contains('\\')
-        || filename.starts_with('.')
-        || filename.len() > 255
-    {
-        return Err(AppError::BadRequest("invalid filename".into()));
-    }
+    super::validate_source_filename(&filename)?;
 
     // Ensure user branch exists before writing (needed for first ingest on a workspace)
     if input.branch != "main" {

--- a/crates/server/src/routes/ingest.rs
+++ b/crates/server/src/routes/ingest.rs
@@ -44,7 +44,18 @@ pub async fn ingest_ws(
 
 async fn do_ingest(repo: &cowiki_core::git::WikiRepo, input: IngestRequest) -> Result<Json<IngestResponse>> {
     let content = match input.source_type.as_str() {
-        "url" => fetch_url(&input.content).await?,
+        "url" => {
+            let result = cowiki_extractor::extract_url(&input.content)
+                .await
+                .map_err(|e| AppError::Internal(format!("URL extraction failed: {e}")))?;
+            format!(
+                "---\ntitle: \"{}\"\nsource_url: \"{}\"\ndomain: \"{}\"\n---\n\n{}",
+                result.title.replace('"', "\\\""),
+                result.url,
+                result.metadata.domain,
+                result.text,
+            )
+        }
         "text" | "file" => input.content.clone(),
         _ => return Err(AppError::BadRequest("invalid source_type".into())),
     };
@@ -70,13 +81,4 @@ async fn do_ingest(repo: &cowiki_core::git::WikiRepo, input: IngestRequest) -> R
     ).map_err(|e| AppError::Internal(e.to_string()))?;
 
     Ok(Json(IngestResponse { filename, content_hash: hash }))
-}
-
-async fn fetch_url(url: &str) -> Result<String> {
-    reqwest::get(url)
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
-        .text()
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))
 }

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -8,3 +8,19 @@ pub mod search;
 pub mod sources;
 pub mod submit;
 pub mod workspace;
+
+use crate::error::{AppError, Result};
+
+/// Validate source filename to prevent path traversal attacks.
+pub fn validate_source_filename(filename: &str) -> Result<()> {
+    if filename.is_empty()
+        || filename.contains("..")
+        || filename.contains('/')
+        || filename.contains('\\')
+        || filename.starts_with('.')
+        || filename.len() > 255
+    {
+        return Err(AppError::BadRequest("invalid filename".into()));
+    }
+    Ok(())
+}

--- a/crates/server/src/routes/sources.rs
+++ b/crates/server/src/routes/sources.rs
@@ -51,34 +51,8 @@ fn load_compile_state(repo: &cowiki_core::git::WikiRepo, branch: &str) -> HashMa
         .unwrap_or_default()
 }
 
+/// Find wiki pages that reference a source (from pre-loaded wiki contents).
 fn find_referencing_pages(
-    repo: &cowiki_core::git::WikiRepo,
-    branch: &str,
-    source_filename: &str,
-) -> Vec<String> {
-    let wiki_files = repo.list_files_recursive(branch, "wiki").unwrap_or_default();
-    let mut pages = Vec::new();
-    for file in &wiki_files {
-        if let Ok(Some(content)) = repo.read_file(branch, file) {
-            let text = String::from_utf8_lossy(&content);
-            if text.contains(&format!("  - {source_filename}"))
-                || text.contains(&format!("- {source_filename}"))
-            {
-                let slug = file
-                    .strip_prefix("wiki/")
-                    .unwrap_or(file)
-                    .strip_suffix(".md")
-                    .unwrap_or(file)
-                    .to_string();
-                pages.push(slug);
-            }
-        }
-    }
-    pages
-}
-
-/// Pre-load all wiki file contents for a branch once, then find referencing pages.
-fn find_referencing_pages_batched(
     wiki_contents: &[(String, String)],
     source_filename: &str,
 ) -> Vec<String> {
@@ -141,7 +115,7 @@ pub async fn list_sources(
             .to_string();
         let compiled = compile_state.contains_key(&filename);
         let compiled_pages = if compiled {
-            find_referencing_pages_batched(&wiki_contents, &filename)
+            find_referencing_pages(&wiki_contents, &filename)
         } else {
             Vec::new()
         };
@@ -155,16 +129,7 @@ pub async fn get_source(
     Path((ws_slug, filename)): Path<(String, String)>,
     Query(params): Query<GetSourceParams>,
 ) -> Result<Json<SourceContent>> {
-    // Path traversal protection
-    if filename.is_empty()
-        || filename.contains("..")
-        || filename.contains('/')
-        || filename.contains('\\')
-        || filename.starts_with('.')
-        || filename.len() > 255
-    {
-        return Err(AppError::BadRequest("invalid filename".into()));
-    }
+    super::validate_source_filename(&filename)?;
 
     let repo = state
         .repo_manager
@@ -172,11 +137,6 @@ pub async fn get_source(
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
 
     let branch = &params.branch;
-    // Ensure branch exists (lazy-create for user branches)
-    if branch != "main" {
-        repo.ensure_branch_exists(branch)
-            .map_err(|e| AppError::Internal(format!("failed to create branch {}: {e}", branch)))?;
-    }
     let file_path = format!("sources/{filename}");
     let content_bytes = repo
         .read_file(branch, &file_path)
@@ -187,7 +147,8 @@ pub async fn get_source(
     let compile_state = load_compile_state(&repo, branch);
     let compiled = compile_state.contains_key(&filename);
     let compiled_pages = if compiled {
-        find_referencing_pages(&repo, branch, &filename)
+        let wiki_contents = load_all_wiki(&repo, branch);
+        find_referencing_pages(&wiki_contents, &filename)
     } else {
         Vec::new()
     };

--- a/web/src/components/AddSourceDialog.tsx
+++ b/web/src/components/AddSourceDialog.tsx
@@ -24,7 +24,7 @@ export function AddSourceDialog({
   workspaceSlug,
   onDone,
 }: AddSourceDialogProps) {
-  const [activeTab, setActiveTab] = useState<'text' | 'url'>('text');
+  const [activeTab, setActiveTab] = useState<'text' | 'url'>('url');
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -61,7 +61,7 @@ export function AddSourceDialog({
         <DialogHeader>
           <DialogTitle>
             Add Source to{' '}
-            <span className="text-[var(--color-accent)]">{workspaceName}</span>
+            <span className="text-foreground/70 italic">{workspaceName}</span>
           </DialogTitle>
         </DialogHeader>
 

--- a/web/src/components/AddSourceDialog.tsx
+++ b/web/src/components/AddSourceDialog.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { Type, Link2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { ingest } from '../api';
+
+interface AddSourceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  branch: string;
+  workspaceName: string;
+  workspaceSlug: string;
+  onDone: () => void;
+}
+
+export function AddSourceDialog({
+  open,
+  onOpenChange,
+  branch,
+  workspaceName,
+  workspaceSlug,
+  onDone,
+}: AddSourceDialogProps) {
+  const [activeTab, setActiveTab] = useState<'text' | 'url'>('text');
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      setContent('');
+      setError('');
+    }
+    onOpenChange(isOpen);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!content.trim() || loading) return;
+    setLoading(true);
+    setError('');
+    try {
+      await ingest(activeTab, content, branch, undefined, workspaceSlug);
+      setContent('');
+      setError('');
+      onDone();
+      onOpenChange(false);
+    } catch (err) {
+      setError(`Failed to add source: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            Add Source to{' '}
+            <span className="text-[var(--color-accent)]">{workspaceName}</span>
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Tabs
+            value={activeTab}
+            onValueChange={(v) => {
+              setActiveTab(v as 'text' | 'url');
+              setContent('');
+              setError('');
+            }}
+          >
+            <TabsList>
+              <TabsTrigger value="text">
+                <Type className="h-4 w-4" />
+                Text
+              </TabsTrigger>
+              <TabsTrigger value="url">
+                <Link2 className="h-4 w-4" />
+                URL
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="text" className="mt-3">
+              <Textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="Paste or type your content here..."
+                rows={8}
+              />
+            </TabsContent>
+
+            <TabsContent value="url" className="mt-3 space-y-1.5">
+              <Input
+                type="url"
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="https://example.com/article"
+              />
+              <p className="text-xs text-muted-foreground">
+                The page content will be automatically extracted and cleaned.
+              </p>
+            </TabsContent>
+          </Tabs>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <Button type="submit" disabled={!content.trim() || loading}>
+            {loading ? 'Adding...' : 'Add Source'}
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -110,10 +110,10 @@ export function MainLayout() {
       await loadSpaceSources(personal);
     }
 
-    // Restore page from URL: /:owner/:wsSlug/:pageSlug
+    // Restore page from URL: /:wsSlug/:pageSlug
     const pathParts = location.pathname.split('/').filter(Boolean);
-    if (pathParts.length >= 3) {
-      const [, wsSlug, ...pageParts] = pathParts;
+    if (pathParts.length >= 2) {
+      const [wsSlug, ...pageParts] = pathParts;
       const pageSlug = pageParts.join('/');
       const targetWs = ws.find((w) => w.slug === wsSlug);
       if (targetWs) {
@@ -141,8 +141,7 @@ export function MainLayout() {
       const firstPage = personalPages.find((p) => p.kind === 'page');
       if (firstPage) {
         setActiveView({ kind: 'page', slug: firstPage.slug, content: null });
-        const owner = auth?.name || 'user';
-        navigate(`/${owner}/${personal.slug}/${firstPage.slug}`, { replace: true });
+        navigate(`/${personal.slug}/${firstPage.slug}`, { replace: true });
         try {
           const page = await getPage(firstPage.slug, userBranch, personal.slug);
           setActiveView(prev => prev?.kind === 'page' ? { ...prev, content: page } : prev);
@@ -245,8 +244,7 @@ export function MainLayout() {
   const selectPage = async (ws: Workspace, slug: string) => {
     setActiveWorkspace(ws);
     setActiveView({ kind: 'page', slug, content: null });
-    const owner = auth?.name || 'user';
-    navigate(`/${owner}/${ws.slug}/${slug}`, { replace: true });
+    navigate(`/${ws.slug}/${slug}`, { replace: true });
 
     const setContent = (content: PageFull | null) =>
       setActiveView(prev => prev?.kind === 'page' ? { ...prev, content } : prev);
@@ -311,8 +309,7 @@ export function MainLayout() {
       await loadSpacePages(ws);
       // Set page content directly from what we just wrote — avoids a re-fetch that may fail
       setActiveView({ kind: 'page', slug, content: { slug, title, summary: '', body, branch: userBranch, kind: 'page', children: [] } });
-      const owner = auth?.name || 'user';
-      navigate(`/${owner}/${ws.slug}/${slug}`, { replace: true });
+      navigate(`/${ws.slug}/${slug}`, { replace: true });
     } catch {
       setMessage({ text: 'Failed to create page', type: 'error' });
     }

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -29,7 +29,7 @@ import {
   listSources, getSource,
   type Workspace, type PageMeta, type PageFull, type PendingInvitation, type MemberInfo, type SourceItem, type SourceContent,
 } from '../api';
-import { IngestForm } from '../components/IngestForm';
+import { AddSourceDialog } from '@/components/AddSourceDialog';
 import { SettingsDialog } from '../components/SettingsDialog';
 import { getStoredAuth, clearAuth } from '../auth';
 
@@ -761,15 +761,15 @@ export function MainLayout() {
               </div>
             )}
 
-            {/* Ingest panel */}
-            {showIngest && activeWorkspace && (
-              <div className="mx-6 mt-2 rounded-lg border border-[var(--color-border)] p-4 bg-[var(--color-bg-secondary)]">
-                <div className="text-xs text-[var(--color-text-tertiary)] mb-2">
-                  Add source to <span className="font-medium text-[var(--color-text)]">{activeWorkspace.name}</span>
-                </div>
-                <IngestForm branch={userBranch} onDone={handleIngestDone} workspaceSlug={activeWorkspace.slug} />
-              </div>
-            )}
+            {/* Ingest dialog */}
+            <AddSourceDialog
+              open={showIngest && !!activeWorkspace}
+              onOpenChange={(open) => setShowIngest(open)}
+              branch={userBranch}
+              workspaceName={activeWorkspace?.name || ''}
+              workspaceSlug={activeWorkspace?.slug || ''}
+              onDone={handleIngestDone}
+            />
 
             {/* Content */}
             <div className="max-w-3xl px-16 py-10">

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -703,25 +703,22 @@ export function MainLayout() {
           <SidebarInset>
             {/* Top bar with breadcrumb + actions */}
             {activeView?.content ? (
-              <div className="sticky top-0 z-10 bg-[var(--color-bg)] border-b border-[var(--color-border)] px-6 py-2 flex items-center justify-between">
-                <div className="flex items-center gap-1.5 text-sm text-[var(--color-text-secondary)]">
-                  <span>{auth?.name}</span>
+              <div className="sticky top-0 z-10 bg-[var(--color-bg)] border-b border-[var(--color-border)] px-6 py-2 flex items-center justify-between min-w-0">
+                <div className="flex items-center gap-1.5 text-sm text-[var(--color-text-secondary)] min-w-0 overflow-hidden">
                   {activeView.kind === 'page' && activeView.content && (
                     <>
-                      <span className="text-[var(--color-text-tertiary)]">/</span>
-                      <span>{activeWorkspace?.name}</span>
-                      <span className="text-[var(--color-text-tertiary)]">/</span>
-                      <span className="text-[var(--color-text)]">{activeView.content.title}</span>
+                      <span className="shrink-0">{activeWorkspace?.name}</span>
+                      <span className="text-[var(--color-text-tertiary)] shrink-0">/</span>
+                      <span className="text-[var(--color-text)] truncate">{activeView.content.title}</span>
                     </>
                   )}
                   {activeView.kind === 'source' && (
                     <>
-                      <span className="text-[var(--color-text-tertiary)]">/</span>
-                      <span>{activeWorkspace?.name}</span>
-                      <span className="text-[var(--color-text-tertiary)]">/</span>
-                      <span className="text-[var(--color-text-tertiary)]">sources</span>
-                      <span className="text-[var(--color-text-tertiary)]">/</span>
-                      <span className="text-[var(--color-text)]">{activeView.filename}</span>
+                      <span className="shrink-0">{activeWorkspace?.name}</span>
+                      <span className="text-[var(--color-text-tertiary)] shrink-0">/</span>
+                      <span className="text-[var(--color-text-tertiary)] shrink-0">sources</span>
+                      <span className="text-[var(--color-text-tertiary)] shrink-0">/</span>
+                      <span className="text-[var(--color-text)] truncate">{activeView.filename}</span>
                     </>
                   )}
                 </div>
@@ -731,7 +728,7 @@ export function MainLayout() {
                     className="flex items-center gap-1.5 px-2.5 py-1 rounded text-xs text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors"
                     title={activeWorkspace ? `Add source to ${activeWorkspace.name}` : 'Add Source'}
                   >
-                    <Upload size={13} /> Add Source{activeWorkspace ? ` to ${activeWorkspace.name}` : ''}
+                    <Upload size={13} /> Add Source
                   </button>
                   <button
                     onClick={handleCompile}

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -1046,6 +1046,74 @@ export function MainLayout() {
 
 // ── Sidebar Components ──
 
+/**
+ * SourcesFolder: Reusable Sources section for both personal and shared workspaces.
+ * @param indent - CSS class for indentation (e.g., "" for personal, "pl-4" for shared)
+ * @param emptyIndent - CSS class for empty state padding (e.g., "pl-8" for personal, "pl-12" for shared)
+ */
+function SourcesFolder({
+  sources,
+  onSelectSource,
+  onSelectPage,
+  onShowIngest,
+  onCompile,
+  indent = '',
+  emptyIndent = 'pl-8',
+}: {
+  sources: SourceItem[];
+  onSelectSource: (filename: string) => void;
+  onSelectPage: (slug: string) => void;
+  onShowIngest: () => void;
+  onCompile: () => void;
+  indent?: string;
+  emptyIndent?: string;
+}) {
+  const [sourcesExpanded, setSourcesExpanded] = useState(false);
+
+  return (
+    <>
+      <SidebarMenuItem className={`group/source-folder relative ${indent}`}>
+        <SidebarMenuButton onClick={() => setSourcesExpanded(!sourcesExpanded)}>
+          <ChevronRight size={12} className={`transition-transform ${sourcesExpanded ? 'rotate-90' : ''}`} />
+          <Folder size={16} />
+          <span>Sources</span>
+        </SidebarMenuButton>
+        <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5 opacity-0 group-hover/source-folder:opacity-100 transition-all">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="p-0.5 rounded text-sidebar-foreground/40 hover:text-sidebar-foreground/70 outline-none focus:outline-none ring-0 focus:ring-0">
+                <MoreHorizontal size={12} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-36">
+              <DropdownMenuItem onClick={onShowIngest}><Upload size={14} className="mr-2" /> Add Source</DropdownMenuItem>
+              <DropdownMenuItem onClick={onCompile}><Wand2 size={14} className="mr-2" /> Compile</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </SidebarMenuItem>
+      {sourcesExpanded && (
+        <>
+          {sources.length === 0 ? (
+            <SidebarMenuItem className={emptyIndent}>
+              <span className="text-xs text-sidebar-foreground/40 italic">No sources yet</span>
+            </SidebarMenuItem>
+          ) : (
+            sources.map((s) => (
+              <SourceTreeItem
+                key={s.filename}
+                source={s}
+                onSelect={() => onSelectSource(s.filename)}
+                onSelectPage={onSelectPage}
+              />
+            ))
+          )}
+        </>
+      )}
+    </>
+  );
+}
+
 function SpaceSection({
   workspace, label, pages, sources, expanded, activeWorkspace, activeView, onToggle, onSelectPage, onSelectSource, onShowIngest, onCompile, onNewPage, onNewFolder, onAddPageInFolder, onAddFolderInFolder,
 }: {
@@ -1057,7 +1125,6 @@ function SpaceSection({
   onNewPage: () => void; onNewFolder: () => void;
   onAddPageInFolder: (folderPath: string) => void; onAddFolderInFolder: (parentPath: string) => void;
 }) {
-  const [sourcesExpanded, setSourcesExpanded] = useState(false);
   return (
     <SidebarGroup>
       <SidebarGroupLabel className="group/label">
@@ -1077,44 +1144,14 @@ function SpaceSection({
       {expanded && (
         <>
           {/* Sources Section — pinned at top */}
-          <SidebarMenuItem className="group/source-folder relative">
-            <SidebarMenuButton onClick={() => setSourcesExpanded(!sourcesExpanded)}>
-              <ChevronRight size={12} className={`transition-transform ${sourcesExpanded ? 'rotate-90' : ''}`} />
-              <Folder size={16} />
-              <span>Sources</span>
-            </SidebarMenuButton>
-            <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5 opacity-0 group-hover/source-folder:opacity-100 transition-all">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button className="p-0.5 rounded text-sidebar-foreground/40 hover:text-sidebar-foreground/70 outline-none focus:outline-none ring-0 focus:ring-0">
-                    <MoreHorizontal size={12} />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-36">
-                  <DropdownMenuItem onClick={onShowIngest}><Upload size={14} className="mr-2" /> Add Source</DropdownMenuItem>
-                  <DropdownMenuItem onClick={onCompile}><Wand2 size={14} className="mr-2" /> Compile</DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </SidebarMenuItem>
-          {sourcesExpanded && (
-            <>
-              {sources.length === 0 ? (
-                <SidebarMenuItem className="pl-8">
-                  <span className="text-xs text-sidebar-foreground/40 italic">No sources yet</span>
-                </SidebarMenuItem>
-              ) : (
-                sources.map((s) => (
-                  <SourceTreeItem
-                    key={s.filename}
-                    source={s}
-                    onSelect={() => onSelectSource(s.filename)}
-                    onSelectPage={onSelectPage}
-                  />
-                ))
-              )}
-            </>
-          )}
+          <SourcesFolder
+            sources={sources}
+            onSelectSource={onSelectSource}
+            onSelectPage={onSelectPage}
+            onShowIngest={onShowIngest}
+            onCompile={onCompile}
+            emptyIndent="pl-8"
+          />
           <SidebarMenu>
             {pages.map((p) => (
               <PageItem
@@ -1146,7 +1183,6 @@ function SpaceTreeItem({
   onInvite: () => void; onManageMembers: () => void; onDelete: () => void;
 }) {
   const isOwner = workspace.role === 'owner';
-  const [sourcesExpanded, setSourcesExpanded] = useState(false);
   return (
     <>
       <SidebarMenuItem className="group/space relative">
@@ -1194,44 +1230,15 @@ function SpaceTreeItem({
       {expanded && (
         <>
           {/* Sources Section — pinned at top, indented like pages */}
-          <SidebarMenuItem className="group/source-folder relative pl-4">
-            <SidebarMenuButton onClick={() => setSourcesExpanded(!sourcesExpanded)}>
-              <ChevronRight size={12} className={`transition-transform ${sourcesExpanded ? 'rotate-90' : ''}`} />
-              <Folder size={16} />
-              <span>Sources</span>
-            </SidebarMenuButton>
-            <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5 opacity-0 group-hover/source-folder:opacity-100 transition-all">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button className="p-0.5 rounded text-sidebar-foreground/40 hover:text-sidebar-foreground/70 outline-none focus:outline-none ring-0 focus:ring-0">
-                    <MoreHorizontal size={12} />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-36">
-                  <DropdownMenuItem onClick={onShowIngest}><Upload size={14} className="mr-2" /> Add Source</DropdownMenuItem>
-                  <DropdownMenuItem onClick={onCompile}><Wand2 size={14} className="mr-2" /> Compile</DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </SidebarMenuItem>
-          {sourcesExpanded && (
-            <>
-              {sources.length === 0 ? (
-                <SidebarMenuItem className="pl-12">
-                  <span className="text-xs text-sidebar-foreground/40 italic">No sources yet</span>
-                </SidebarMenuItem>
-              ) : (
-                sources.map((s) => (
-                  <SourceTreeItem
-                    key={s.filename}
-                    source={s}
-                    onSelect={() => onSelectSource(s.filename)}
-                    onSelectPage={onSelectPage}
-                  />
-                ))
-              )}
-            </>
-          )}
+          <SourcesFolder
+            sources={sources}
+            onSelectSource={onSelectSource}
+            onSelectPage={onSelectPage}
+            onShowIngest={onShowIngest}
+            onCompile={onCompile}
+            indent="pl-4"
+            emptyIndent="pl-12"
+          />
         </>
       )}
       {expanded && pages.map((p) => (
@@ -1286,7 +1293,7 @@ function SourceTreeItem({ source, onSelect, onSelectPage }: {
   );
 }
 
-function PageItem({ page, isActive, onSelect, onSelectChild, onAddPage, onAddFolder, depth = 0, activeSlug }: {
+function PageItem({ page, isActive, onSelect, onSelectChild, onAddPage, onAddFolder, depth = 0, activeSlug = null }: {
   page: PageMeta; isActive: boolean; onSelect: () => void;
   onSelectChild?: (slug: string) => void; onAddPage?: (folderPath: string) => void;
   onAddFolder?: (parentPath: string) => void; depth?: number; activeSlug?: string | null;


### PR DESCRIPTION
## Summary

- **Add Source Modal Dialog (Issue #9)**: Replace inline IngestForm panel with a shadcn/ui Dialog + Tabs (Text / URL modes)
- **cowiki-extractor crate (Issue #24)**: New standalone crate for intelligent URL content extraction using readability + CSS selector fallback
- **Ingest integration**: URL sources now store clean extracted text with YAML frontmatter (title, source_url, domain) instead of raw HTML
- **Frontend refactors**: Extract SourcesFolder component, fix breadcrumb routing

## Changes

### New: `crates/extractor/` (cowiki-extractor)
- `fetch.rs` — HTTP fetch with 30s timeout, Mozilla UA, 10MB size limit
- `readability_extract.rs` — Readability-based content extraction with CSS selector fallback
- `metadata.rs` — Title, meta tags, Open Graph extraction
- `clean.rs` — Text cleaning with noise removal + 4 unit tests
- Zero coupling to other cowiki crates — designed as a standalone publishable crate

### Frontend
- `AddSourceDialog.tsx` — New Dialog component with Text/URL tabs
- `MainLayout.tsx` — Swapped inline panel for Dialog
- `SourcesFolder` extraction and breadcrumb fixes

### Backend
- `ingest.rs` — Replaced raw `reqwest::get()` with `cowiki_extractor::extract_url()`

## Test plan

- [x] `cargo test -p cowiki-extractor` — 4/4 tests pass
- [x] `cargo check -p cowiki-server` — compiles clean
- [x] `npx tsc --noEmit` — no TypeScript errors
- [ ] Manual: open dialog, add text source, add URL source, verify extracted content quality

Closes #9
Related: #24, #23

🤖 Generated with [Claude Code](https://claude.ai/claude-code)