### PR TITLE
GitHub OAuth config: .env only (drop cowiki.conf [github])

### DIFF
--- a/cowiki.conf.example
+++ b/cowiki.conf.example
@@ -45,11 +45,9 @@ api_base = ""
 # Output vector dimension (0 = model default)
 dimension = 1536
 
-[github]
-# GitHub OAuth app credentials
-client_id = "your_github_client_id"
-client_secret = "your_github_client_secret"
-redirect_uri = "http://localhost:3000/api/auth/github/callback"
+# GitHub OAuth is configured via environment variables only (see .env.example):
+#   GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_REDIRECT_URI
+# It is intentionally NOT read from this file, to keep a single source of truth.
 
 [frontend]
 # Frontend URL (for CORS and redirects)

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -25,23 +25,12 @@ impl Config {
     pub fn load(args: Option<CliArgs>) -> Self {
         let shared = cowiki_utils::CowikiConfig::load(args);
 
-        // GitHub OAuth: from TOML if available, else env vars
-        let github = cowiki_utils::discover_config_path(None).and_then(|path| {
-            let content = std::fs::read_to_string(&path).ok()?;
-            let toml: cowiki_utils::TomlConfig = toml::from_str(&content).ok()?;
-            toml.github
-        });
-
+        // GitHub OAuth: env vars only (loaded from .env via dotenvy). Single source of truth.
         let auth = AuthConfig {
-            github_client_id: github.as_ref().and_then(|g| g.client_id.clone())
-                .or_else(|| std::env::var("GITHUB_CLIENT_ID").ok())
-                .unwrap_or_default(),
-            github_client_secret: github.as_ref().and_then(|g| g.client_secret.clone())
-                .or_else(|| std::env::var("GITHUB_CLIENT_SECRET").ok())
-                .unwrap_or_default(),
-            github_redirect_uri: github.as_ref().and_then(|g| g.redirect_uri.clone())
-                .or_else(|| std::env::var("GITHUB_REDIRECT_URI").ok())
-                .unwrap_or_else(|| "http://localhost:3000/api/auth/github/callback".into()),
+            github_client_id: std::env::var("GITHUB_CLIENT_ID").unwrap_or_default(),
+            github_client_secret: std::env::var("GITHUB_CLIENT_SECRET").unwrap_or_default(),
+            github_redirect_uri: std::env::var("GITHUB_REDIRECT_URI")
+                .unwrap_or_else(|_| "http://localhost:3000/api/auth/github/callback".into()),
         };
 
         Config {

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -25,7 +25,6 @@ pub struct TomlConfig {
     pub server: Option<TomlServer>,
     pub llm: Option<TomlLlm>,
     pub embedder: Option<TomlEmbedder>,
-    pub github: Option<TomlGithub>,
     pub frontend: Option<TomlFrontend>,
     #[serde(rename = "mcp-server")]
     pub mcp_server: Option<TomlMcpServer>,
@@ -60,13 +59,6 @@ pub struct TomlEmbedder {
     pub api_key: Option<String>,
     pub api_base: Option<String>,
     pub dimension: Option<u32>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct TomlGithub {
-    pub client_id: Option<String>,
-    pub client_secret: Option<String>,
-    pub redirect_uri: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/docs/config.md
+++ b/docs/config.md
@@ -156,22 +156,21 @@ dimension = 1024
 
 ---
 
-### `[github]`
+### GitHub OAuth (environment variables only)
 
-GitHub OAuth app credentials for social login.
+GitHub OAuth credentials are **not** read from `cowiki.conf` — they come from environment variables only (loaded from `.env` via dotenvy), to keep a single source of truth.
 
-| Field | Type | Default | Env Var | Description |
-|-------|------|---------|---------|-------------|
-| `client_id` | string | `""` | `GITHUB_CLIENT_ID` | GitHub OAuth app client ID |
-| `client_secret` | string | `""` | `GITHUB_CLIENT_SECRET` | GitHub OAuth app client secret |
-| `redirect_uri` | string | `"http://localhost:3000/api/auth/github/callback"` | `GITHUB_REDIRECT_URI` | OAuth callback URL |
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `GITHUB_CLIENT_ID` | `""` | GitHub OAuth app client ID |
+| `GITHUB_CLIENT_SECRET` | `""` | GitHub OAuth app client secret |
+| `GITHUB_REDIRECT_URI` | `"http://localhost:3000/api/auth/github/callback"` | OAuth callback URL |
 
-Example:
-```toml
-[github]
-client_id = "Iv23li..."
-client_secret = "abc123..."
-redirect_uri = "http://localhost:3000/api/auth/github/callback"
+Example (`.env`):
+```bash
+GITHUB_CLIENT_ID=Iv23li...
+GITHUB_CLIENT_SECRET=abc123...
+GITHUB_REDIRECT_URI=http://localhost:3000/api/auth/github/callback
 ```
 
 ---
@@ -213,10 +212,9 @@ Every field in `cowiki.conf` can be overridden by an environment variable. The e
 | `embedder.api_key` | `COWIKI_EMBEDDER_API_KEY` |
 | `embedder.api_base` | `COWIKI_EMBEDDER_BASE_URL` |
 | `embedder.dimension` | `COWIKI_EMBEDDER_DIMENSION` |
-| `github.client_id` | `GITHUB_CLIENT_ID` |
-| `github.client_secret` | `GITHUB_CLIENT_SECRET` |
-| `github.redirect_uri` | `GITHUB_REDIRECT_URI` |
 | `frontend.url` | `FRONTEND_URL` |
+
+> GitHub OAuth has no `cowiki.conf` keys — it is configured via `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GITHUB_REDIRECT_URI` environment variables only.
 
 ---
 


### PR DESCRIPTION
## Problem
GitHub OAuth `client_id` / `client_secret` / `redirect_uri` were read from **two** places — `cowiki.conf` `[github]` first, then env vars as fallback — with the TOML value silently overriding `.env`. Confusing and error-prone (a stale `client_id` in the conf shadows the real `.env` one).

## Fix
Env vars are the **single source of truth**:
- `config.rs` — read `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` / `GITHUB_REDIRECT_URI` from env only (loaded from `.env` via dotenvy)
- `crates/utils` — remove the now-dead `TomlConfig.github` field + `TomlGithub` struct
- `cowiki.conf.example` / `docs/config.md` — drop the `[github]` section, document the env-only behaviour

No behaviour change for deployments that already set the env vars. Deployments that relied on `[github]` in `cowiki.conf` must move those three values into `.env`.

`cargo build -p cowiki-server` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)