### PR TITLE
fix(sources): use source_pages mapping instead of string matching to find compiled pages

### DIFF
--- a/crates/server/src/routes/compile.rs
+++ b/crates/server/src/routes/compile.rs
@@ -27,8 +27,10 @@ pub struct CompiledPage {
 }
 
 #[derive(Serialize, Deserialize, Default)]
-struct CompileState {
-    sources: HashMap<String, String>,
+pub(crate) struct CompileState {
+    pub sources: HashMap<String, String>,
+    #[serde(default)]
+    pub source_pages: HashMap<String, Vec<String>>,
 }
 
 /// Legacy compile (uses default repo)
@@ -119,6 +121,15 @@ async fn do_compile(
         if let Ok(emb) = state.compiler.embed(&format!("{}\n{}", page.title, page.summary)).await {
             cowiki_db::pages::upsert(&state.db, &page.slug, &page.title, &page.summary, branch, &hash, Some(&emb), default_user.id)
                 .await.ok();
+        }
+
+        // Record source→page mapping from the compiler's output
+        for source in &page.sources {
+            compile_state
+                .source_pages
+                .entry(source.clone())
+                .or_default()
+                .push(page.slug.clone());
         }
 
         result_pages.push(CompiledPage { slug: page.slug.clone(), title: page.title.clone(), summary: page.summary.clone() });

--- a/crates/server/src/routes/sources.rs
+++ b/crates/server/src/routes/sources.rs
@@ -1,7 +1,6 @@
 use axum::extract::{Path, Query, State};
 use axum::Json;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::error::{AppError, Result};
@@ -38,78 +37,12 @@ pub struct SourceContent {
     pub compiled_pages: Vec<String>,
 }
 
-fn load_compile_state(repo: &cowiki_core::git::WikiRepo, branch: &str) -> HashMap<String, String> {
-    #[derive(Deserialize, Default)]
-    struct CompileState {
-        sources: HashMap<String, String>,
-    }
+fn load_compile_state(repo: &cowiki_core::git::WikiRepo, branch: &str) -> super::compile::CompileState {
     repo.read_file(branch, ".cowiki/state.json")
         .ok()
         .flatten()
-        .and_then(|bytes| serde_json::from_slice::<CompileState>(&bytes).ok())
-        .map(|s| s.sources)
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
         .unwrap_or_default()
-}
-
-fn find_referencing_pages(
-    repo: &cowiki_core::git::WikiRepo,
-    branch: &str,
-    source_filename: &str,
-) -> Vec<String> {
-    let wiki_files = repo.list_files_recursive(branch, "wiki").unwrap_or_default();
-    let mut pages = Vec::new();
-    for file in &wiki_files {
-        if let Ok(Some(content)) = repo.read_file(branch, file) {
-            let text = String::from_utf8_lossy(&content);
-            if text.contains(&format!("  - {source_filename}"))
-                || text.contains(&format!("- {source_filename}"))
-            {
-                let slug = file
-                    .strip_prefix("wiki/")
-                    .unwrap_or(file)
-                    .strip_suffix(".md")
-                    .unwrap_or(file)
-                    .to_string();
-                pages.push(slug);
-            }
-        }
-    }
-    pages
-}
-
-/// Pre-load all wiki file contents for a branch once, then find referencing pages.
-fn find_referencing_pages_batched(
-    wiki_contents: &[(String, String)],
-    source_filename: &str,
-) -> Vec<String> {
-    let mut pages = Vec::new();
-    for (file_path, text) in wiki_contents {
-        if text.contains(&format!("  - {source_filename}"))
-            || text.contains(&format!("- {source_filename}"))
-        {
-            let slug = file_path
-                .strip_prefix("wiki/")
-                .unwrap_or(file_path)
-                .strip_suffix(".md")
-                .unwrap_or(file_path)
-                .to_string();
-            pages.push(slug);
-        }
-    }
-    pages
-}
-
-fn load_all_wiki(repo: &cowiki_core::git::WikiRepo, branch: &str) -> Vec<(String, String)> {
-    let wiki_files = repo.list_files_recursive(branch, "wiki").unwrap_or_default();
-    wiki_files
-        .iter()
-        .filter_map(|file| {
-            repo.read_file(branch, file)
-                .ok()
-                .flatten()
-                .map(|content| (file.clone(), String::from_utf8_lossy(&content).into_owned()))
-        })
-        .collect()
 }
 
 pub async fn list_sources(
@@ -124,14 +57,9 @@ pub async fn list_sources(
 
     let branch = &params.branch;
     let compile_state = load_compile_state(&repo, branch);
-    // Use non-recursive list to match get_source's filename validation
-    // (compiler only considers top-level sources/*.md)
     let source_files = repo
         .list_files(branch, "sources")
         .map_err(|e| AppError::Internal(e.to_string()))?;
-
-    // Pre-load all wiki files once to avoid O(n*m) per-source scans
-    let wiki_contents = load_all_wiki(&repo, branch);
 
     let mut items = Vec::new();
     for file in &source_files {
@@ -139,9 +67,9 @@ pub async fn list_sources(
             .strip_prefix("sources/")
             .unwrap_or(file)
             .to_string();
-        let compiled = compile_state.contains_key(&filename);
+        let compiled = compile_state.sources.contains_key(&filename);
         let compiled_pages = if compiled {
-            find_referencing_pages_batched(&wiki_contents, &filename)
+            compile_state.source_pages.get(&filename).cloned().unwrap_or_default()
         } else {
             Vec::new()
         };
@@ -185,9 +113,9 @@ pub async fn get_source(
 
     let content = String::from_utf8_lossy(&content_bytes).into_owned();
     let compile_state = load_compile_state(&repo, branch);
-    let compiled = compile_state.contains_key(&filename);
+    let compiled = compile_state.sources.contains_key(&filename);
     let compiled_pages = if compiled {
-        find_referencing_pages(&repo, branch, &filename)
+        compile_state.source_pages.get(&filename).cloned().unwrap_or_default()
     } else {
         Vec::new()
     };


### PR DESCRIPTION
## Summary

Replace fragile string-matching (`find_referencing_pages`) with a deterministic `source_pages` map populated during compilation. This ensures sources that share substrings don't get incorrectly linked.

Fixes #6

## Changes

- Add `source_pages` field to `CompileState` (`HashMap<String, Vec<String>>`)
- Populate `source_pages` during `do_compile` from compiler output
- Use `source_pages` in `list_sources` and `get_source` for O(1) lookups
- Remove `find_referencing_pages`, `find_referencing_pages_batched`, `load_all_wiki`

## Design Decisions

- `#[serde(default)]` on `source_pages` ensures backward compatibility with existing `state.json` files that don't have this field
- Mapping is sourced from the compiler's output (which already knows which sources produced which pages), not from scraping wiki file contents
- CompileState struct is now `pub(crate)` and shared between compile and sources modules