### PR TITLE
fix(db): allow invitation 'rejected' status (#57)

### DIFF
--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -59,5 +59,10 @@ pub async fn run_migrations(pool: &PgPool, embedding_dim: u32) -> sqlx::Result<(
         tracing::error!("DB error: {e}");
         e
     })?;
+    let sql10 = include_str!("migrations/010_invitation_reject_status.sql");
+    sqlx::raw_sql(sql10).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     Ok(())
 }

--- a/crates/db/src/migrations/010_invitation_reject_status.sql
+++ b/crates/db/src/migrations/010_invitation_reject_status.sql
@@ -1,0 +1,6 @@
+-- Allow invitations to be rejected. `reject_invitation` writes status = 'rejected',
+-- but the original CHECK (002_workspaces.sql) only permitted ('pending','accepted','expired'),
+-- so the reject-invitation endpoint failed at runtime with a check_violation.
+ALTER TABLE invitations DROP CONSTRAINT IF EXISTS invitations_status_check;
+ALTER TABLE invitations ADD CONSTRAINT invitations_status_check
+    CHECK (status IN ('pending', 'accepted', 'expired', 'rejected'));

--- a/crates/db/src/submissions.rs
+++ b/crates/db/src/submissions.rs
@@ -100,6 +100,7 @@ mod tests {
             include_str!("migrations/007_team_permissions.sql"),
             include_str!("migrations/008_submission_workspace.sql"),
             include_str!("migrations/009_review_comments.sql"),
+            include_str!("migrations/010_invitation_reject_status.sql"),
         ] {
             let _ = sqlx::raw_sql(m).execute(&pool).await;
         }

--- a/crates/db/src/workspaces.rs
+++ b/crates/db/src/workspaces.rs
@@ -526,6 +526,12 @@ mod tests {
         let _ = sqlx::raw_sql(include_str!("migrations/008_submission_workspace.sql"))
             .execute(&pool)
             .await;
+        let _ = sqlx::raw_sql(include_str!("migrations/009_review_comments.sql"))
+            .execute(&pool)
+            .await;
+        let _ = sqlx::raw_sql(include_str!("migrations/010_invitation_reject_status.sql"))
+            .execute(&pool)
+            .await;
         Some(pool)
     }
 


### PR DESCRIPTION
`reject_invitation` writes `status = 'rejected'`, but the `invitations.status` CHECK (`002_workspaces.sql`) only allowed `('pending','accepted','expired')` — so the live reject-invitation endpoint crashed with `check_violation`.

Migration **010** extends the CHECK to include `'rejected'`; registered in `run_migrations` and both `test_pool` helpers. The pre-existing `test_reject_invitation_changes_status` now passes (full `cowiki-db` suite green).

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)