### PR TITLE
fix: avoid merge deadlock

### DIFF
--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -442,8 +442,6 @@ impl WikiRepo {
         author: &str,
         message: &str,
     ) -> Result<(), git2::Error> {
-        let lock = self.branch_lock("main");
-        let _guard = lock.write().unwrap();
         for path in file_paths {
             if let Some(content) = self.read_file(branch, path)? {
                 self.write_file("main", path, &content, message, author)?;


### PR DESCRIPTION
## Summary
- remove the outer main-branch write lock in merge_to_main
- rely on write_file("main") to serialize each write and avoid re-entering the same std::sync::RwLock

## Verification
- cargo fmt --all -- --check
- cargo test