### PR TITLE
ci: enforce Rust formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2
+      - name: Check Rust formatting
+        run: cargo fmt --all -- --check
       - name: Build
         run: cargo build --workspace --locked
       - name: Test

--- a/crates/core/src/ai/llm/openai.rs
+++ b/crates/core/src/ai/llm/openai.rs
@@ -101,16 +101,22 @@ impl Llm for OpenAILlm {
             .send()
             .await
             .map_err(|e| {
-                tracing::error!("LLM API request failed for model {}: {e}", self.config.model);
+                tracing::error!(
+                    "LLM API request failed for model {}: {e}",
+                    self.config.model
+                );
                 e.to_string()
             })?
             .json::<ChatResponse>()
             .await
             .map_err(|e| {
-                tracing::error!("LLM API response parse failed for model {}: {e}", self.config.model);
+                tracing::error!(
+                    "LLM API response parse failed for model {}: {e}",
+                    self.config.model
+                );
                 e.to_string()
             })?;
-        
+
         let content = resp
             .choices
             .first()

--- a/crates/core/src/ai/mod.rs
+++ b/crates/core/src/ai/mod.rs
@@ -1,4 +1,4 @@
-pub mod llm;
-pub mod vlm;
 pub mod embedder;
+pub mod llm;
 pub mod token_usage;
+pub mod vlm;

--- a/crates/core/src/ai/vlm/mod.rs
+++ b/crates/core/src/ai/vlm/mod.rs
@@ -46,4 +46,3 @@ pub fn create_vlm(config: VlmConfig) -> Box<dyn Vlm> {
         other => panic!("unsupported VLM provider: {other}"),
     }
 }
-

--- a/crates/core/src/ai/vlm/openai.rs
+++ b/crates/core/src/ai/vlm/openai.rs
@@ -98,13 +98,19 @@ impl Vlm for OpenAIVlm {
             .send()
             .await
             .map_err(|e| {
-                tracing::error!("VLM API request failed for model {}: {e}", self.config.model);
+                tracing::error!(
+                    "VLM API request failed for model {}: {e}",
+                    self.config.model
+                );
                 e.to_string()
             })?
             .json::<ChatResponse>()
             .await
             .map_err(|e| {
-                tracing::error!("VLM API response parse failed for model {}: {e}", self.config.model);
+                tracing::error!(
+                    "VLM API response parse failed for model {}: {e}",
+                    self.config.model
+                );
                 e.to_string()
             })?;
 

--- a/crates/core/src/compiler.rs
+++ b/crates/core/src/compiler.rs
@@ -13,11 +13,7 @@ pub struct Compiler {
 }
 
 impl Compiler {
-    pub fn new(
-        llm: Box<dyn Llm>,
-        vlm: Option<Box<dyn Vlm>>,
-        embedder: Box<dyn Embedder>,
-    ) -> Self {
+    pub fn new(llm: Box<dyn Llm>, vlm: Option<Box<dyn Vlm>>, embedder: Box<dyn Embedder>) -> Self {
         Self { llm, vlm, embedder }
     }
 

--- a/crates/core/src/dedup.rs
+++ b/crates/core/src/dedup.rs
@@ -3,10 +3,7 @@ use crate::models::DuplicateWarning;
 /// Check for duplicate pages by comparing embeddings.
 /// Returns (slug, similarity) pairs for pages above the threshold.
 /// This is a pure function that takes pre-fetched similar pages.
-pub fn find_duplicates(
-    new_slug: &str,
-    similar_pages: &[(String, f64)],
-) -> Vec<DuplicateWarning> {
+pub fn find_duplicates(new_slug: &str, similar_pages: &[(String, f64)]) -> Vec<DuplicateWarning> {
     similar_pages
         .iter()
         .filter(|(slug, _)| slug != new_slug)

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -236,11 +236,7 @@ impl WikiRepo {
         Ok(())
     }
 
-    pub fn read_file(
-        &self,
-        branch: &str,
-        file_path: &str,
-    ) -> Result<Option<Vec<u8>>, git2::Error> {
+    pub fn read_file(&self, branch: &str, file_path: &str) -> Result<Option<Vec<u8>>, git2::Error> {
         let repo = self.repo()?;
         let branch_ref = repo.find_branch(branch, BranchType::Local)?;
         let commit = branch_ref.get().peel_to_commit()?;
@@ -286,7 +282,11 @@ impl WikiRepo {
     }
 
     /// List all files recursively under a directory, returning full paths.
-    pub fn list_files_recursive(&self, branch: &str, dir: &str) -> Result<Vec<String>, git2::Error> {
+    pub fn list_files_recursive(
+        &self,
+        branch: &str,
+        dir: &str,
+    ) -> Result<Vec<String>, git2::Error> {
         let repo = self.repo()?;
         let branch_ref = repo.find_branch(branch, BranchType::Local)?;
         let commit = branch_ref.get().peel_to_commit()?;
@@ -343,11 +343,7 @@ impl WikiRepo {
         Ok(())
     }
 
-    pub fn diff_files(
-        &self,
-        branch: &str,
-        slugs: &[String],
-    ) -> Result<Vec<FileDiff>, git2::Error> {
+    pub fn diff_files(&self, branch: &str, slugs: &[String]) -> Result<Vec<FileDiff>, git2::Error> {
         let mut diffs = Vec::new();
         for slug in slugs {
             let path = format!("wiki/{slug}.md");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod git;
-pub mod models;
 pub mod ai;
 pub mod compiler;
 pub mod dedup;
+pub mod git;
+pub mod models;

--- a/crates/db/src/api_keys.rs
+++ b/crates/db/src/api_keys.rs
@@ -1,8 +1,8 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use uuid::Uuid;
-use serde::{Deserialize, Serialize};
-use sha2::{Sha256, Digest};
-use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct ApiKey {
@@ -77,7 +77,10 @@ pub async fn revoke(pool: &PgPool, key_id: Uuid, user_id: Uuid) -> sqlx::Result<
 
 /// Look up an active key by its SHA-256 hash. Returns (ApiKey, user_id) or None.
 /// Used by the auth fallback path — MUST filter revoked_at IS NULL.
-pub async fn find_by_key_hash(pool: &PgPool, key_hash: &str) -> sqlx::Result<Option<(ApiKey, Uuid)>> {
+pub async fn find_by_key_hash(
+    pool: &PgPool,
+    key_hash: &str,
+) -> sqlx::Result<Option<(ApiKey, Uuid)>> {
     sqlx::query_as::<_, ApiKey>(
         "SELECT id, user_id, name, key_prefix, last_used_at, created_at, revoked_at FROM api_keys WHERE key_hash = $1 AND revoked_at IS NULL"
     )
@@ -93,12 +96,17 @@ pub async fn find_by_key_hash(pool: &PgPool, key_hash: &str) -> sqlx::Result<Opt
 
 /// Update last_used_at when a key successfully authenticates.
 pub async fn touch_last_used(pool: &PgPool, key_hash: &str) -> sqlx::Result<()> {
-    sqlx::query("UPDATE api_keys SET last_used_at = now() WHERE key_hash = $1 AND revoked_at IS NULL")
-        .bind(key_hash)
-        .execute(pool)
-        .await
-        .map(|_| ())
-        .map_err(|e| { tracing::error!("DB touch_last_used failed: {e}"); e })
+    sqlx::query(
+        "UPDATE api_keys SET last_used_at = now() WHERE key_hash = $1 AND revoked_at IS NULL",
+    )
+    .bind(key_hash)
+    .execute(pool)
+    .await
+    .map(|_| ())
+    .map_err(|e| {
+        tracing::error!("DB touch_last_used failed: {e}");
+        e
+    })
 }
 
 // ── Helpers ──
@@ -106,7 +114,7 @@ pub async fn touch_last_used(pool: &PgPool, key_hash: &str) -> sqlx::Result<()> 
 pub fn mask_key_prefix(prefix: &str) -> String {
     // prefix is "cw_xxxxxxxx" (11 chars). Show "cw_****xxxx"
     if prefix.len() >= 7 {
-        format!("{}****{}", &prefix[..3], &prefix[prefix.len()-4..])
+        format!("{}****{}", &prefix[..3], &prefix[prefix.len() - 4..])
     } else {
         format!("{}****", prefix)
     }

--- a/crates/db/src/audit.rs
+++ b/crates/db/src/audit.rs
@@ -15,7 +15,7 @@ pub async fn log(
     let meta = metadata.unwrap_or(serde_json::Value::Object(Default::default()));
     sqlx::query(
         "INSERT INTO audit_log (workspace_id, actor_id, action, target_type, target_id, metadata)
-         VALUES ($1, $2, $3, $4, $5, $6)"
+         VALUES ($1, $2, $3, $4, $5, $6)",
     )
     .bind(workspace_id)
     .bind(actor_id)

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,11 +1,11 @@
 use sqlx::PgPool;
 
-pub mod users;
-pub mod pages;
-pub mod submissions;
-pub mod workspaces;
 pub mod api_keys;
 pub mod audit;
+pub mod pages;
+pub mod submissions;
+pub mod users;
+pub mod workspaces;
 
 pub async fn create_pool(database_url: &str) -> sqlx::Result<PgPool> {
     PgPool::connect(database_url).await
@@ -14,20 +14,44 @@ pub async fn create_pool(database_url: &str) -> sqlx::Result<PgPool> {
 pub async fn run_migrations(pool: &PgPool, embedding_dim: u32) -> sqlx::Result<()> {
     let sql = include_str!("migrations/001_init.sql")
         .replace("__EMBEDDING_DIM__", &embedding_dim.to_string());
-    sqlx::raw_sql(&sql).execute(pool).await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    sqlx::raw_sql(&sql).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     let sql2 = include_str!("migrations/002_workspaces.sql");
-    sqlx::raw_sql(sql2).execute(pool).await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    sqlx::raw_sql(sql2).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     let sql3 = include_str!("migrations/003_workspace_visibility.sql");
-    sqlx::raw_sql(sql3).execute(pool).await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    sqlx::raw_sql(sql3).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     let sql4 = include_str!("migrations/004_role_update.sql");
-    sqlx::raw_sql(sql4).execute(pool).await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    sqlx::raw_sql(sql4).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     let sql5 = include_str!("migrations/005_fts.sql");
-    sqlx::raw_sql(sql5).execute(pool).await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    sqlx::raw_sql(sql5).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     let sql6 = include_str!("migrations/006_api_keys.sql");
-    sqlx::raw_sql(sql6).execute(pool).await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    sqlx::raw_sql(sql6).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     let sql7 = include_str!("migrations/007_team_permissions.sql");
-    sqlx::raw_sql(sql7).execute(pool).await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    sqlx::raw_sql(sql7).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     let sql8 = include_str!("migrations/008_submission_workspace.sql");
-    sqlx::raw_sql(sql8).execute(pool).await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    sqlx::raw_sql(sql8).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     Ok(())
 }

--- a/crates/db/src/pages.rs
+++ b/crates/db/src/pages.rs
@@ -1,7 +1,7 @@
+use pgvector::Vector;
+use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;
-use serde::{Deserialize, Serialize};
-use pgvector::Vector;
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct PageMeta {
@@ -46,7 +46,10 @@ pub async fn upsert(
     .bind(user_id)
     .fetch_one(pool)
     .await
-    .map_err(|e| { tracing::error!("DB upsert page {slug}: {e}"); e })
+    .map_err(|e| {
+        tracing::error!("DB upsert page {slug}: {e}");
+        e
+    })
 }
 
 pub async fn list_by_branch(pool: &PgPool, branch: &str) -> sqlx::Result<Vec<PageMeta>> {
@@ -69,7 +72,20 @@ pub async fn find_similar(
     let emb = Vector::from(embedding.to_vec());
 
     // Use a subquery to compute similarity then filter
-    let rows = sqlx::query_as::<_, (Uuid, String, String, String, String, String, chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>, f64)>(
+    let rows = sqlx::query_as::<
+        _,
+        (
+            Uuid,
+            String,
+            String,
+            String,
+            String,
+            String,
+            chrono::DateTime<chrono::Utc>,
+            chrono::DateTime<chrono::Utc>,
+            f64,
+        ),
+    >(
         r#"SELECT id, slug, title, summary, branch, content_hash, created_at, updated_at,
             1 - (embedding <=> $1::vector) as similarity
         FROM pages
@@ -83,7 +99,11 @@ pub async fn find_similar(
     .bind(threshold)
     .bind(limit)
     .fetch_all(pool)
-    .await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    .await
+    .map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
 
     Ok(rows
         .into_iter()

--- a/crates/db/src/submissions.rs
+++ b/crates/db/src/submissions.rs
@@ -1,6 +1,6 @@
+use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct Submission {
@@ -48,7 +48,10 @@ pub async fn list_pending_for_workspace(
     .bind(workspace_slug)
     .fetch_all(pool)
     .await
-    .map_err(|e| { tracing::error!("DB list submissions for workspace failed: {e}"); e })
+    .map_err(|e| {
+        tracing::error!("DB list submissions for workspace failed: {e}");
+        e
+    })
 }
 
 pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Submission>> {
@@ -56,7 +59,10 @@ pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Submissi
         .bind(id)
         .fetch_optional(pool)
         .await
-        .map_err(|e| { tracing::error!("DB find submission by id failed: {e}"); e })
+        .map_err(|e| {
+            tracing::error!("DB find submission by id failed: {e}");
+            e
+        })
 }
 
 pub async fn update_status(
@@ -114,18 +120,31 @@ mod tests {
 
     #[tokio::test]
     async fn submission_records_and_filters_by_workspace() {
-        let Some(pool) = test_pool().await else { return };
+        let Some(pool) = test_pool().await else {
+            return;
+        };
         let user = make_user(&pool).await;
 
-        let s = create(&pool, user, "summary", &["page-a".into()], "user/abc", "team-alpha")
-            .await
-            .unwrap();
+        let s = create(
+            &pool,
+            user,
+            "summary",
+            &["page-a".into()],
+            "user/abc",
+            "team-alpha",
+        )
+        .await
+        .unwrap();
         assert_eq!(s.workspace_slug, "team-alpha");
 
-        let in_alpha = list_pending_for_workspace(&pool, "team-alpha").await.unwrap();
+        let in_alpha = list_pending_for_workspace(&pool, "team-alpha")
+            .await
+            .unwrap();
         assert!(in_alpha.iter().any(|x| x.id == s.id));
 
-        let in_beta = list_pending_for_workspace(&pool, "team-beta").await.unwrap();
+        let in_beta = list_pending_for_workspace(&pool, "team-beta")
+            .await
+            .unwrap();
         assert!(!in_beta.iter().any(|x| x.id == s.id));
     }
 }

--- a/crates/db/src/users.rs
+++ b/crates/db/src/users.rs
@@ -1,6 +1,6 @@
+use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct User {
@@ -38,7 +38,12 @@ pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<User>> {
         .await
 }
 
-pub async fn create(pool: &PgPool, name: &str, email: Option<&str>, password_hash: Option<&str>) -> sqlx::Result<User> {
+pub async fn create(
+    pool: &PgPool,
+    name: &str,
+    email: Option<&str>,
+    password_hash: Option<&str>,
+) -> sqlx::Result<User> {
     let api_key = generate_api_key();
     sqlx::query_as::<_, User>(
         "INSERT INTO users (name, email, api_key, password_hash) VALUES ($1, $2, $3, $4) RETURNING id, name, email, api_key"
@@ -54,13 +59,16 @@ pub async fn create(pool: &PgPool, name: &str, email: Option<&str>, password_has
 pub async fn regenerate_api_key(pool: &PgPool, user_id: Uuid) -> sqlx::Result<User> {
     let api_key = generate_api_key();
     sqlx::query_as::<_, User>(
-        "UPDATE users SET api_key = $2 WHERE id = $1 RETURNING id, name, email, api_key"
+        "UPDATE users SET api_key = $2 WHERE id = $1 RETURNING id, name, email, api_key",
     )
     .bind(user_id)
     .bind(&api_key)
     .fetch_one(pool)
     .await
-    .map_err(|e| { tracing::error!("DB regenerate API key failed: {e}"); e })
+    .map_err(|e| {
+        tracing::error!("DB regenerate API key failed: {e}");
+        e
+    })
 }
 
 pub async fn update_email(pool: &PgPool, user_id: Uuid, email: &str) -> sqlx::Result<()> {
@@ -70,7 +78,10 @@ pub async fn update_email(pool: &PgPool, user_id: Uuid, email: &str) -> sqlx::Re
         .execute(pool)
         .await
         .map(|_| ())
-        .map_err(|e| { tracing::error!("DB update_email failed: {e}"); e })
+        .map_err(|e| {
+            tracing::error!("DB update_email failed: {e}");
+            e
+        })
 }
 
 pub async fn get_default(pool: &PgPool) -> sqlx::Result<User> {

--- a/crates/db/src/workspaces.rs
+++ b/crates/db/src/workspaces.rs
@@ -1,7 +1,7 @@
-use sqlx::PgPool;
-use uuid::Uuid;
 use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
 use std::str::FromStr;
+use uuid::Uuid;
 
 /// Workspace member role with GitHub-style three-tier permissions.
 /// Extensible: add new variants + update ALL + update DB CHECK constraint.
@@ -79,8 +79,17 @@ pub struct Invitation {
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
-pub async fn create(pool: &PgPool, name: &str, slug: &str, visibility: &str, created_by: Uuid) -> sqlx::Result<Workspace> {
-    let mut tx = pool.begin().await.map_err(|e| { tracing::error!("DB begin tx error: {e}"); e })?;
+pub async fn create(
+    pool: &PgPool,
+    name: &str,
+    slug: &str,
+    visibility: &str,
+    created_by: Uuid,
+) -> sqlx::Result<Workspace> {
+    let mut tx = pool.begin().await.map_err(|e| {
+        tracing::error!("DB begin tx error: {e}");
+        e
+    })?;
 
     let ws = sqlx::query_as::<_, Workspace>(
         "INSERT INTO workspaces (name, slug, visibility, created_by) VALUES ($1, $2, $3, $4) RETURNING *"
@@ -91,13 +100,21 @@ pub async fn create(pool: &PgPool, name: &str, slug: &str, visibility: &str, cre
 
     // Add creator as owner
     sqlx::query(
-        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'owner')"
+        "INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
     )
-    .bind(ws.id).bind(created_by)
+    .bind(ws.id)
+    .bind(created_by)
     .execute(&mut *tx)
-    .await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    .await
+    .map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
 
-    tx.commit().await.map_err(|e| { tracing::error!("DB commit tx error: {e}"); e })?;
+    tx.commit().await.map_err(|e| {
+        tracing::error!("DB commit tx error: {e}");
+        e
+    })?;
 
     Ok(ws)
 }
@@ -107,7 +124,10 @@ pub async fn find_by_slug(pool: &PgPool, slug: &str) -> sqlx::Result<Option<Work
         .bind(slug)
         .fetch_optional(pool)
         .await
-        .map_err(|e| { tracing::error!("DB find workspace by slug failed: {e}"); e })
+        .map_err(|e| {
+            tracing::error!("DB find workspace by slug failed: {e}");
+            e
+        })
 }
 
 pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Workspace>> {
@@ -115,12 +135,15 @@ pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Workspac
         .bind(id)
         .fetch_optional(pool)
         .await
-        .map_err(|e| { tracing::error!("DB find workspace by id failed: {e}"); e })
+        .map_err(|e| {
+            tracing::error!("DB find workspace by id failed: {e}");
+            e
+        })
 }
 
 pub async fn list_public(pool: &PgPool) -> sqlx::Result<Vec<Workspace>> {
     sqlx::query_as::<_, Workspace>(
-        "SELECT * FROM workspaces WHERE visibility = 'public' ORDER BY created_at DESC"
+        "SELECT * FROM workspaces WHERE visibility = 'public' ORDER BY created_at DESC",
     )
     .fetch_all(pool)
     .await
@@ -138,15 +161,26 @@ pub async fn list_for_user(pool: &PgPool, user_id: Uuid) -> sqlx::Result<Vec<Wor
 
 pub async fn is_member(pool: &PgPool, workspace_id: Uuid, user_id: Uuid) -> sqlx::Result<bool> {
     let row = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM workspace_members WHERE workspace_id = $1 AND user_id = $2"
+        "SELECT COUNT(*) FROM workspace_members WHERE workspace_id = $1 AND user_id = $2",
     )
-    .bind(workspace_id).bind(user_id)
+    .bind(workspace_id)
+    .bind(user_id)
     .fetch_one(pool)
-    .await.map_err(|e| { tracing::error!("DB error: {e}"); e })?;
+    .await
+    .map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     Ok(row > 0)
 }
 
-pub async fn add_member(pool: &PgPool, workspace_id: Uuid, user_id: Uuid, role: &str, invited_by: Uuid) -> sqlx::Result<()> {
+pub async fn add_member(
+    pool: &PgPool,
+    workspace_id: Uuid,
+    user_id: Uuid,
+    role: &str,
+    invited_by: Uuid,
+) -> sqlx::Result<()> {
     sqlx::query(
         "INSERT INTO workspace_members (workspace_id, user_id, role, invited_by) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING"
     )
@@ -157,16 +191,23 @@ pub async fn add_member(pool: &PgPool, workspace_id: Uuid, user_id: Uuid, role: 
 }
 
 pub async fn list_members(pool: &PgPool, workspace_id: Uuid) -> sqlx::Result<Vec<WorkspaceMember>> {
-    sqlx::query_as::<_, WorkspaceMember>(
-        "SELECT * FROM workspace_members WHERE workspace_id = $1"
-    )
-    .bind(workspace_id)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| { tracing::error!("DB list members failed: {e}"); e })
+    sqlx::query_as::<_, WorkspaceMember>("SELECT * FROM workspace_members WHERE workspace_id = $1")
+        .bind(workspace_id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB list members failed: {e}");
+            e
+        })
 }
 
-pub async fn create_invitation(pool: &PgPool, workspace_id: Uuid, email: &str, role: &str, invited_by: Uuid) -> sqlx::Result<Invitation> {
+pub async fn create_invitation(
+    pool: &PgPool,
+    workspace_id: Uuid,
+    email: &str,
+    role: &str,
+    invited_by: Uuid,
+) -> sqlx::Result<Invitation> {
     sqlx::query_as::<_, Invitation>(
         "INSERT INTO invitations (workspace_id, email, role, invited_by) VALUES ($1, $2, $3, $4) RETURNING *"
     )
@@ -178,7 +219,7 @@ pub async fn create_invitation(pool: &PgPool, workspace_id: Uuid, email: &str, r
 
 pub async fn find_pending_invitations(pool: &PgPool, email: &str) -> sqlx::Result<Vec<Invitation>> {
     sqlx::query_as::<_, Invitation>(
-        "SELECT * FROM invitations WHERE email = $1 AND status = 'pending'"
+        "SELECT * FROM invitations WHERE email = $1 AND status = 'pending'",
     )
     .bind(email)
     .fetch_all(pool)
@@ -187,7 +228,7 @@ pub async fn find_pending_invitations(pool: &PgPool, email: &str) -> sqlx::Resul
 
 pub async fn accept_invitation(pool: &PgPool, invitation_id: Uuid) -> sqlx::Result<Invitation> {
     sqlx::query_as::<_, Invitation>(
-        "UPDATE invitations SET status = 'accepted' WHERE id = $1 RETURNING *"
+        "UPDATE invitations SET status = 'accepted' WHERE id = $1 RETURNING *",
     )
     .bind(invitation_id)
     .fetch_one(pool)
@@ -195,23 +236,30 @@ pub async fn accept_invitation(pool: &PgPool, invitation_id: Uuid) -> sqlx::Resu
 }
 
 pub async fn rename(pool: &PgPool, id: Uuid, new_name: &str) -> sqlx::Result<Workspace> {
-    sqlx::query_as::<_, Workspace>(
-        "UPDATE workspaces SET name = $2 WHERE id = $1 RETURNING *"
-    )
-    .bind(id).bind(new_name)
-    .fetch_one(pool)
-    .await
+    sqlx::query_as::<_, Workspace>("UPDATE workspaces SET name = $2 WHERE id = $1 RETURNING *")
+        .bind(id)
+        .bind(new_name)
+        .fetch_one(pool)
+        .await
 }
 
 /// Get the role of a user in a workspace. Returns None if not a member.
-pub async fn get_member_role(pool: &PgPool, workspace_id: Uuid, user_id: Uuid) -> sqlx::Result<Option<String>> {
+pub async fn get_member_role(
+    pool: &PgPool,
+    workspace_id: Uuid,
+    user_id: Uuid,
+) -> sqlx::Result<Option<String>> {
     sqlx::query_scalar::<_, String>(
-        "SELECT role FROM workspace_members WHERE workspace_id = $1 AND user_id = $2"
+        "SELECT role FROM workspace_members WHERE workspace_id = $1 AND user_id = $2",
     )
-    .bind(workspace_id).bind(user_id)
+    .bind(workspace_id)
+    .bind(user_id)
     .fetch_optional(pool)
     .await
-    .map_err(|e| { tracing::error!("DB get_member_role failed: {e}"); e })
+    .map_err(|e| {
+        tracing::error!("DB get_member_role failed: {e}");
+        e
+    })
 }
 
 /// Remove a member from a workspace. Cannot remove owners. Returns true if deleted.
@@ -228,51 +276,65 @@ pub async fn remove_member(pool: &PgPool, workspace_id: Uuid, user_id: Uuid) -> 
 
 /// Change a member's role. Cannot change owner's role. Returns the new role string.
 pub async fn change_member_role(
-    pool: &PgPool, workspace_id: Uuid, user_id: Uuid, new_role: &str
+    pool: &PgPool,
+    workspace_id: Uuid,
+    user_id: Uuid,
+    new_role: &str,
 ) -> sqlx::Result<Option<String>> {
     let row = sqlx::query_scalar::<_, String>(
         "UPDATE workspace_members SET role = $3
          WHERE workspace_id = $1 AND user_id = $2 AND role != 'owner'
-         RETURNING role"
+         RETURNING role",
     )
-    .bind(workspace_id).bind(user_id).bind(new_role)
+    .bind(workspace_id)
+    .bind(user_id)
+    .bind(new_role)
     .fetch_optional(pool)
     .await
-    .map_err(|e| { tracing::error!("DB change_member_role failed: {e}"); e })?;
+    .map_err(|e| {
+        tracing::error!("DB change_member_role failed: {e}");
+        e
+    })?;
     Ok(row)
 }
 
 /// Find all pending invitations for a user.
 /// Tries email match first, falls back to NULL-email handling.
 pub async fn find_pending_invitations_for_user(
-    pool: &PgPool, user_id: Uuid
+    pool: &PgPool,
+    user_id: Uuid,
 ) -> sqlx::Result<Vec<Invitation>> {
     // First get the user's email
-    let email: Option<String> = sqlx::query_scalar(
-        "SELECT email FROM users WHERE id = $1"
-    )
-    .bind(user_id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| { tracing::error!("DB get user email failed: {e}"); e })?
-    .flatten();
+    let email: Option<String> = sqlx::query_scalar("SELECT email FROM users WHERE id = $1")
+        .bind(user_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB get user email failed: {e}");
+            e
+        })?
+        .flatten();
 
     match email {
-        Some(ref e) if !e.is_empty() => {
-            sqlx::query_as::<_, Invitation>(
-                "SELECT i.* FROM invitations i WHERE i.email = $1 AND i.status = 'pending'"
-            )
-            .bind(e)
-            .fetch_all(pool)
-            .await
-            .map_err(|e| { tracing::error!("DB find_pending_invitations_for_user failed: {e}"); e })
-        }
-        _ => Ok(vec![]) // No email → no email-based invitations
+        Some(ref e) if !e.is_empty() => sqlx::query_as::<_, Invitation>(
+            "SELECT i.* FROM invitations i WHERE i.email = $1 AND i.status = 'pending'",
+        )
+        .bind(e)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB find_pending_invitations_for_user failed: {e}");
+            e
+        }),
+        _ => Ok(vec![]), // No email → no email-based invitations
     }
 }
 
 /// Find an invitation by its ID.
-pub async fn find_invitation_by_id(pool: &PgPool, invitation_id: Uuid) -> sqlx::Result<Option<Invitation>> {
+pub async fn find_invitation_by_id(
+    pool: &PgPool,
+    invitation_id: Uuid,
+) -> sqlx::Result<Option<Invitation>> {
     sqlx::query_as::<_, Invitation>("SELECT * FROM invitations WHERE id = $1")
         .bind(invitation_id)
         .fetch_optional(pool)
@@ -282,7 +344,7 @@ pub async fn find_invitation_by_id(pool: &PgPool, invitation_id: Uuid) -> sqlx::
 /// Reject an invitation (set status to 'rejected').
 pub async fn reject_invitation(pool: &PgPool, invitation_id: Uuid) -> sqlx::Result<Invitation> {
     sqlx::query_as::<_, Invitation>(
-        "UPDATE invitations SET status = 'rejected' WHERE id = $1 RETURNING *"
+        "UPDATE invitations SET status = 'rejected' WHERE id = $1 RETURNING *",
     )
     .bind(invitation_id)
     .fetch_one(pool)
@@ -295,7 +357,10 @@ pub async fn delete_workspace(pool: &PgPool, workspace_id: Uuid) -> sqlx::Result
         .bind(workspace_id)
         .execute(pool)
         .await
-        .map_err(|e| { tracing::error!("DB delete_workspace failed: {e}"); e })?;
+        .map_err(|e| {
+            tracing::error!("DB delete_workspace failed: {e}");
+            e
+        })?;
     Ok(rows.rows_affected() > 0)
 }
 
@@ -440,13 +505,27 @@ mod tests {
         // Run all migrations
         let sql1 = include_str!("migrations/001_init.sql").replace("__EMBEDDING_DIM__", "768");
         let _ = sqlx::raw_sql(&sql1).execute(&pool).await;
-        let _ = sqlx::raw_sql(include_str!("migrations/002_workspaces.sql")).execute(&pool).await;
-        let _ = sqlx::raw_sql(include_str!("migrations/003_workspace_visibility.sql")).execute(&pool).await;
-        let _ = sqlx::raw_sql(include_str!("migrations/004_role_update.sql")).execute(&pool).await;
-        let _ = sqlx::raw_sql(include_str!("migrations/005_fts.sql")).execute(&pool).await;
-        let _ = sqlx::raw_sql(include_str!("migrations/006_api_keys.sql")).execute(&pool).await;
-        let _ = sqlx::raw_sql(include_str!("migrations/007_team_permissions.sql")).execute(&pool).await;
-        let _ = sqlx::raw_sql(include_str!("migrations/008_submission_workspace.sql")).execute(&pool).await;
+        let _ = sqlx::raw_sql(include_str!("migrations/002_workspaces.sql"))
+            .execute(&pool)
+            .await;
+        let _ = sqlx::raw_sql(include_str!("migrations/003_workspace_visibility.sql"))
+            .execute(&pool)
+            .await;
+        let _ = sqlx::raw_sql(include_str!("migrations/004_role_update.sql"))
+            .execute(&pool)
+            .await;
+        let _ = sqlx::raw_sql(include_str!("migrations/005_fts.sql"))
+            .execute(&pool)
+            .await;
+        let _ = sqlx::raw_sql(include_str!("migrations/006_api_keys.sql"))
+            .execute(&pool)
+            .await;
+        let _ = sqlx::raw_sql(include_str!("migrations/007_team_permissions.sql"))
+            .execute(&pool)
+            .await;
+        let _ = sqlx::raw_sql(include_str!("migrations/008_submission_workspace.sql"))
+            .execute(&pool)
+            .await;
         Some(pool)
     }
 
@@ -481,12 +560,20 @@ mod tests {
     async fn test_create_workspace_adds_creator_as_owner() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
         assert_eq!(ws.name, "Test WS");
         assert_eq!(ws.slug, slug);
         assert_eq!(ws.visibility, "public");
@@ -495,58 +582,104 @@ mod tests {
         let role = get_member_role(&pool, ws.id, user_a).await.unwrap();
         assert_eq!(role.as_deref(), Some("owner"));
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_get_member_role_returns_none_for_non_member() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, user_b, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
         let role = get_member_role(&pool, ws.id, user_b).await.unwrap();
         assert!(role.is_none());
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_add_member_with_role() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, user_b, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
-        add_member(&pool, ws.id, user_b, "reader", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
+        add_member(&pool, ws.id, user_b, "reader", user_a)
+            .await
+            .unwrap();
         let role = get_member_role(&pool, ws.id, user_b).await.unwrap();
         assert_eq!(role.as_deref(), Some("reader"));
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_add_member_idempotent_no_override() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, user_b, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
-        add_member(&pool, ws.id, user_b, "reader", user_a).await.unwrap();
-        add_member(&pool, ws.id, user_b, "writer", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
+        add_member(&pool, ws.id, user_b, "reader", user_a)
+            .await
+            .unwrap();
+        add_member(&pool, ws.id, user_b, "writer", user_a)
+            .await
+            .unwrap();
         let role = get_member_role(&pool, ws.id, user_b).await.unwrap();
-        assert_eq!(role.as_deref(), Some("reader"), "ON CONFLICT DO NOTHING preserves original role");
+        assert_eq!(
+            role.as_deref(),
+            Some("reader"),
+            "ON CONFLICT DO NOTHING preserves original role"
+        );
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     // ── Remove Member Tests ───────────────────────────────────────
@@ -555,54 +688,89 @@ mod tests {
     async fn test_remove_member_success() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, user_b, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
-        add_member(&pool, ws.id, user_b, "writer", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
+        add_member(&pool, ws.id, user_b, "writer", user_a)
+            .await
+            .unwrap();
 
         let removed = remove_member(&pool, ws.id, user_b).await.unwrap();
         assert!(removed);
         let role = get_member_role(&pool, ws.id, user_b).await.unwrap();
         assert!(role.is_none());
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_remove_member_cannot_remove_owner() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
         let removed = remove_member(&pool, ws.id, user_a).await.unwrap();
         assert!(!removed, "owner should not be removable");
         let role = get_member_role(&pool, ws.id, user_a).await.unwrap();
         assert_eq!(role.as_deref(), Some("owner"));
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_remove_member_nonexistent_returns_false() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
         let removed = remove_member(&pool, ws.id, Uuid::new_v4()).await.unwrap();
         assert!(!removed);
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     // ── Change Role Tests ─────────────────────────────────────────
@@ -611,41 +779,71 @@ mod tests {
     async fn test_change_member_role_success() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, user_b, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
-        add_member(&pool, ws.id, user_b, "reader", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
+        add_member(&pool, ws.id, user_b, "reader", user_a)
+            .await
+            .unwrap();
 
-        let new_role = change_member_role(&pool, ws.id, user_b, "writer").await.unwrap();
+        let new_role = change_member_role(&pool, ws.id, user_b, "writer")
+            .await
+            .unwrap();
         assert_eq!(new_role.as_deref(), Some("writer"));
         let role = get_member_role(&pool, ws.id, user_b).await.unwrap();
         assert_eq!(role.as_deref(), Some("writer"));
 
-        let new_role = change_member_role(&pool, ws.id, user_b, "reader").await.unwrap();
+        let new_role = change_member_role(&pool, ws.id, user_b, "reader")
+            .await
+            .unwrap();
         assert_eq!(new_role.as_deref(), Some("reader"));
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_change_member_role_cannot_change_owner() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
-        let result = change_member_role(&pool, ws.id, user_a, "writer").await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
+        let result = change_member_role(&pool, ws.id, user_a, "writer")
+            .await
+            .unwrap();
         assert!(result.is_none(), "owner's role should not be changeable");
         let role = get_member_role(&pool, ws.id, user_a).await.unwrap();
         assert_eq!(role.as_deref(), Some("owner"));
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     // ── Invitation Tests ──────────────────────────────────────────
@@ -654,73 +852,124 @@ mod tests {
     async fn test_create_invitation_with_role() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
 
-        let inv = create_invitation(&pool, ws.id, "newuser@test.com", "reader", user_a).await.unwrap();
+        let inv = create_invitation(&pool, ws.id, "newuser@test.com", "reader", user_a)
+            .await
+            .unwrap();
         assert_eq!(inv.email, "newuser@test.com");
         assert_eq!(inv.role, "reader");
         assert_eq!(inv.status, "pending");
         assert_eq!(inv.invited_by, user_a);
 
-        let inv2 = create_invitation(&pool, ws.id, "newuser2@test.com", "writer", user_a).await.unwrap();
+        let inv2 = create_invitation(&pool, ws.id, "newuser2@test.com", "writer", user_a)
+            .await
+            .unwrap();
         assert_eq!(inv2.role, "writer");
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_accept_invitation_changes_status() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
-        let inv = create_invitation(&pool, ws.id, "newuser@test.com", "writer", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
+        let inv = create_invitation(&pool, ws.id, "newuser@test.com", "writer", user_a)
+            .await
+            .unwrap();
 
         assert_eq!(inv.status, "pending");
         let accepted = accept_invitation(&pool, inv.id).await.unwrap();
         assert_eq!(accepted.status, "accepted");
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_reject_invitation_changes_status() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
-        let inv = create_invitation(&pool, ws.id, "newuser@test.com", "reader", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
+        let inv = create_invitation(&pool, ws.id, "newuser@test.com", "reader", user_a)
+            .await
+            .unwrap();
 
         let rejected = reject_invitation(&pool, inv.id).await.unwrap();
         assert_eq!(rejected.status, "rejected");
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_find_invitation_by_id() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
-        let inv = create_invitation(&pool, ws.id, "findme@test.com", "writer", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
+        let inv = create_invitation(&pool, ws.id, "findme@test.com", "writer", user_a)
+            .await
+            .unwrap();
 
         let found = find_invitation_by_id(&pool, inv.id).await.unwrap();
         assert!(found.is_some());
@@ -729,7 +978,10 @@ mod tests {
         let not_found = find_invitation_by_id(&pool, Uuid::new_v4()).await.unwrap();
         assert!(not_found.is_none());
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     // ── Delete Workspace Test ─────────────────────────────────────
@@ -738,12 +990,20 @@ mod tests {
     async fn test_delete_workspace_success() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
         let deleted = delete_workspace(&pool, ws.id).await.unwrap();
         assert!(deleted);
         let found = find_by_slug(&pool, &slug).await.unwrap();
@@ -754,7 +1014,10 @@ mod tests {
     async fn test_delete_workspace_nonexistent_returns_false() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let deleted = delete_workspace(&pool, Uuid::new_v4()).await.unwrap();
         assert!(!deleted);
@@ -766,55 +1029,100 @@ mod tests {
     async fn test_audit_log_insert() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
 
         crate::audit::log(
-            &pool, ws.id, user_a,
-            "invite_member", Some("invitation"), Some(Uuid::new_v4()),
+            &pool,
+            ws.id,
+            user_a,
+            "invite_member",
+            Some("invitation"),
+            Some(Uuid::new_v4()),
             Some(serde_json::json!({"email": "test@test.com", "role": "writer"})),
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
         let count: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM audit_log WHERE workspace_id = $1 AND actor_id = $2"
+            "SELECT COUNT(*) FROM audit_log WHERE workspace_id = $1 AND actor_id = $2",
         )
-        .bind(ws.id).bind(user_a)
-        .fetch_one(&pool).await.unwrap();
+        .bind(ws.id)
+        .bind(user_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
         assert!(count.0 >= 1, "audit log entry should exist");
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_audit_log_multiple_actions() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
 
-        let actions = ["invite_member", "remove_member", "change_member_role", "delete_workspace"];
+        let actions = [
+            "invite_member",
+            "remove_member",
+            "change_member_role",
+            "delete_workspace",
+        ];
         for action in &actions {
             crate::audit::log(
-                &pool, ws.id, user_a, action, Some("user"), Some(Uuid::new_v4()), None,
-            ).await.unwrap();
+                &pool,
+                ws.id,
+                user_a,
+                action,
+                Some("user"),
+                Some(Uuid::new_v4()),
+                None,
+            )
+            .await
+            .unwrap();
         }
 
-        let count: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM audit_log WHERE workspace_id = $1"
-        )
-        .bind(ws.id)
-        .fetch_one(&pool).await.unwrap();
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM audit_log WHERE workspace_id = $1")
+                .bind(ws.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
         assert!(count.0 >= 4, "all audit log entries should exist");
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     // ── Edge Cases ────────────────────────────────────────────────
@@ -823,30 +1131,53 @@ mod tests {
     async fn test_is_member_returns_false_for_non_member() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, user_b, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
         assert!(is_member(&pool, ws.id, user_a).await.unwrap());
         assert!(!is_member(&pool, ws.id, user_b).await.unwrap());
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_list_members_includes_all_roles() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, user_b, user_c) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
-        add_member(&pool, ws.id, user_b, "writer", user_a).await.unwrap();
-        add_member(&pool, ws.id, user_c, "reader", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
+        add_member(&pool, ws.id, user_b, "writer", user_a)
+            .await
+            .unwrap();
+        add_member(&pool, ws.id, user_c, "reader", user_a)
+            .await
+            .unwrap();
 
         let members = list_members(&pool, ws.id).await.unwrap();
         assert_eq!(members.len(), 3);
@@ -855,59 +1186,102 @@ mod tests {
         assert!(roles.contains(&"writer"));
         assert!(roles.contains(&"reader"));
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_find_pending_invitations_for_user() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, user_b, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Test WS", &slug, "public", user_a).await.unwrap();
-        create_invitation(&pool, ws.id, "bob@test.com", "writer", user_a).await.unwrap();
+        let ws = create(&pool, "Test WS", &slug, "public", user_a)
+            .await
+            .unwrap();
+        create_invitation(&pool, ws.id, "bob@test.com", "writer", user_a)
+            .await
+            .unwrap();
 
-        let pending = find_pending_invitations_for_user(&pool, user_b).await.unwrap();
-        assert!(!pending.is_empty(), "user_b should see the pending invitation");
+        let pending = find_pending_invitations_for_user(&pool, user_b)
+            .await
+            .unwrap();
+        assert!(
+            !pending.is_empty(),
+            "user_b should see the pending invitation"
+        );
         assert_eq!(pending[0].email, "bob@test.com");
         assert_eq!(pending[0].status, "pending");
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_create_workspace_private_visibility() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Private WS", &slug, "private", user_a).await.unwrap();
+        let ws = create(&pool, "Private WS", &slug, "private", user_a)
+            .await
+            .unwrap();
         assert_eq!(ws.visibility, "private");
         assert_eq!(ws.name, "Private WS");
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 
     #[tokio::test]
     async fn test_rename_workspace() {
         let pool = match test_pool().await {
             Some(p) => p,
-            None => { eprintln!("Skipping: TEST_DATABASE_URL not set"); return; }
+            None => {
+                eprintln!("Skipping: TEST_DATABASE_URL not set");
+                return;
+            }
         };
         let (user_a, _, _) = create_test_users(&pool).await;
-        let slug = format!("test-ws-{}", Uuid::new_v4().to_string().split('-').next().unwrap());
+        let slug = format!(
+            "test-ws-{}",
+            Uuid::new_v4().to_string().split('-').next().unwrap()
+        );
 
-        let ws = create(&pool, "Original Name", &slug, "public", user_a).await.unwrap();
+        let ws = create(&pool, "Original Name", &slug, "public", user_a)
+            .await
+            .unwrap();
         let updated = rename(&pool, ws.id, "Renamed WS").await.unwrap();
         assert_eq!(updated.name, "Renamed WS");
         assert_eq!(updated.slug, slug);
 
-        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1").bind(ws.id).execute(&pool).await;
+        let _ = sqlx::query("DELETE FROM workspaces WHERE id = $1")
+            .bind(ws.id)
+            .execute(&pool)
+            .await;
     }
 }

--- a/crates/extractor/src/clean.rs
+++ b/crates/extractor/src/clean.rs
@@ -114,12 +114,25 @@ mod tests {
 
     #[test]
     fn test_removes_noise_patterns() {
-        let input = "Great article about Rust.\nCookie Policy\nMore content here.\nPrivacy Policy\nEnd.";
+        let input =
+            "Great article about Rust.\nCookie Policy\nMore content here.\nPrivacy Policy\nEnd.";
         let result = clean_text(input);
-        assert!(!result.contains("Cookie Policy"), "should remove Cookie Policy");
-        assert!(!result.contains("Privacy Policy"), "should remove Privacy Policy");
-        assert!(result.contains("Great article about Rust."), "should keep real content");
-        assert!(result.contains("More content here."), "should keep real content");
+        assert!(
+            !result.contains("Cookie Policy"),
+            "should remove Cookie Policy"
+        );
+        assert!(
+            !result.contains("Privacy Policy"),
+            "should remove Privacy Policy"
+        );
+        assert!(
+            result.contains("Great article about Rust."),
+            "should keep real content"
+        );
+        assert!(
+            result.contains("More content here."),
+            "should keep real content"
+        );
         assert!(result.contains("End."), "should keep real content");
     }
 
@@ -128,9 +141,18 @@ mod tests {
         let input = "First paragraph.\n\n\n\n\nSecond paragraph.";
         let result = clean_text(input);
         // Should have at most 2 blank lines between paragraphs
-        assert!(!result.contains("\n\n\n"), "should not have 3+ consecutive newlines");
-        assert!(result.contains("First paragraph."), "should keep first paragraph");
-        assert!(result.contains("Second paragraph."), "should keep second paragraph");
+        assert!(
+            !result.contains("\n\n\n"),
+            "should not have 3+ consecutive newlines"
+        );
+        assert!(
+            result.contains("First paragraph."),
+            "should keep first paragraph"
+        );
+        assert!(
+            result.contains("Second paragraph."),
+            "should keep second paragraph"
+        );
     }
 
     #[test]

--- a/crates/extractor/src/metadata.rs
+++ b/crates/extractor/src/metadata.rs
@@ -69,11 +69,7 @@ pub fn extract_headings(html: &str) -> Vec<Heading> {
 
     for el in document.select(&selector) {
         let tag = el.value().name();
-        let level: u8 = tag
-            .chars()
-            .nth(1)
-            .and_then(|c| c.to_digit(10))
-            .unwrap_or(1) as u8;
+        let level: u8 = tag.chars().nth(1).and_then(|c| c.to_digit(10)).unwrap_or(1) as u8;
         let text = el.text().collect::<String>().trim().to_string();
         if !text.is_empty() {
             headings.push(Heading { level, text });

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -42,8 +42,8 @@ impl From<git2::Error> for AppError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::response::IntoResponse;
     use axum::http::StatusCode;
+    use axum::response::IntoResponse;
 
     fn status_of(err: AppError) -> StatusCode {
         err.into_response().status()
@@ -51,27 +51,42 @@ mod tests {
 
     #[test]
     fn test_internal_returns_500() {
-        assert_eq!(status_of(AppError::Internal("boom".into())), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            status_of(AppError::Internal("boom".into())),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
     }
 
     #[test]
     fn test_not_found_returns_404() {
-        assert_eq!(status_of(AppError::NotFound("gone".into())), StatusCode::NOT_FOUND);
+        assert_eq!(
+            status_of(AppError::NotFound("gone".into())),
+            StatusCode::NOT_FOUND
+        );
     }
 
     #[test]
     fn test_bad_request_returns_400() {
-        assert_eq!(status_of(AppError::BadRequest("wrong".into())), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            status_of(AppError::BadRequest("wrong".into())),
+            StatusCode::BAD_REQUEST
+        );
     }
 
     #[test]
     fn test_unauthorized_returns_401() {
-        assert_eq!(status_of(AppError::Unauthorized("no access".into())), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            status_of(AppError::Unauthorized("no access".into())),
+            StatusCode::UNAUTHORIZED
+        );
     }
 
     #[test]
     fn test_forbidden_returns_403() {
-        assert_eq!(status_of(AppError::Forbidden("not allowed".into())), StatusCode::FORBIDDEN);
+        assert_eq!(
+            status_of(AppError::Forbidden("not allowed".into())),
+            StatusCode::FORBIDDEN
+        );
     }
 
     #[test]
@@ -84,13 +99,18 @@ mod tests {
             AppError::Forbidden("".into()),
         ];
 
-        let codes: Vec<StatusCode> = errors.into_iter()
+        let codes: Vec<StatusCode> = errors
+            .into_iter()
             .map(|e| e.into_response().status())
             .collect();
 
         use std::collections::HashSet;
         let unique: HashSet<_> = codes.into_iter().collect();
-        assert_eq!(unique.len(), 5, "all error types should have distinct status codes");
+        assert_eq!(
+            unique.len(),
+            5,
+            "all error types should have distinct status codes"
+        );
     }
 
     #[test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,9 +1,9 @@
 use axum::routing::{delete, get, post};
 use axum::Router;
 use clap::Parser;
-use cowiki_core::compiler::Compiler;
 use cowiki_core::ai::embedder::{create_embedder, EmbedderConfig};
 use cowiki_core::ai::llm::{create_llm, LlmConfig};
+use cowiki_core::compiler::Compiler;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
@@ -97,44 +97,119 @@ async fn main() {
         // Auth
         .route("/api/auth/register", post(routes::auth::register))
         .route("/api/auth/me", get(routes::auth::me))
-        .route("/api/auth/regenerate-key", post(routes::auth::regenerate_key))
+        .route(
+            "/api/auth/regenerate-key",
+            post(routes::auth::regenerate_key),
+        )
         .route("/api/auth/github", get(routes::auth::github_login))
-        .route("/api/auth/github/callback", get(routes::auth::github_callback))
+        .route(
+            "/api/auth/github/callback",
+            get(routes::auth::github_callback),
+        )
         // Workspaces
         .route("/api/workspaces", get(routes::workspace::list_workspaces))
         .route("/api/workspaces", post(routes::workspace::create_workspace))
-        .route("/api/workspaces/public", get(routes::workspace::list_public_workspaces))
-        .route("/api/workspaces/{slug}/join", post(routes::workspace::join_workspace))
-        .route("/api/workspaces/{slug}/rename", post(routes::workspace::rename_workspace))
-        .route("/api/workspaces/{slug}/invite", post(routes::workspace::invite))
-        .route("/api/workspaces/{slug}/members", get(routes::workspace::list_members))
+        .route(
+            "/api/workspaces/public",
+            get(routes::workspace::list_public_workspaces),
+        )
+        .route(
+            "/api/workspaces/{slug}/join",
+            post(routes::workspace::join_workspace),
+        )
+        .route(
+            "/api/workspaces/{slug}/rename",
+            post(routes::workspace::rename_workspace),
+        )
+        .route(
+            "/api/workspaces/{slug}/invite",
+            post(routes::workspace::invite),
+        )
+        .route(
+            "/api/workspaces/{slug}/members",
+            get(routes::workspace::list_members),
+        )
         // Invitations (accept/reject/pending)
-        .route("/api/invitations/pending", get(routes::workspace::list_pending_invitations))
-        .route("/api/invitations/{id}/accept", post(routes::workspace::accept_invitation))
-        .route("/api/invitations/{id}/reject", post(routes::workspace::reject_invitation))
+        .route(
+            "/api/invitations/pending",
+            get(routes::workspace::list_pending_invitations),
+        )
+        .route(
+            "/api/invitations/{id}/accept",
+            post(routes::workspace::accept_invitation),
+        )
+        .route(
+            "/api/invitations/{id}/reject",
+            post(routes::workspace::reject_invitation),
+        )
         // Member management (owner only)
-        .route("/api/workspaces/{slug}/members/remove", post(routes::workspace::remove_member))
-        .route("/api/workspaces/{slug}/members/role", post(routes::workspace::change_member_role))
+        .route(
+            "/api/workspaces/{slug}/members/remove",
+            post(routes::workspace::remove_member),
+        )
+        .route(
+            "/api/workspaces/{slug}/members/role",
+            post(routes::workspace::change_member_role),
+        )
         // Workspace deletion (owner only)
-        .route("/api/workspaces/{slug}", delete(routes::workspace::delete_workspace))
+        .route(
+            "/api/workspaces/{slug}",
+            delete(routes::workspace::delete_workspace),
+        )
         // Pages (workspace-scoped — uses per-workspace repo)
-        .route("/api/workspaces/{ws_slug}/pages", get(routes::pages::list_pages_ws))
-        .route("/api/workspaces/{ws_slug}/pages", post(routes::pages::write_page_ws))
-        .route("/api/workspaces/{ws_slug}/folders", post(routes::pages::create_folder_ws))
-        .route("/api/workspaces/{ws_slug}/pages/{*slug}", get(routes::pages::get_page_ws))
+        .route(
+            "/api/workspaces/{ws_slug}/pages",
+            get(routes::pages::list_pages_ws),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/pages",
+            post(routes::pages::write_page_ws),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/folders",
+            post(routes::pages::create_folder_ws),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/pages/{*slug}",
+            get(routes::pages::get_page_ws),
+        )
         // Ingest
-        .route("/api/workspaces/{ws_slug}/ingest", post(routes::ingest::ingest_ws))
+        .route(
+            "/api/workspaces/{ws_slug}/ingest",
+            post(routes::ingest::ingest_ws),
+        )
         // Compile
-        .route("/api/workspaces/{ws_slug}/compile", post(routes::compile::compile_ws))
+        .route(
+            "/api/workspaces/{ws_slug}/compile",
+            post(routes::compile::compile_ws),
+        )
         // Sources
-        .route("/api/workspaces/{ws_slug}/sources", get(routes::sources::list_sources))
-        .route("/api/workspaces/{ws_slug}/sources/{filename}", get(routes::sources::get_source))
+        .route(
+            "/api/workspaces/{ws_slug}/sources",
+            get(routes::sources::list_sources),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/sources/{filename}",
+            get(routes::sources::get_source),
+        )
         // Submit (workspace-scoped)
-        .route("/api/workspaces/{ws_slug}/submit", post(routes::submit::submit))
+        .route(
+            "/api/workspaces/{ws_slug}/submit",
+            post(routes::submit::submit),
+        )
         // Reviews (workspace-scoped)
-        .route("/api/workspaces/{ws_slug}/reviews", get(routes::review::list_reviews))
-        .route("/api/workspaces/{ws_slug}/reviews/{id}", get(routes::review::get_review))
-        .route("/api/workspaces/{ws_slug}/reviews/{id}", post(routes::review::review_action))
+        .route(
+            "/api/workspaces/{ws_slug}/reviews",
+            get(routes::review::list_reviews),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/reviews/{id}",
+            get(routes::review::get_review),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/reviews/{id}",
+            post(routes::review::review_action),
+        )
         // Search
         .route("/api/search", get(routes::search::search))
         // API Keys — multi-key management

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -32,11 +32,15 @@ pub async fn register(
     State(state): State<Arc<AppState>>,
     Json(input): Json<RegisterRequest>,
 ) -> Result<Json<AuthResponse>> {
-    if cowiki_db::users::find_by_name(&state.db, &input.name).await?.is_some() {
+    if cowiki_db::users::find_by_name(&state.db, &input.name)
+        .await?
+        .is_some()
+    {
         return Err(AppError::BadRequest("name already taken".into()));
     }
 
-    let user = cowiki_db::users::create(&state.db, &input.name, input.email.as_deref(), None).await?;
+    let user =
+        cowiki_db::users::create(&state.db, &input.name, input.email.as_deref(), None).await?;
     init_user_space(&state, &user).await?;
 
     Ok(Json(AuthResponse {
@@ -133,18 +137,25 @@ pub async fn github_callback(
             "client_secret": state.config.auth.github_client_secret,
             "code": params.code,
         }))
-        .send().await
+        .send()
+        .await
         .map_err(|e| AppError::Internal(format!("github token exchange failed: {e}")))?
-        .json::<GithubTokenResponse>().await
+        .json::<GithubTokenResponse>()
+        .await
         .map_err(|e| AppError::Internal(format!("github token parse failed: {e}")))?;
 
     let gh_user = client
         .get("https://api.github.com/user")
-        .header("Authorization", format!("Bearer {}", token_resp.access_token))
+        .header(
+            "Authorization",
+            format!("Bearer {}", token_resp.access_token),
+        )
         .header("User-Agent", "cowiki")
-        .send().await
+        .send()
+        .await
         .map_err(|e| AppError::Internal(format!("github user fetch failed: {e}")))?
-        .json::<GithubUser>().await
+        .json::<GithubUser>()
+        .await
         .map_err(|e| AppError::Internal(format!("github user parse failed: {e}")))?;
 
     let email = if gh_user.email.is_some() {
@@ -152,9 +163,13 @@ pub async fn github_callback(
     } else {
         let emails = match client
             .get("https://api.github.com/user/emails")
-            .header("Authorization", format!("Bearer {}", token_resp.access_token))
+            .header(
+                "Authorization",
+                format!("Bearer {}", token_resp.access_token),
+            )
             .header("User-Agent", "cowiki")
-            .send().await
+            .send()
+            .await
         {
             Ok(r) => r.json::<Vec<GithubEmail>>().await.ok(),
             Err(_) => None,
@@ -162,18 +177,23 @@ pub async fn github_callback(
         emails.and_then(|list| list.into_iter().find(|e| e.primary).map(|e| e.email))
     };
 
-    let user = if let Some(existing) = cowiki_db::users::find_by_name(&state.db, &gh_user.login).await? {
+    let user = if let Some(existing) =
+        cowiki_db::users::find_by_name(&state.db, &gh_user.login).await?
+    {
         // Update email if the existing user has none but GitHub provides one
         if existing.email.is_none() {
             if let Some(ref gh_email) = email {
-                if let Err(e) = cowiki_db::users::update_email(&state.db, existing.id, gh_email).await {
+                if let Err(e) =
+                    cowiki_db::users::update_email(&state.db, existing.id, gh_email).await
+                {
                     tracing::warn!("failed to update email for user {}: {:?}", existing.name, e);
                 }
             }
         }
         existing
     } else {
-        let user = cowiki_db::users::create(&state.db, &gh_user.login, email.as_deref(), None).await?;
+        let user =
+            cowiki_db::users::create(&state.db, &gh_user.login, email.as_deref(), None).await?;
         if let Err(e) = init_user_space(&state, &user).await {
             tracing::error!("failed to init user space: {:?}", e);
         }
@@ -201,7 +221,7 @@ pub async fn extract_user(
     db: &sqlx::PgPool,
     headers: &axum::http::HeaderMap,
 ) -> Result<cowiki_db::users::User> {
-    use sha2::{Sha256, Digest};
+    use sha2::{Digest, Sha256};
 
     let auth_header = headers
         .get("authorization")
@@ -250,34 +270,64 @@ async fn init_user_space(state: &crate::AppState, user: &cowiki_db::users::User)
 
     // 1. Create personal workspace in DB
     let personal_slug = format!("personal-{}", &user.id.to_string()[..8]);
-    cowiki_db::workspaces::create(&state.db, &format!("{}'s Space", user.name), &personal_slug, "private", user.id)
-        .await.ok();
+    cowiki_db::workspaces::create(
+        &state.db,
+        &format!("{}'s Space", user.name),
+        &personal_slug,
+        "private",
+        user.id,
+    )
+    .await
+    .ok();
 
     // 2. Init personal repo + user branch + welcome page
-    let personal_repo = state.repo_manager.get(&personal_slug)
+    let personal_repo = state
+        .repo_manager
+        .get(&personal_slug)
         .map_err(|e| AppError::Internal(e.to_string()))?;
-    personal_repo.ensure_user_branch(&user.id.to_string())
+    personal_repo
+        .ensure_user_branch(&user.id.to_string())
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
     let welcome = "---\ntitle: \"Getting Started\"\nsummary: \"Welcome to your personal knowledge space.\"\nkind: concept\n---\n\n# Getting Started\n\nWelcome to **CoWiki** — your personal knowledge space.\n\n## What you can do here\n\n- **Add sources** — paste text or URLs, CoWiki will compile them into wiki pages\n- **Organize** — create folders to keep your knowledge structured\n- **Search** — find anything with semantic search\n- **Collaborate** — join or create a Team Space to share knowledge with others\n";
 
-    personal_repo.write_file(&branch, "wiki/getting-started.md", welcome.as_bytes(), "init: getting started", &user.name)
+    personal_repo
+        .write_file(
+            &branch,
+            "wiki/getting-started.md",
+            welcome.as_bytes(),
+            "init: getting started",
+            &user.name,
+        )
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
     // 3. Create default Team Space ("General") in DB
     let team_slug = format!("general-{}", &user.id.to_string()[..8]);
-    if cowiki_db::workspaces::create(&state.db, "General", &team_slug, "public", user.id).await.is_ok() {
+    if cowiki_db::workspaces::create(&state.db, "General", &team_slug, "public", user.id)
+        .await
+        .is_ok()
+    {
         // 4. Init team repo + welcome page on main
-        let team_repo = state.repo_manager.get(&team_slug)
+        let team_repo = state
+            .repo_manager
+            .get(&team_slug)
             .map_err(|e| AppError::Internal(e.to_string()))?;
 
         let team_welcome = "---\ntitle: \"Team Space Home\"\nsummary: \"Welcome to the team's shared knowledge base.\"\nkind: overview\n---\n\n# Team Space Home\n\nWelcome to the team! This is your shared knowledge base.\n\nUse the **+** button in the sidebar to add pages and folders.\n\n## Getting started\n\n1. **Add sources** — paste articles, docs, or notes\n2. **Compile** — AI turns your sources into structured wiki pages\n3. **Submit** — submit your drafts for team review\n4. **Review** — approve or request changes on teammates' submissions\n";
 
-        team_repo.write_file("main", "wiki/team-space-home.md", team_welcome.as_bytes(), "init: team space home", "cowiki")
+        team_repo
+            .write_file(
+                "main",
+                "wiki/team-space-home.md",
+                team_welcome.as_bytes(),
+                "init: team space home",
+                "cowiki",
+            )
             .map_err(|e| AppError::Internal(e.to_string()))?;
 
         // Create user branch in team repo too
-        team_repo.ensure_user_branch(&user.id.to_string())
+        team_repo
+            .ensure_user_branch(&user.id.to_string())
             .map_err(|e| AppError::Internal(e.to_string()))?;
 
         tracing::info!("created team space '{}' for user {}", team_slug, user.name);

--- a/crates/server/src/routes/compile.rs
+++ b/crates/server/src/routes/compile.rs
@@ -39,7 +39,9 @@ pub async fn compile_ws(
     Path(ws_slug): Path<String>,
     Json(input): Json<CompileRequest>,
 ) -> Result<Json<CompileResponse>> {
-    let repo = state.repo_manager.get(&ws_slug)
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     super::pages::ensure_user_branch_if_needed(&repo, &input.branch)?;
     do_compile(&state, &repo, &input.branch).await
@@ -59,7 +61,10 @@ async fn do_compile(
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
     if source_files.is_empty() {
-        return Ok(Json(CompileResponse { pages: vec![], skipped: 0 }));
+        return Ok(Json(CompileResponse {
+            pages: vec![],
+            skipped: 0,
+        }));
     }
 
     // 3. Read sources, check which changed
@@ -86,11 +91,18 @@ async fn do_compile(
     }
 
     if new_sources.is_empty() {
-        return Ok(Json(CompileResponse { pages: vec![], skipped }));
+        return Ok(Json(CompileResponse {
+            pages: vec![],
+            skipped,
+        }));
     }
 
     // 4. Compile via LLM
-    let compiled = state.compiler.compile(&new_sources).await.map_err(AppError::Internal)?;
+    let compiled = state
+        .compiler
+        .compile(&new_sources)
+        .await
+        .map_err(AppError::Internal)?;
 
     let default_user = cowiki_db::users::get_default(&state.db).await?;
 
@@ -99,19 +111,44 @@ async fn do_compile(
     for page in &compiled {
         let full_content = format!(
             "---\ntitle: \"{}\"\nsummary: \"{}\"\nkind: concept\nsources:\n{}\n---\n\n{}",
-            page.title, page.summary,
-            page.sources.iter().map(|s| format!("  - {s}")).collect::<Vec<_>>().join("\n"),
+            page.title,
+            page.summary,
+            page.sources
+                .iter()
+                .map(|s| format!("  - {s}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
             page.body,
         );
 
         let path = format!("wiki/{}.md", page.slug);
-        repo.write_file(branch, &path, full_content.as_bytes(), &format!("compile: {}", page.title), branch)
-            .map_err(|e| AppError::Internal(e.to_string()))?;
+        repo.write_file(
+            branch,
+            &path,
+            full_content.as_bytes(),
+            &format!("compile: {}", page.title),
+            branch,
+        )
+        .map_err(|e| AppError::Internal(e.to_string()))?;
 
         let hash = format!("{:x}", Sha256::digest(full_content.as_bytes()));
-        if let Ok(emb) = state.compiler.embed(&format!("{}\n{}", page.title, page.summary)).await {
-            cowiki_db::pages::upsert(&state.db, &page.slug, &page.title, &page.summary, branch, &hash, Some(&emb), default_user.id)
-                .await.ok();
+        if let Ok(emb) = state
+            .compiler
+            .embed(&format!("{}\n{}", page.title, page.summary))
+            .await
+        {
+            cowiki_db::pages::upsert(
+                &state.db,
+                &page.slug,
+                &page.title,
+                &page.summary,
+                branch,
+                &hash,
+                Some(&emb),
+                default_user.id,
+            )
+            .await
+            .ok();
         }
 
         // Record source→page mapping from the compiler's output
@@ -123,24 +160,39 @@ async fn do_compile(
                 .push(page.slug.clone());
         }
 
-        result_pages.push(CompiledPage { slug: page.slug.clone(), title: page.title.clone(), summary: page.summary.clone() });
+        result_pages.push(CompiledPage {
+            slug: page.slug.clone(),
+            title: page.title.clone(),
+            summary: page.summary.clone(),
+        });
     }
 
     // 6. Save state
     save_state(repo, branch, &compile_state);
 
-    Ok(Json(CompileResponse { pages: result_pages, skipped }))
+    Ok(Json(CompileResponse {
+        pages: result_pages,
+        skipped,
+    }))
 }
 
 fn load_state(repo: &cowiki_core::git::WikiRepo, branch: &str) -> CompileState {
     repo.read_file(branch, ".cowiki/state.json")
-        .ok().flatten()
+        .ok()
+        .flatten()
         .and_then(|bytes| serde_json::from_slice(&bytes).ok())
         .unwrap_or_default()
 }
 
 fn save_state(repo: &cowiki_core::git::WikiRepo, branch: &str, compile_state: &CompileState) {
     if let Ok(json) = serde_json::to_string_pretty(compile_state) {
-        repo.write_file(branch, ".cowiki/state.json", json.as_bytes(), "update compile state", "cowiki").ok();
+        repo.write_file(
+            branch,
+            ".cowiki/state.json",
+            json.as_bytes(),
+            "update compile state",
+            "cowiki",
+        )
+        .ok();
     }
 }

--- a/crates/server/src/routes/ingest.rs
+++ b/crates/server/src/routes/ingest.rs
@@ -27,13 +27,18 @@ pub async fn ingest_ws(
     Path(ws_slug): Path<String>,
     Json(input): Json<IngestRequest>,
 ) -> Result<Json<IngestResponse>> {
-    let repo = state.repo_manager.get(&ws_slug)
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     super::pages::ensure_user_branch_if_needed(&repo, &input.branch)?;
     do_ingest(&repo, input).await
 }
 
-async fn do_ingest(repo: &cowiki_core::git::WikiRepo, input: IngestRequest) -> Result<Json<IngestResponse>> {
+async fn do_ingest(
+    repo: &cowiki_core::git::WikiRepo,
+    input: IngestRequest,
+) -> Result<Json<IngestResponse>> {
     let content = match input.source_type.as_str() {
         "url" => {
             let result = cowiki_extractor::extract_url(&input.content)
@@ -61,15 +66,23 @@ async fn do_ingest(repo: &cowiki_core::git::WikiRepo, input: IngestRequest) -> R
 
     // Ensure user branch exists before writing (needed for first ingest on a workspace)
     if input.branch != "main" {
-        repo.ensure_branch_exists(&input.branch)
-            .map_err(|e| AppError::Internal(format!("failed to create branch {}: {e}", input.branch)))?;
+        repo.ensure_branch_exists(&input.branch).map_err(|e| {
+            AppError::Internal(format!("failed to create branch {}: {e}", input.branch))
+        })?;
     }
 
     let path = format!("sources/{filename}");
     repo.write_file(
-        &input.branch, &path, content.as_bytes(),
-        &format!("ingest: {filename}"), &input.branch,
-    ).map_err(|e| AppError::Internal(e.to_string()))?;
+        &input.branch,
+        &path,
+        content.as_bytes(),
+        &format!("ingest: {filename}"),
+        &input.branch,
+    )
+    .map_err(|e| AppError::Internal(e.to_string()))?;
 
-    Ok(Json(IngestResponse { filename, content_hash: hash }))
+    Ok(Json(IngestResponse {
+        filename,
+        content_hash: hash,
+    }))
 }

--- a/crates/server/src/routes/keys.rs
+++ b/crates/server/src/routes/keys.rs
@@ -11,7 +11,7 @@ use crate::AppState;
 pub struct KeyResponse {
     pub id: String,
     pub name: String,
-    pub key_prefix: String,   // masked: "cw_****xxxx"
+    pub key_prefix: String, // masked: "cw_****xxxx"
     pub last_used_at: Option<String>,
     pub created_at: String,
 }
@@ -26,7 +26,7 @@ pub struct CreateKeyResponse {
     pub id: String,
     pub name: String,
     pub key_prefix: String,
-    pub raw_key: String,      // ONLY returned here — store it now!
+    pub raw_key: String, // ONLY returned here — store it now!
     pub created_at: String,
 }
 
@@ -88,7 +88,9 @@ pub async fn revoke_key(
     let revoked = cowiki_db::api_keys::revoke(&state.db, key_id, user.id).await?;
 
     if !revoked {
-        return Err(AppError::NotFound("key not found or already revoked".into()));
+        return Err(AppError::NotFound(
+            "key not found or already revoked".into(),
+        ));
     }
 
     Ok(Json(serde_json::json!({ "revoked": true })))

--- a/crates/server/src/routes/pages.rs
+++ b/crates/server/src/routes/pages.rs
@@ -45,12 +45,24 @@ fn parse_frontmatter(content: &str) -> (String, String) {
     let title = fm
         .lines()
         .find(|l| l.trim().starts_with("title:"))
-        .map(|l| l.trim().trim_start_matches("title:").trim().trim_matches('"').to_string())
+        .map(|l| {
+            l.trim()
+                .trim_start_matches("title:")
+                .trim()
+                .trim_matches('"')
+                .to_string()
+        })
         .unwrap_or_else(|| "Untitled".into());
     let summary = fm
         .lines()
         .find(|l| l.trim().starts_with("summary:"))
-        .map(|l| l.trim().trim_start_matches("summary:").trim().trim_matches('"').to_string())
+        .map(|l| {
+            l.trim()
+                .trim_start_matches("summary:")
+                .trim()
+                .trim_matches('"')
+                .to_string()
+        })
         .unwrap_or_default();
     (title, summary)
 }
@@ -77,7 +89,9 @@ pub async fn list_pages_ws(
     Path(ws_slug): Path<String>,
     Query(params): Query<ListParams>,
 ) -> Result<Json<Vec<PageListItem>>> {
-    let repo = state.repo_manager.get(&ws_slug)
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     let branch = params.branch.unwrap_or_else(|| "main".into());
     ensure_user_branch_if_needed(&repo, &branch)?;
@@ -90,17 +104,26 @@ pub async fn get_page_ws(
     Query(params): Query<ListParams>,
 ) -> Result<Json<PageResponse>> {
     let slug = raw_slug.strip_prefix('/').unwrap_or(&raw_slug).to_string();
-    let repo = state.repo_manager.get(&ws_slug)
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     let branch = params.branch.unwrap_or_else(|| "main".into());
     ensure_user_branch_if_needed(&repo, &branch)?;
     let path = format!("wiki/{slug}.md");
-    let content = repo.read_file(&branch, &path)
+    let content = repo
+        .read_file(&branch, &path)
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ok_or_else(|| AppError::NotFound(format!("page {slug} not found")))?;
     let body = String::from_utf8_lossy(&content).into_owned();
     let (title, summary) = parse_frontmatter(&body);
-    Ok(Json(PageResponse { slug, title, summary, body, branch }))
+    Ok(Json(PageResponse {
+        slug,
+        title,
+        summary,
+        body,
+        branch,
+    }))
 }
 
 pub async fn write_page_ws(
@@ -108,12 +131,20 @@ pub async fn write_page_ws(
     Path(ws_slug): Path<String>,
     Json(input): Json<WritePage>,
 ) -> Result<Json<serde_json::Value>> {
-    let repo = state.repo_manager.get(&ws_slug)
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     ensure_user_branch_if_needed(&repo, &input.branch)?;
     let path = format!("wiki/{}.md", input.slug);
-    repo.write_file(&input.branch, &path, input.body.as_bytes(), &format!("edit: {}", input.slug), &input.branch)
-        .map_err(|e| AppError::Internal(e.to_string()))?;
+    repo.write_file(
+        &input.branch,
+        &path,
+        input.body.as_bytes(),
+        &format!("edit: {}", input.slug),
+        &input.branch,
+    )
+    .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(Json(serde_json::json!({"ok": true, "slug": input.slug})))
 }
 
@@ -122,35 +153,60 @@ pub async fn create_folder_ws(
     Path(ws_slug): Path<String>,
     Json(input): Json<CreateFolder>,
 ) -> Result<Json<serde_json::Value>> {
-    let repo = state.repo_manager.get(&ws_slug)
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     ensure_user_branch_if_needed(&repo, &input.branch)?;
-    let slug = input.name.to_lowercase()
+    let slug = input
+        .name
+        .to_lowercase()
         .replace(|c: char| !c.is_alphanumeric() && c != ' ', "")
-        .split_whitespace().collect::<Vec<_>>().join("-");
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("-");
     let dir = match &input.parent {
         Some(p) => format!("{p}/{slug}"),
         None => format!("wiki/{slug}"),
     };
     let index_path = format!("{dir}/_index.md");
-    let body = format!("---\ntitle: \"{}\"\nsummary: \"\"\nkind: overview\n---\n\n", input.name);
-    repo.write_file(&input.branch, &index_path, body.as_bytes(), &format!("create folder: {}", input.name), &input.branch)
-        .map_err(|e| AppError::Internal(e.to_string()))?;
-    Ok(Json(serde_json::json!({"ok": true, "slug": format!("{slug}/_index"), "path": dir})))
+    let body = format!(
+        "---\ntitle: \"{}\"\nsummary: \"\"\nkind: overview\n---\n\n",
+        input.name
+    );
+    repo.write_file(
+        &input.branch,
+        &index_path,
+        body.as_bytes(),
+        &format!("create folder: {}", input.name),
+        &input.branch,
+    )
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(Json(
+        serde_json::json!({"ok": true, "slug": format!("{slug}/_index"), "path": dir}),
+    ))
 }
 
 /// Ensure user branch exists lazily (for workspace repos and legacy routes)
-pub(crate) fn ensure_user_branch_if_needed(repo: &cowiki_core::git::WikiRepo, branch: &str) -> Result<()> {
+pub(crate) fn ensure_user_branch_if_needed(
+    repo: &cowiki_core::git::WikiRepo,
+    branch: &str,
+) -> Result<()> {
     if let Some(user_id) = branch.strip_prefix("user/") {
-        repo.ensure_user_branch(user_id)
-            .map_err(|e| AppError::Internal(format!("failed to ensure user branch '{branch}': {e}")))?;
+        repo.ensure_user_branch(user_id).map_err(|e| {
+            AppError::Internal(format!("failed to ensure user branch '{branch}': {e}"))
+        })?;
     }
     Ok(())
 }
 
 /// Internal: list pages from a specific repo instance
-fn list_pages_from_repo(repo: &cowiki_core::git::WikiRepo, branch: &str) -> Result<Json<Vec<PageListItem>>> {
-    let files = repo.list_files_recursive(branch, "wiki")
+fn list_pages_from_repo(
+    repo: &cowiki_core::git::WikiRepo,
+    branch: &str,
+) -> Result<Json<Vec<PageListItem>>> {
+    let files = repo
+        .list_files_recursive(branch, "wiki")
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
     // Collect all items: pages and folder _index metadata
@@ -173,11 +229,23 @@ fn list_pages_from_repo(repo: &cowiki_core::git::WikiRepo, branch: &str) -> Resu
         };
         let parts: Vec<&str> = slug.split('/').collect();
         if parts.len() == 1 {
-            items.push(RawItem { slug: slug.clone(), title, summary, is_index: false, dir: String::new() });
+            items.push(RawItem {
+                slug: slug.clone(),
+                title,
+                summary,
+                is_index: false,
+                dir: String::new(),
+            });
         } else {
             let dir = parts[..parts.len() - 1].join("/");
             let filename = *parts.last().unwrap();
-            items.push(RawItem { slug: slug.clone(), title, summary, is_index: filename == "_index", dir });
+            items.push(RawItem {
+                slug: slug.clone(),
+                title,
+                summary,
+                is_index: filename == "_index",
+                dir,
+            });
         }
     }
 
@@ -189,8 +257,12 @@ fn list_pages_from_repo(repo: &cowiki_core::git::WikiRepo, branch: &str) -> Resu
         for item in items {
             if item.dir == parent_dir && !item.is_index {
                 result.push(PageListItem {
-                    slug: item.slug.clone(), title: item.title.clone(), summary: item.summary.clone(),
-                    branch: branch.into(), kind: "page".into(), children: Vec::new(),
+                    slug: item.slug.clone(),
+                    title: item.title.clone(),
+                    summary: item.summary.clone(),
+                    branch: branch.into(),
+                    kind: "page".into(),
+                    children: Vec::new(),
                 });
             }
         }
@@ -210,7 +282,10 @@ fn list_pages_from_repo(repo: &cowiki_core::git::WikiRepo, branch: &str) -> Resu
                 } else {
                     // Nested: subdirs start with parent_dir + "/"
                     if item.dir.starts_with(&format!("{parent_dir}/")) || item.dir == parent_dir {
-                        let rest = item.dir.strip_prefix(&format!("{parent_dir}/")).unwrap_or("");
+                        let rest = item
+                            .dir
+                            .strip_prefix(&format!("{parent_dir}/"))
+                            .unwrap_or("");
                         if rest.is_empty() {
                             continue; // same dir
                         }
@@ -232,7 +307,8 @@ fn list_pages_from_repo(repo: &cowiki_core::git::WikiRepo, branch: &str) -> Resu
 
         for subdir in subdirs {
             // Find _index for this subdir
-            let (title, summary) = items.iter()
+            let (title, summary) = items
+                .iter()
                 .find(|i| i.dir == subdir && i.is_index)
                 .map(|i| (i.title.clone(), i.summary.clone()))
                 .unwrap_or_else(|| {
@@ -242,13 +318,21 @@ fn list_pages_from_repo(repo: &cowiki_core::git::WikiRepo, branch: &str) -> Resu
 
             let children = build_level(items, &subdir, branch);
             result.push(PageListItem {
-                slug: format!("{subdir}/_index"), title, summary,
-                branch: branch.into(), kind: "folder".into(), children,
+                slug: format!("{subdir}/_index"),
+                title,
+                summary,
+                branch: branch.into(),
+                kind: "folder".into(),
+                children,
             });
         }
 
         // Sort: folders first, then alphabetically
-        result.sort_by(|a, b| (b.kind == "folder").cmp(&(a.kind == "folder")).then(a.title.cmp(&b.title)));
+        result.sort_by(|a, b| {
+            (b.kind == "folder")
+                .cmp(&(a.kind == "folder"))
+                .then(a.title.cmp(&b.title))
+        });
         result
     }
 

--- a/crates/server/src/routes/review.rs
+++ b/crates/server/src/routes/review.rs
@@ -30,10 +30,14 @@ pub async fn get_review(
         .await?
         .ok_or_else(|| AppError::NotFound("submission not found".into()))?;
     if submission.workspace_slug != ws_slug {
-        return Err(AppError::NotFound("submission not found in this workspace".into()));
+        return Err(AppError::NotFound(
+            "submission not found in this workspace".into(),
+        ));
     }
 
-    let repo = state.repo_manager.get(&ws_slug)
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     let diffs = repo
         .diff_files(&submission.source_branch, &submission.page_slugs)
@@ -59,7 +63,9 @@ pub async fn review_action(
         .await?
         .ok_or_else(|| AppError::NotFound("submission not found".into()))?;
     if submission.workspace_slug != ws_slug {
-        return Err(AppError::NotFound("submission not found in this workspace".into()));
+        return Err(AppError::NotFound(
+            "submission not found in this workspace".into(),
+        ));
     }
 
     // Authorization: reviewer must be a writer/owner of the workspace.
@@ -75,7 +81,9 @@ pub async fn review_action(
         ));
     }
 
-    let repo = state.repo_manager.get(&ws_slug)
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
 
     match input.action.as_str() {
@@ -86,14 +94,13 @@ pub async fn review_action(
                 .map(|s| format!("wiki/{s}.md"))
                 .collect();
 
-            repo
-                .merge_to_main(
-                    &submission.source_branch,
-                    &file_paths,
-                    &reviewer.name,
-                    &format!("approve: {}", submission.summary),
-                )
-                .map_err(|e| AppError::Internal(e.to_string()))?;
+            repo.merge_to_main(
+                &submission.source_branch,
+                &file_paths,
+                &reviewer.name,
+                &format!("approve: {}", submission.summary),
+            )
+            .map_err(|e| AppError::Internal(e.to_string()))?;
 
             // Update page records to main branch
             for slug in &submission.page_slugs {

--- a/crates/server/src/routes/sources.rs
+++ b/crates/server/src/routes/sources.rs
@@ -37,7 +37,10 @@ pub struct SourceContent {
     pub compiled_pages: Vec<String>,
 }
 
-fn load_compile_state(repo: &cowiki_core::git::WikiRepo, branch: &str) -> super::compile::CompileState {
+fn load_compile_state(
+    repo: &cowiki_core::git::WikiRepo,
+    branch: &str,
+) -> super::compile::CompileState {
     repo.read_file(branch, ".cowiki/state.json")
         .ok()
         .flatten()
@@ -63,17 +66,22 @@ pub async fn list_sources(
 
     let mut items = Vec::new();
     for file in &source_files {
-        let filename = file
-            .strip_prefix("sources/")
-            .unwrap_or(file)
-            .to_string();
+        let filename = file.strip_prefix("sources/").unwrap_or(file).to_string();
         let compiled = compile_state.sources.contains_key(&filename);
         let compiled_pages = if compiled {
-            compile_state.source_pages.get(&filename).cloned().unwrap_or_default()
+            compile_state
+                .source_pages
+                .get(&filename)
+                .cloned()
+                .unwrap_or_default()
         } else {
             Vec::new()
         };
-        items.push(SourceItem { filename, compiled, compiled_pages });
+        items.push(SourceItem {
+            filename,
+            compiled,
+            compiled_pages,
+        });
     }
     Ok(Json(items))
 }
@@ -101,10 +109,19 @@ pub async fn get_source(
     let compile_state = load_compile_state(&repo, branch);
     let compiled = compile_state.sources.contains_key(&filename);
     let compiled_pages = if compiled {
-        compile_state.source_pages.get(&filename).cloned().unwrap_or_default()
+        compile_state
+            .source_pages
+            .get(&filename)
+            .cloned()
+            .unwrap_or_default()
     } else {
         Vec::new()
     };
 
-    Ok(Json(SourceContent { filename, content, compiled, compiled_pages }))
+    Ok(Json(SourceContent {
+        filename,
+        content,
+        compiled,
+        compiled_pages,
+    }))
 }

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -31,7 +31,9 @@ pub async fn submit(
     Json(input): Json<SubmitRequest>,
 ) -> Result<Json<SubmitResponse>> {
     let user = extract_user(&state.db, &headers).await?;
-    let repo = state.repo_manager.get(&ws_slug)
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     super::pages::ensure_user_branch_if_needed(&repo, &input.branch)?;
 
@@ -128,14 +130,13 @@ pub async fn submit(
             .iter()
             .map(|s| format!("wiki/{s}.md"))
             .collect();
-        repo
-            .merge_to_main(
-                &input.branch,
-                &file_paths,
-                &user.name,
-                &format!("commit: {summary}"),
-            )
-            .map_err(|e| AppError::Internal(e.to_string()))?;
+        repo.merge_to_main(
+            &input.branch,
+            &file_paths,
+            &user.name,
+            &format!("commit: {summary}"),
+        )
+        .map_err(|e| AppError::Internal(e.to_string()))?;
 
         return Ok(Json(SubmitResponse {
             submission_id: uuid::Uuid::nil(),

--- a/crates/server/src/routes/workspace.rs
+++ b/crates/server/src/routes/workspace.rs
@@ -43,29 +43,40 @@ pub async fn create_workspace(
     let user = extract_user(&state.db, &headers).await?;
 
     if input.name.is_empty() || input.name.len() > 100 {
-        return Err(AppError::BadRequest("name must be between 1 and 100 characters".into()));
+        return Err(AppError::BadRequest(
+            "name must be between 1 and 100 characters".into(),
+        ));
     }
     if input.slug.is_empty() || input.slug.len() > 50 {
-        return Err(AppError::BadRequest("slug must be between 1 and 50 characters".into()));
+        return Err(AppError::BadRequest(
+            "slug must be between 1 and 50 characters".into(),
+        ));
     }
-    if !input.slug.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
+    if !input
+        .slug
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
         return Err(AppError::BadRequest("slug must match [a-z0-9-]+".into()));
     }
 
     let visibility = input.visibility.as_deref().unwrap_or("private");
     if visibility != "private" && visibility != "public" {
-        return Err(AppError::BadRequest("visibility must be 'private' or 'public'".into()));
+        return Err(AppError::BadRequest(
+            "visibility must be 'private' or 'public'".into(),
+        ));
     }
 
-    let ws = cowiki_db::workspaces::create(&state.db, &input.name, &input.slug, visibility, user.id)
-        .await
-        .map_err(|e| {
-            if e.to_string().contains("duplicate") {
-                AppError::BadRequest("workspace slug already taken".into())
-            } else {
-                AppError::Internal(e.to_string())
-            }
-        })?;
+    let ws =
+        cowiki_db::workspaces::create(&state.db, &input.name, &input.slug, visibility, user.id)
+            .await
+            .map_err(|e| {
+                if e.to_string().contains("duplicate") {
+                    AppError::BadRequest("workspace slug already taken".into())
+                } else {
+                    AppError::Internal(e.to_string())
+                }
+            })?;
 
     Ok(Json(ws_response(&ws, "owner")))
 }
@@ -82,7 +93,13 @@ pub async fn list_workspaces(
     for ws in workspaces {
         let role = cowiki_db::workspaces::get_member_role(&state.db, ws.id, user.id)
             .await?
-            .unwrap_or_else(|| if ws.created_by == user.id { "owner".into() } else { "reader".into() });
+            .unwrap_or_else(|| {
+                if ws.created_by == user.id {
+                    "owner".into()
+                } else {
+                    "reader".into()
+                }
+            });
         result.push(ws_response(&ws, &role));
     }
     Ok(Json(result))
@@ -96,7 +113,10 @@ pub async fn list_public_workspaces(
     let _user = extract_user(&state.db, &headers).await?;
     let workspaces = cowiki_db::workspaces::list_public(&state.db).await?;
 
-    let result = workspaces.iter().map(|ws| ws_response(ws, "viewer")).collect();
+    let result = workspaces
+        .iter()
+        .map(|ws| ws_response(ws, "viewer"))
+        .collect();
     Ok(Json(result))
 }
 
@@ -113,13 +133,16 @@ pub async fn join_workspace(
         .ok_or_else(|| AppError::NotFound("workspace not found".into()))?;
 
     if ws.visibility != "public" {
-        return Err(AppError::BadRequest("workspace is private, you need an invitation".into()));
+        return Err(AppError::BadRequest(
+            "workspace is private, you need an invitation".into(),
+        ));
     }
 
     cowiki_db::workspaces::add_member(&state.db, ws.id, user.id, "writer", user.id).await?;
 
     // Create user branch in the workspace repo
-    state.repo_manager
+    state
+        .repo_manager
         .get(&workspace_slug)
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ensure_user_branch(&user.id.to_string())
@@ -154,9 +177,9 @@ pub async fn invite(
     // Validate role
     let role = input.role.as_deref().unwrap_or("writer");
     if !cowiki_db::workspaces::Role::ALL.contains(&role) {
-        return Err(AppError::BadRequest(
-            format!("invalid role '{role}': must be one of: owner, writer, reader")
-        ));
+        return Err(AppError::BadRequest(format!(
+            "invalid role '{role}': must be one of: owner, writer, reader"
+        )));
     }
 
     let ws = cowiki_db::workspaces::find_by_slug(&state.db, &workspace_slug)
@@ -168,20 +191,27 @@ pub async fn invite(
         .await?
         .unwrap_or_default();
     if current_role != "owner" {
-        return Err(AppError::Forbidden("only the workspace owner can invite members".into()));
+        return Err(AppError::Forbidden(
+            "only the workspace owner can invite members".into(),
+        ));
     }
 
     // Create invitation (no auto-add — invitee must accept)
-    let invitation = cowiki_db::workspaces::create_invitation(
-        &state.db, ws.id, &input.email, role, user.id,
-    ).await?;
+    let invitation =
+        cowiki_db::workspaces::create_invitation(&state.db, ws.id, &input.email, role, user.id)
+            .await?;
 
     // Audit log
     cowiki_db::audit::log(
-        &state.db, ws.id, user.id,
-        "invite_member", Some("invitation"), Some(invitation.id),
+        &state.db,
+        ws.id,
+        user.id,
+        "invite_member",
+        Some("invitation"),
+        Some(invitation.id),
         Some(serde_json::json!({"email": input.email, "role": role})),
-    ).await?;
+    )
+    .await?;
 
     Ok(Json(InviteResponse {
         invitation_id: invitation.id.to_string(),
@@ -203,7 +233,9 @@ pub async fn list_members(
         .ok_or_else(|| AppError::NotFound("workspace not found".into()))?;
 
     if !cowiki_db::workspaces::is_member(&state.db, ws.id, user.id).await? {
-        return Err(AppError::Forbidden("you are not a member of this workspace".into()));
+        return Err(AppError::Forbidden(
+            "you are not a member of this workspace".into(),
+        ));
     }
 
     let members = cowiki_db::workspaces::list_members(&state.db, ws.id).await?;
@@ -255,10 +287,15 @@ pub async fn rename_workspace(
 
     // Audit log
     cowiki_db::audit::log(
-        &state.db, ws.id, user.id,
-        "rename_workspace", Some("workspace"), Some(ws.id),
+        &state.db,
+        ws.id,
+        user.id,
+        "rename_workspace",
+        Some("workspace"),
+        Some(ws.id),
         Some(serde_json::json!({"old_name": ws.name, "new_name": input.name})),
-    ).await?;
+    )
+    .await?;
 
     Ok(Json(ws_response(&updated, "owner")))
 }
@@ -289,7 +326,9 @@ pub async fn accept_invitation(
         .ok_or_else(|| AppError::NotFound("invitation not found".into()))?;
 
     if invitation.status != "pending" {
-        return Err(AppError::BadRequest("invitation is no longer pending".into()));
+        return Err(AppError::BadRequest(
+            "invitation is no longer pending".into(),
+        ));
     }
 
     // Verify the invitation is for this user (by email match)
@@ -303,32 +342,43 @@ pub async fn accept_invitation(
         ));
     }
     if current_user.email.as_deref() != Some(&invitation.email) {
-        return Err(AppError::Forbidden("this invitation is for a different email address".into()));
+        return Err(AppError::Forbidden(
+            "this invitation is for a different email address".into(),
+        ));
     }
 
     // Add as member with the invited role
     cowiki_db::workspaces::add_member(
-        &state.db, invitation.workspace_id, user.id,
-        &invitation.role, invitation.invited_by,
-    ).await?;
+        &state.db,
+        invitation.workspace_id,
+        user.id,
+        &invitation.role,
+        invitation.invited_by,
+    )
+    .await?;
 
     // Accept the invitation
     cowiki_db::workspaces::accept_invitation(&state.db, invitation.id).await?;
 
     // Audit log
     cowiki_db::audit::log(
-        &state.db, invitation.workspace_id, user.id,
-        "accept_invitation", Some("invitation"), Some(invitation.id),
+        &state.db,
+        invitation.workspace_id,
+        user.id,
+        "accept_invitation",
+        Some("invitation"),
+        Some(invitation.id),
         Some(serde_json::json!({"role": invitation.role})),
-    ).await?;
+    )
+    .await?;
 
     // Create user branch in the workspace repo
-    let ws = cowiki_db::workspaces::find_by_id(
-        &state.db, invitation.workspace_id,
-    ).await?
-    .ok_or_else(|| AppError::NotFound("workspace not found".into()))?;
+    let ws = cowiki_db::workspaces::find_by_id(&state.db, invitation.workspace_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("workspace not found".into()))?;
 
-    state.repo_manager
+    state
+        .repo_manager
         .get(&ws.slug)
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ensure_user_branch(&user.id.to_string())
@@ -350,7 +400,9 @@ pub async fn reject_invitation(
         .ok_or_else(|| AppError::NotFound("invitation not found".into()))?;
 
     if invitation.status != "pending" {
-        return Err(AppError::BadRequest("invitation is no longer pending".into()));
+        return Err(AppError::BadRequest(
+            "invitation is no longer pending".into(),
+        ));
     }
 
     // Verify email match
@@ -359,17 +411,24 @@ pub async fn reject_invitation(
         .ok_or_else(|| AppError::Unauthorized("user not found".into()))?;
 
     if current_user.email.as_deref() != Some(&invitation.email) {
-        return Err(AppError::Forbidden("this invitation is for a different email address".into()));
+        return Err(AppError::Forbidden(
+            "this invitation is for a different email address".into(),
+        ));
     }
 
     cowiki_db::workspaces::reject_invitation(&state.db, invitation.id).await?;
 
     // Audit log
     cowiki_db::audit::log(
-        &state.db, invitation.workspace_id, user.id,
-        "reject_invitation", Some("invitation"), Some(invitation.id),
+        &state.db,
+        invitation.workspace_id,
+        user.id,
+        "reject_invitation",
+        Some("invitation"),
+        Some(invitation.id),
         None,
-    ).await?;
+    )
+    .await?;
 
     Ok(Json(serde_json::json!({"status": "rejected"})))
 }
@@ -381,9 +440,8 @@ pub async fn list_pending_invitations(
 ) -> Result<Json<Vec<PendingInvitationResponse>>> {
     let user = extract_user(&state.db, &headers).await?;
 
-    let invitations = cowiki_db::workspaces::find_pending_invitations_for_user(
-        &state.db, user.id,
-    ).await?;
+    let invitations =
+        cowiki_db::workspaces::find_pending_invitations_for_user(&state.db, user.id).await?;
 
     let mut result = Vec::new();
     for inv in invitations {
@@ -433,14 +491,18 @@ pub async fn remove_member(
         .await?
         .unwrap_or_default();
     if current_role != "owner" {
-        return Err(AppError::Forbidden("only the owner can remove members".into()));
+        return Err(AppError::Forbidden(
+            "only the owner can remove members".into(),
+        ));
     }
 
     let target_id = Uuid::parse_str(&input.user_id)
         .map_err(|_| AppError::BadRequest("invalid user_id".into()))?;
 
     if target_id == user.id {
-        return Err(AppError::BadRequest("cannot remove yourself as owner".into()));
+        return Err(AppError::BadRequest(
+            "cannot remove yourself as owner".into(),
+        ));
     }
 
     let removed = cowiki_db::workspaces::remove_member(&state.db, ws.id, target_id).await?;
@@ -450,10 +512,15 @@ pub async fn remove_member(
 
     // Audit log
     cowiki_db::audit::log(
-        &state.db, ws.id, user.id,
-        "remove_member", Some("user"), Some(target_id),
+        &state.db,
+        ws.id,
+        user.id,
+        "remove_member",
+        Some("user"),
+        Some(target_id),
         None,
-    ).await?;
+    )
+    .await?;
 
     Ok(Json(serde_json::json!({"status": "removed"})))
 }
@@ -482,30 +549,38 @@ pub async fn change_member_role(
         .await?
         .unwrap_or_default();
     if current_role != "owner" {
-        return Err(AppError::Forbidden("only the owner can change member roles".into()));
+        return Err(AppError::Forbidden(
+            "only the owner can change member roles".into(),
+        ));
     }
 
     // Validate target role
     if !cowiki_db::workspaces::Role::ALL.contains(&input.role.as_str()) {
-        return Err(AppError::BadRequest(
-            format!("invalid role '{}': must be owner, writer, or reader", input.role)
-        ));
+        return Err(AppError::BadRequest(format!(
+            "invalid role '{}': must be owner, writer, or reader",
+            input.role
+        )));
     }
 
     let target_id = Uuid::parse_str(&input.user_id)
         .map_err(|_| AppError::BadRequest("invalid user_id".into()))?;
 
-    let new_role = cowiki_db::workspaces::change_member_role(
-        &state.db, ws.id, target_id, &input.role,
-    ).await?
-    .ok_or_else(|| AppError::NotFound("member not found or is owner".into()))?;
+    let new_role =
+        cowiki_db::workspaces::change_member_role(&state.db, ws.id, target_id, &input.role)
+            .await?
+            .ok_or_else(|| AppError::NotFound("member not found or is owner".into()))?;
 
     // Audit log
     cowiki_db::audit::log(
-        &state.db, ws.id, user.id,
-        "change_member_role", Some("user"), Some(target_id),
+        &state.db,
+        ws.id,
+        user.id,
+        "change_member_role",
+        Some("user"),
+        Some(target_id),
         Some(serde_json::json!({"new_role": new_role})),
-    ).await?;
+    )
+    .await?;
 
     let member_user = cowiki_db::users::find_by_id(&state.db, target_id)
         .await?
@@ -538,15 +613,22 @@ pub async fn delete_workspace(
         .await?
         .unwrap_or_default();
     if current_role != "owner" {
-        return Err(AppError::Forbidden("only the owner can delete a workspace".into()));
+        return Err(AppError::Forbidden(
+            "only the owner can delete a workspace".into(),
+        ));
     }
 
     // Audit log (before delete so we capture it)
     cowiki_db::audit::log(
-        &state.db, ws.id, user.id,
-        "delete_workspace", Some("workspace"), Some(ws.id),
+        &state.db,
+        ws.id,
+        user.id,
+        "delete_workspace",
+        Some("workspace"),
+        Some(ws.id),
         Some(serde_json::json!({"name": ws.name, "slug": ws.slug})),
-    ).await?;
+    )
+    .await?;
 
     cowiki_db::workspaces::delete_workspace(&state.db, ws.id).await?;
 

--- a/crates/server/tests/permission_api_tests.rs
+++ b/crates/server/tests/permission_api_tests.rs
@@ -5,12 +5,7 @@
 use std::process::Command;
 
 /// Helper: make an HTTP request to the API
-fn api_request(
-    method: &str,
-    path: &str,
-    body: Option<&str>,
-    api_key: &str,
-) -> (String, i32) {
+fn api_request(method: &str, path: &str, body: Option<&str>, api_key: &str) -> (String, i32) {
     let mut args = vec!["-s", "-o", "/dev/stderr", "-w", "%{http_code}"];
     if let Some(b) = body {
         args.push("-d");
@@ -24,7 +19,8 @@ fn api_request(
     args.push("-X");
     args.push(method);
 
-    let base_url = std::env::var("TEST_API_URL").unwrap_or_else(|_| "http://localhost:3000/api".into());
+    let base_url =
+        std::env::var("TEST_API_URL").unwrap_or_else(|_| "http://localhost:3000/api".into());
     let url = format!("{}{}", base_url, path);
     args.push(&url);
 
@@ -33,7 +29,10 @@ fn api_request(
         .output()
         .expect("failed to execute curl (is it installed?)");
 
-    let status = String::from_utf8_lossy(&output.stdout).trim().parse::<i32>().unwrap_or(-1);
+    let status = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<i32>()
+        .unwrap_or(-1);
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
     if status == 0 {
@@ -58,7 +57,10 @@ fn register_user(name: &str) -> (String, String) {
 
 /// Helper: create a workspace and return the slug
 fn create_workspace(api_key: &str, name: &str, slug: &str, visibility: &str) -> String {
-    let body = format!(r#"{{"name":"{}","slug":"{}","visibility":"{}"}}"#, name, slug, visibility);
+    let body = format!(
+        r#"{{"name":"{}","slug":"{}","visibility":"{}"}}"#,
+        name, slug, visibility
+    );
     let (resp, status) = api_request("POST", "/workspaces", Some(&body), api_key);
     assert_eq!(status, 200, "create workspace failed: {}", resp);
     slug.to_string()
@@ -67,7 +69,11 @@ fn create_workspace(api_key: &str, name: &str, slug: &str, visibility: &str) -> 
 /// Helper: join a public workspace
 fn join_workspace(api_key: &str, slug: &str) -> String {
     let (resp, status) = api_request("POST", &format!("/workspaces/{}/join", slug), None, api_key);
-    assert_eq!(status, 200, "join workspace failed: {} (status: {})", resp, status);
+    assert_eq!(
+        status, 200,
+        "join workspace failed: {} (status: {})",
+        resp, status
+    );
     let json: serde_json::Value = serde_json::from_str(&resp).unwrap();
     json["role"].as_str().unwrap().to_string()
 }
@@ -83,7 +89,10 @@ fn test_create_and_list_workspaces() {
         return;
     }
     let (_uid, key) = register_user("testuser-perm-1");
-    let slug = format!("perm-test-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-test-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     create_workspace(&key, "Perm Test WS", &slug, "public");
 
@@ -102,7 +111,10 @@ fn test_list_workspaces_returns_correct_role() {
     }
     let (_uid_a, key_a) = register_user("testuser-perm-2a");
     let (_uid_b, key_b) = register_user("testuser-perm-2b");
-    let slug = format!("perm-test-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-test-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     create_workspace(&key_a, "Role Test WS", &slug, "public");
     join_workspace(&key_b, &slug);
@@ -113,7 +125,10 @@ fn test_list_workspaces_returns_correct_role() {
 
     // User B (writer, joined public) lists
     let (resp_b, _) = api_request("GET", "/workspaces", None, &key_b);
-    assert!(resp_b.contains("writer"), "user_b should be writer for joined workspace");
+    assert!(
+        resp_b.contains("writer"),
+        "user_b should be writer for joined workspace"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -129,7 +144,10 @@ fn test_invite_requires_owner() {
     let (_uid_a, key_a) = register_user("testuser-inv-a");
     let (_uid_b, key_b) = register_user("testuser-inv-b");
     let (_uid_c, key_c) = register_user("testuser-inv-c");
-    let slug = format!("perm-inv-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-inv-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     create_workspace(&key_a, "Invite Test WS", &slug, "public");
     join_workspace(&key_b, &slug); // user_b joins as writer
@@ -137,11 +155,21 @@ fn test_invite_requires_owner() {
 
     // Writer tries to invite → should get 403 Forbidden
     let body = r#"{"email":"new@test.com","role":"writer"}"#;
-    let (_resp, status) = api_request("POST", &format!("/workspaces/{}/invite", slug), Some(body), &key_b);
+    let (_resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/invite", slug),
+        Some(body),
+        &key_b,
+    );
     assert_eq!(status, 403, "writer should not be able to invite members");
 
     // Owner can invite
-    let (_resp, status) = api_request("POST", &format!("/workspaces/{}/invite", slug), Some(body), &key_a);
+    let (_resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/invite", slug),
+        Some(body),
+        &key_a,
+    );
     assert_eq!(status, 200, "owner should be able to invite members");
 }
 
@@ -152,13 +180,21 @@ fn test_invite_with_invalid_role_rejected() {
         return;
     }
     let (_uid_a, key_a) = register_user("testuser-inv-role");
-    let slug = format!("perm-inv-role-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-inv-role-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     create_workspace(&key_a, "Invite Role WS", &slug, "public");
 
     // Invalid role
     let body = r#"{"email":"new@test.com","role":"admin"}"#;
-    let (_resp, status) = api_request("POST", &format!("/workspaces/{}/invite", slug), Some(body), &key_a);
+    let (_resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/invite", slug),
+        Some(body),
+        &key_a,
+    );
     assert_eq!(status, 400, "invalid role should be rejected");
 }
 
@@ -174,16 +210,29 @@ fn test_list_members_all_roles_can_view() {
     }
     let (_uid_a, key_a) = register_user("testuser-mem-a");
     let (_uid_b, key_b) = register_user("testuser-mem-b");
-    let slug = format!("perm-mem-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-mem-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     create_workspace(&key_a, "Member View WS", &slug, "public");
     join_workspace(&key_b, &slug);
 
     // Both owner and writer should be able to list members
-    let (_resp, status_a) = api_request("GET", &format!("/workspaces/{}/members", slug), None, &key_a);
+    let (_resp, status_a) = api_request(
+        "GET",
+        &format!("/workspaces/{}/members", slug),
+        None,
+        &key_a,
+    );
     assert_eq!(status_a, 200, "owner should list members");
 
-    let (_resp, status_b) = api_request("GET", &format!("/workspaces/{}/members", slug), None, &key_b);
+    let (_resp, status_b) = api_request(
+        "GET",
+        &format!("/workspaces/{}/members", slug),
+        None,
+        &key_b,
+    );
     assert_eq!(status_b, 200, "writer should list members");
 }
 
@@ -195,12 +244,20 @@ fn test_list_members_non_member_rejected() {
     }
     let (_uid_a, key_a) = register_user("testuser-nonmem-a");
     let (_uid_b, key_b) = register_user("testuser-nonmem-b");
-    let slug = format!("perm-nonmem-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-nonmem-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     create_workspace(&key_a, "NonMember WS", &slug, "public");
 
     // user_b is not a member → should get 403
-    let (_resp, status) = api_request("GET", &format!("/workspaces/{}/members", slug), None, &key_b);
+    let (_resp, status) = api_request(
+        "GET",
+        &format!("/workspaces/{}/members", slug),
+        None,
+        &key_b,
+    );
     assert_eq!(status, 403, "non-member should not see members");
 }
 
@@ -212,26 +269,45 @@ fn test_remove_member_owner_only() {
     }
     let (_uid_a, key_a) = register_user("testuser-rm-a");
     let (_uid_b, key_b) = register_user("testuser-rm-b");
-    let slug = format!("perm-rm-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-rm-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     create_workspace(&key_a, "Remove Test WS", &slug, "public");
     join_workspace(&key_b, &slug);
 
     // Get user_b's ID from member list
-    let (resp, _) = api_request("GET", &format!("/workspaces/{}/members", slug), None, &key_a);
+    let (resp, _) = api_request(
+        "GET",
+        &format!("/workspaces/{}/members", slug),
+        None,
+        &key_a,
+    );
     let members: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap();
-    let user_b_id = members.iter()
+    let user_b_id = members
+        .iter()
         .find(|m| m["name"].as_str() == Some("testuser-rm-b"))
         .map(|m| m["id"].as_str().unwrap())
         .expect("user_b should be in member list");
 
     // Writer tries to remove → 403
     let body = format!(r#"{{"user_id":"{}"}}"#, user_b_id);
-    let (_resp, status) = api_request("POST", &format!("/workspaces/{}/members/remove", slug), Some(&body), &key_b);
+    let (_resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/members/remove", slug),
+        Some(&body),
+        &key_b,
+    );
     assert_eq!(status, 403, "writer should not remove members");
 
     // Owner removes → 200
-    let (_resp, status) = api_request("POST", &format!("/workspaces/{}/members/remove", slug), Some(&body), &key_a);
+    let (_resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/members/remove", slug),
+        Some(&body),
+        &key_a,
+    );
     assert_eq!(status, 200, "owner should remove members");
 }
 
@@ -243,26 +319,45 @@ fn test_change_role_owner_only() {
     }
     let (_uid_a, key_a) = register_user("testuser-cr-a");
     let (_uid_b, key_b) = register_user("testuser-cr-b");
-    let slug = format!("perm-cr-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-cr-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     create_workspace(&key_a, "ChangeRole WS", &slug, "public");
     join_workspace(&key_b, &slug);
 
     // Get user_b's ID
-    let (resp, _) = api_request("GET", &format!("/workspaces/{}/members", slug), None, &key_a);
+    let (resp, _) = api_request(
+        "GET",
+        &format!("/workspaces/{}/members", slug),
+        None,
+        &key_a,
+    );
     let members: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap();
-    let user_b_id = members.iter()
+    let user_b_id = members
+        .iter()
         .find(|m| m["name"].as_str() == Some("testuser-cr-b"))
         .map(|m| m["id"].as_str().unwrap())
         .expect("user_b should be in member list");
 
     // Writer tries to change role → 403
     let body = format!(r#"{{"user_id":"{}","role":"reader"}}"#, user_b_id);
-    let (_resp, status) = api_request("POST", &format!("/workspaces/{}/members/role", slug), Some(&body), &key_b);
+    let (_resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/members/role", slug),
+        Some(&body),
+        &key_b,
+    );
     assert_eq!(status, 403, "writer should not change roles");
 
     // Owner changes role → 200
-    let (_resp, status) = api_request("POST", &format!("/workspaces/{}/members/role", slug), Some(&body), &key_a);
+    let (_resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/members/role", slug),
+        Some(&body),
+        &key_a,
+    );
     assert_eq!(status, 200, "owner should change roles");
 }
 
@@ -278,19 +373,32 @@ fn test_rename_requires_owner() {
     }
     let (_uid_a, key_a) = register_user("testuser-rn-a");
     let (_uid_b, key_b) = register_user("testuser-rn-b");
-    let slug = format!("perm-rn-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-rn-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     create_workspace(&key_a, "Rename Test WS", &slug, "public");
     join_workspace(&key_b, &slug);
 
     // Writer tries to rename → 403
     let body = r#"{"name":"Renamed by Writer"}"#;
-    let (_resp, status) = api_request("POST", &format!("/workspaces/{}/rename", slug), Some(body), &key_b);
+    let (_resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/rename", slug),
+        Some(body),
+        &key_b,
+    );
     assert_eq!(status, 403, "writer should not rename workspace");
 
     // Owner renames → 200
     let body = r#"{"name":"Renamed by Owner"}"#;
-    let (_resp, status) = api_request("POST", &format!("/workspaces/{}/rename", slug), Some(body), &key_a);
+    let (_resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/rename", slug),
+        Some(body),
+        &key_a,
+    );
     assert_eq!(status, 200, "owner should rename workspace");
 }
 
@@ -306,7 +414,10 @@ fn test_delete_requires_owner() {
     }
     let (_uid_a, key_a) = register_user("testuser-del-a");
     let (_uid_b, key_b) = register_user("testuser-del-b");
-    let slug = format!("perm-del-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-del-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     create_workspace(&key_a, "Delete Test WS", &slug, "public");
     join_workspace(&key_b, &slug);
@@ -335,7 +446,10 @@ fn test_full_permission_matrix() {
     let (_uid_a, key_a) = register_user("perm-matrix-alice");
     let (_uid_b, key_b) = register_user("perm-matrix-bob");
     let (_uid_c, _key_c) = register_user("perm-matrix-carol");
-    let slug = format!("perm-matrix-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug = format!(
+        "perm-matrix-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
 
     // Alice creates the workspace (becomes owner)
     create_workspace(&key_a, "Matrix Test WS", &slug, "public");
@@ -345,8 +459,17 @@ fn test_full_permission_matrix() {
 
     // Owner invites Carol as reader
     let invite_body = format!(r#"{{"email":"perm-matrix-carol@test.com","role":"reader"}}"#);
-    let (invite_resp, inv_status) = api_request("POST", &format!("/workspaces/{}/invite", slug), Some(&invite_body), &key_a);
-    assert_eq!(inv_status, 200, "owner should invite reader: {}", invite_resp);
+    let (invite_resp, inv_status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/invite", slug),
+        Some(&invite_body),
+        &key_a,
+    );
+    assert_eq!(
+        inv_status, 200,
+        "owner should invite reader: {}",
+        invite_resp
+    );
 
     // Get Carol's user_id from invite response (or reader list would have it)
     // For simplicity, we'll test that Carol can see the workspace but not manage
@@ -356,23 +479,51 @@ fn test_full_permission_matrix() {
     // ── Matrix verification ──
 
     // Operations that ALL can do: list members
-    let (_, s) = api_request("GET", &format!("/workspaces/{}/members", slug), None, &key_a);
+    let (_, s) = api_request(
+        "GET",
+        &format!("/workspaces/{}/members", slug),
+        None,
+        &key_a,
+    );
     assert_eq!(s, 200, "owner list members");
-    let (_, s) = api_request("GET", &format!("/workspaces/{}/members", slug), None, &key_b);
+    let (_, s) = api_request(
+        "GET",
+        &format!("/workspaces/{}/members", slug),
+        None,
+        &key_b,
+    );
     assert_eq!(s, 200, "writer list members");
 
     // Operations that ONLY owner can do: invite
-    let (_, s) = api_request("POST", &format!("/workspaces/{}/invite", slug), Some(r#"{"email":"x@t.com","role":"reader"}"#), &key_b);
+    let (_, s) = api_request(
+        "POST",
+        &format!("/workspaces/{}/invite", slug),
+        Some(r#"{"email":"x@t.com","role":"reader"}"#),
+        &key_b,
+    );
     assert_eq!(s, 403, "writer invite → 403");
-    let (_, s) = api_request("POST", &format!("/workspaces/{}/invite", slug), Some(r#"{"email":"x@t.com","role":"reader"}"#), &key_a);
+    let (_, s) = api_request(
+        "POST",
+        &format!("/workspaces/{}/invite", slug),
+        Some(r#"{"email":"x@t.com","role":"reader"}"#),
+        &key_a,
+    );
     assert_eq!(s, 200, "owner invite → 200");
 
     // Operations that ONLY owner can do: rename
-    let (_, s) = api_request("POST", &format!("/workspaces/{}/rename", slug), Some(r#"{"name":"Hacked"}"#), &key_b);
+    let (_, s) = api_request(
+        "POST",
+        &format!("/workspaces/{}/rename", slug),
+        Some(r#"{"name":"Hacked"}"#),
+        &key_b,
+    );
     assert_eq!(s, 403, "writer rename → 403");
 
     // Operations that ONLY owner can do: delete
-    let slug_del = format!("perm-matrix-del-{}", uuid::Uuid::new_v4().to_string().split('-').next().unwrap());
+    let slug_del = format!(
+        "perm-matrix-del-{}",
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
     create_workspace(&key_a, "Matrix Del WS", &slug_del, "public");
     join_workspace(&key_b, &slug_del);
     let (_, s) = api_request("DELETE", &format!("/workspaces/{}", slug_del), None, &key_b);

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -290,9 +290,13 @@ impl CowikiConfig {
     pub fn from_env() -> Self {
         // COWIKI_PORT → cowiki-server REST API port; COWIKI_MCP_PORT → MCP server port
         let server_port: u16 = std::env::var("COWIKI_PORT")
-            .ok().and_then(|s| s.parse().ok()).unwrap_or(3000);
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(3000);
         let mcp_port: u16 = std::env::var("COWIKI_MCP_PORT")
-            .ok().and_then(|s| s.parse().ok()).unwrap_or(8080);
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(8080);
 
         let llm_api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
         let llm_api_base =


### PR DESCRIPTION
## Summary
- install the rustfmt component in CI
- run `cargo fmt --all -- --check` before build/test
- apply the current rustfmt baseline so the new check passes on dev

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`

Note: `actionlint` is not installed in this environment, so I could not run it locally.