### PR TITLE
refactor(server): request tracing + stop swallowing index errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3251,6 +3251,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -12,7 +12,7 @@ axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tower-http = { version = "0.6", features = ["cors", "fs"] }
+tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dotenvy = "0.15"

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -7,6 +7,8 @@ use cowiki_core::compiler::Compiler;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
+use tower_http::trace::{DefaultOnRequest, DefaultOnResponse, TraceLayer};
+use tracing::Level;
 
 mod config;
 mod error;
@@ -301,6 +303,11 @@ async fn main() {
         .route(
             "/api/notifications/{id}/read",
             post(routes::notifications::mark_read),
+        )
+        .layer(
+            TraceLayer::new_for_http()
+                .on_request(DefaultOnRequest::new().level(Level::INFO))
+                .on_response(DefaultOnResponse::new().level(Level::INFO)),
         )
         .layer(CorsLayer::permissive())
         .with_state(state);

--- a/crates/server/src/routes/compile.rs
+++ b/crates/server/src/routes/compile.rs
@@ -132,23 +132,34 @@ async fn do_compile(
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
         let hash = format!("{:x}", Sha256::digest(full_content.as_bytes()));
-        if let Ok(emb) = state
+        match state
             .compiler
             .embed(&format!("{}\n{}", page.title, page.summary))
             .await
         {
-            cowiki_db::pages::upsert(
-                &state.db,
-                &page.slug,
-                &page.title,
-                &page.summary,
-                branch,
-                &hash,
-                Some(&emb),
-                default_user.id,
-            )
-            .await
-            .ok();
+            Ok(emb) => {
+                if let Err(e) = cowiki_db::pages::upsert(
+                    &state.db,
+                    &page.slug,
+                    &page.title,
+                    &page.summary,
+                    branch,
+                    &hash,
+                    Some(&emb),
+                    default_user.id,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        "failed to index compiled page '{}' for search: {e}",
+                        page.slug
+                    );
+                }
+            }
+            Err(e) => tracing::warn!(
+                "failed to embed compiled page '{}' (not indexed for search): {e}",
+                page.slug
+            ),
         }
 
         // Record source→page mapping from the compiler's output
@@ -185,14 +196,18 @@ fn load_state(repo: &cowiki_core::git::WikiRepo, branch: &str) -> CompileState {
 }
 
 fn save_state(repo: &cowiki_core::git::WikiRepo, branch: &str, compile_state: &CompileState) {
-    if let Ok(json) = serde_json::to_string_pretty(compile_state) {
-        repo.write_file(
-            branch,
-            ".cowiki/state.json",
-            json.as_bytes(),
-            "update compile state",
-            "cowiki",
-        )
-        .ok();
+    match serde_json::to_string_pretty(compile_state) {
+        Ok(json) => {
+            if let Err(e) = repo.write_file(
+                branch,
+                ".cowiki/state.json",
+                json.as_bytes(),
+                "update compile state",
+                "cowiki",
+            ) {
+                tracing::warn!("failed to persist compile state on branch '{branch}': {e}");
+            }
+        }
+        Err(e) => tracing::warn!("failed to serialize compile state: {e}"),
     }
 }

--- a/crates/server/src/routes/review.rs
+++ b/crates/server/src/routes/review.rs
@@ -124,7 +124,7 @@ pub async fn review_action(
                 {
                     let text = String::from_utf8_lossy(&content);
                     let hash = format!("{:x}", Sha256::digest(text.as_bytes()));
-                    cowiki_db::pages::upsert(
+                    if let Err(e) = cowiki_db::pages::upsert(
                         &state.db,
                         slug,
                         slug,
@@ -135,7 +135,9 @@ pub async fn review_action(
                         guard.user.id,
                     )
                     .await
-                    .ok();
+                    {
+                        tracing::warn!("failed to index merged page '{slug}' for search: {e}");
+                    }
                 }
             }
 


### PR DESCRIPTION
First slice of the error-visibility Epic (observability — low-risk/high-value, per the review feedback to do this before structured `{code}` errors).

- **`TraceLayer`** (method/path/status/latency at INFO) — the server previously logged almost nothing per request, so stuck/pending requests were undiagnosable.
- **Stop swallowing search-index errors** — `compile.rs` (embed + page `upsert`, `save_state`) and `review.rs` (merge-time `upsert`) used `.ok()`, so a page reported "compiled"/"merged" could silently never be indexed for search, and a dropped compile-state caused redundant recompiles. Now each `Err` is `tracing::warn!`-logged with context.

Behavior-preserving (no control-flow change beyond logging). `cargo build` green.

Refs the error-visibility Epic in `docs/refactor-roadmap.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)