### PR TITLE
fix: require canonical page titles

### DIFF
--- a/crates/core/src/compiler.rs
+++ b/crates/core/src/compiler.rs
@@ -49,7 +49,7 @@ Be concise. One concept per page. Use clear headings. Attribute claims to source
             .split("===PAGE_BREAK===")
             .filter(|s: &&str| !s.trim().is_empty())
             .map(|raw: &str| parse_compiled_page(raw.trim()))
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(pages)
     }
@@ -81,8 +81,8 @@ Be concise. One concept per page. Use clear headings. Attribute claims to source
     }
 }
 
-fn parse_compiled_page(raw: &str) -> Page {
-    let mut title = "Untitled".to_string();
+fn parse_compiled_page(raw: &str) -> Result<Page, String> {
+    let mut title: Option<String> = None;
     let mut summary = String::new();
     let mut sources = Vec::new();
     let mut body = raw.to_string();
@@ -104,11 +104,14 @@ fn parse_compiled_page(raw: &str) -> Page {
             for line in fm.lines() {
                 let trimmed = line.trim();
                 if trimmed.starts_with("title:") {
-                    title = trimmed
+                    let parsed = trimmed
                         .trim_start_matches("title:")
                         .trim()
                         .trim_matches('"')
                         .to_string();
+                    if !parsed.trim().is_empty() {
+                        title = Some(parsed);
+                    }
                     in_sources = false;
                 } else if trimmed.starts_with("summary:") {
                     summary = trimmed
@@ -128,6 +131,7 @@ fn parse_compiled_page(raw: &str) -> Page {
         }
     }
 
+    let title = title.ok_or_else(|| "compiled page missing frontmatter.title".to_string())?;
     let slug = title
         .to_lowercase()
         .replace(|c: char| !c.is_alphanumeric() && c != ' ', "")
@@ -135,12 +139,12 @@ fn parse_compiled_page(raw: &str) -> Page {
         .collect::<Vec<_>>()
         .join("-");
 
-    Page {
+    Ok(Page {
         slug,
         title,
         summary,
         body,
         sources,
         created_at: chrono::Utc::now().to_rfc3339(),
-    }
+    })
 }

--- a/crates/server/src/routes/pages.rs
+++ b/crates/server/src/routes/pages.rs
@@ -33,13 +33,13 @@ pub struct PageResponse {
     pub branch: String,
 }
 
-fn parse_frontmatter(content: &str) -> (String, String) {
+pub(crate) fn parse_frontmatter(content: &str) -> (Option<String>, String) {
     if !content.starts_with("---") {
-        return ("Untitled".into(), String::new());
+        return (None, String::new());
     }
     let parts: Vec<&str> = content.splitn(3, "---").collect();
     if parts.len() < 3 {
-        return ("Untitled".into(), String::new());
+        return (None, String::new());
     }
     let fm = parts[1];
     let title = fm
@@ -52,7 +52,7 @@ fn parse_frontmatter(content: &str) -> (String, String) {
                 .trim_matches('"')
                 .to_string()
         })
-        .unwrap_or_else(|| "Untitled".into());
+        .filter(|title| !title.trim().is_empty());
     let summary = fm
         .lines()
         .find(|l| l.trim().starts_with("summary:"))
@@ -65,6 +65,49 @@ fn parse_frontmatter(content: &str) -> (String, String) {
         })
         .unwrap_or_default();
     (title, summary)
+}
+
+pub(crate) fn require_page_title(content: &str) -> Result<(String, String)> {
+    let (title, summary) = parse_frontmatter(content);
+    let title = title.ok_or_else(|| {
+        AppError::BadRequest("wiki pages require non-empty frontmatter.title".into())
+    })?;
+    Ok((title, summary))
+}
+
+fn fallback_title_from_content_or_slug(content: &str, slug: &str) -> String {
+    content
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("# "))
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| title_from_slug(slug))
+}
+
+fn title_from_slug(slug: &str) -> String {
+    let base = slug
+        .trim_end_matches("/_index")
+        .rsplit('/')
+        .next()
+        .unwrap_or(slug);
+    let title = base
+        .replace(['-', '_'], " ")
+        .split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    if title.is_empty() {
+        "Untitled".into()
+    } else {
+        title
+    }
 }
 
 #[derive(Deserialize)]
@@ -117,6 +160,7 @@ pub async fn get_page_ws(
         .ok_or_else(|| AppError::NotFound(format!("page {slug} not found")))?;
     let body = String::from_utf8_lossy(&content).into_owned();
     let (title, summary) = parse_frontmatter(&body);
+    let title = title.unwrap_or_else(|| fallback_title_from_content_or_slug(&body, &slug));
     Ok(Json(PageResponse {
         slug,
         title,
@@ -136,6 +180,7 @@ pub async fn write_page_ws(
         .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     ensure_user_branch_if_needed(&repo, &input.branch)?;
+    require_page_title(&input.body)?;
     let path = format!("wiki/{}.md", input.slug);
     repo.write_file(
         &input.branch,
@@ -224,8 +269,18 @@ fn list_pages_from_repo(
         let rel = file_path.strip_prefix("wiki/").unwrap_or(file_path);
         let slug = rel.strip_suffix(".md").unwrap_or(rel).to_string();
         let (title, summary) = match repo.read_file(branch, file_path) {
-            Ok(Some(content)) => parse_frontmatter(&String::from_utf8_lossy(&content)),
-            _ => ("Untitled".into(), String::new()),
+            Ok(Some(content)) => {
+                let body = String::from_utf8_lossy(&content);
+                let (title, summary) = parse_frontmatter(&body);
+                let title =
+                    title.unwrap_or_else(|| fallback_title_from_content_or_slug(&body, &slug));
+                (title, summary)
+            }
+            _ => {
+                return Err(AppError::BadRequest(format!(
+                    "{file_path} could not be read"
+                )));
+            }
         };
         let parts: Vec<&str> = slug.split('/').collect();
         if parts.len() == 1 {

--- a/crates/server/src/routes/review.rs
+++ b/crates/server/src/routes/review.rs
@@ -107,6 +107,15 @@ pub async fn review_action(
                 .map(|s| format!("wiki/{s}.md"))
                 .collect();
 
+            for (slug, path) in submission.page_slugs.iter().zip(file_paths.iter()) {
+                let content = repo
+                    .read_file(&submission.source_branch, path)
+                    .map_err(|e| AppError::Internal(e.to_string()))?
+                    .ok_or_else(|| AppError::BadRequest(format!("page {slug} not found")))?;
+                let text = String::from_utf8_lossy(&content);
+                super::pages::require_page_title(&text)?;
+            }
+
             repo.merge_to_main(
                 &submission.source_branch,
                 &file_paths,
@@ -123,12 +132,13 @@ pub async fn review_action(
                     .map_err(|e| AppError::Internal(e.to_string()))?
                 {
                     let text = String::from_utf8_lossy(&content);
+                    let (title, summary) = super::pages::require_page_title(&text)?;
                     let hash = format!("{:x}", Sha256::digest(text.as_bytes()));
                     cowiki_db::pages::upsert(
                         &state.db,
                         slug,
-                        slug,
-                        "",
+                        &title,
+                        &summary,
                         "main",
                         &hash,
                         None,

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -54,14 +54,14 @@ pub async fn submit(
     let mut embeddings = Vec::new();
     for slug in &input.page_slugs {
         let path = format!("wiki/{slug}.md");
-        if let Some(content) = repo
+        let content = repo
             .read_file(&input.branch, &path)
             .map_err(|e| AppError::Internal(e.to_string()))?
-        {
-            let text = String::from_utf8_lossy(&content);
-            if let Ok(emb) = state.compiler.embed(&text).await {
-                embeddings.push((slug.clone(), emb));
-            }
+            .ok_or_else(|| AppError::BadRequest(format!("page {slug} not found")))?;
+        let text = String::from_utf8_lossy(&content);
+        super::pages::require_page_title(&text)?;
+        if let Ok(emb) = state.compiler.embed(&text).await {
+            embeddings.push((slug.clone(), emb));
         }
     }
 


### PR DESCRIPTION
## Summary
- require non-empty frontmatter.title when writing wiki pages
- reject submit/merge flows for pages missing canonical titles
- make AI compile parsing fail when generated pages omit title
- store merged page metadata using frontmatter title and summary

## Data migration
- scanned local workspace git repos and added frontmatter.title to existing wiki markdown pages that were missing it
- post-scan result: missing=0

## Verification
- cargo fmt --all -- --check
- cargo test