### PR TITLE
fix(db): scope pages by workspace + vector index (#26)

### DIFF
--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -76,5 +76,10 @@ pub async fn run_migrations(pool: &PgPool, embedding_dim: u32) -> sqlx::Result<(
         tracing::error!("DB error: {e}");
         e
     })?;
+    let sql13 = include_str!("migrations/011_pages_workspace_scope.sql");
+    sqlx::raw_sql(sql13).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     Ok(())
 }

--- a/crates/db/src/migrations/011_pages_workspace_scope.sql
+++ b/crates/db/src/migrations/011_pages_workspace_scope.sql
@@ -1,0 +1,19 @@
+-- Scope pages by workspace. Previously the unique key was (slug, branch), so two
+-- workspaces that shared a slug+branch (e.g. both have "main"/"retry-patterns")
+-- overwrote each other via ON CONFLICT, and semantic search/dedup (find_similar)
+-- leaked pages across all workspaces on that branch. workspace_slug already exists
+-- (005_fts) but was never written.
+ALTER TABLE pages DROP CONSTRAINT IF EXISTS pages_slug_branch_key;
+CREATE UNIQUE INDEX IF NOT EXISTS pages_slug_branch_workspace_key
+    ON pages (slug, branch, workspace_slug);
+
+-- ANN index for vector similarity. find_similar's inner query is shaped
+-- `ORDER BY embedding <=> $1 LIMIT n` (the form pgvector can serve from HNSW);
+-- the threshold/workspace filters are applied around it. Previously every
+-- search/submit was an exact full scan.
+CREATE INDEX IF NOT EXISTS pages_embedding_hnsw
+    ON pages USING hnsw (embedding vector_cosine_ops);
+
+-- NOTE: existing rows keep workspace_slug = '' (legacy/unscoped); they are not
+-- backfilled here because branch alone does not identify a workspace. They simply
+-- won't match workspace-scoped reads. Search route scoping is tracked in #44.

--- a/crates/db/src/pages.rs
+++ b/crates/db/src/pages.rs
@@ -15,6 +15,7 @@ pub struct PageMeta {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn upsert(
     pool: &PgPool,
     slug: &str,
@@ -24,12 +25,13 @@ pub async fn upsert(
     content_hash: &str,
     embedding: Option<&[f32]>,
     user_id: Uuid,
+    workspace_slug: &str,
 ) -> sqlx::Result<PageMeta> {
     let emb = embedding.map(|e| Vector::from(e.to_vec()));
     sqlx::query_as::<_, PageMeta>(
-        r#"INSERT INTO pages (slug, title, summary, branch, content_hash, embedding, created_by)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
-        ON CONFLICT (slug, branch) DO UPDATE SET
+        r#"INSERT INTO pages (slug, title, summary, branch, content_hash, embedding, created_by, workspace_slug)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        ON CONFLICT (slug, branch, workspace_slug) DO UPDATE SET
             title = EXCLUDED.title,
             summary = EXCLUDED.summary,
             content_hash = EXCLUDED.content_hash,
@@ -44,6 +46,7 @@ pub async fn upsert(
     .bind(content_hash)
     .bind(emb)
     .bind(user_id)
+    .bind(workspace_slug)
     .fetch_one(pool)
     .await
     .map_err(|e| {
@@ -62,16 +65,23 @@ pub async fn list_by_branch(pool: &PgPool, branch: &str) -> sqlx::Result<Vec<Pag
     .map_err(|e| { tracing::error!("DB list pages by branch {branch}: {e}"); e })
 }
 
+/// Find pages similar to `embedding` on `branch`. Pass `workspace_slug = Some(ws)`
+/// to scope the search to one workspace (dedup/submit); `None` searches across all
+/// workspaces (the global search route — see #44 for scoping that).
 pub async fn find_similar(
     pool: &PgPool,
     embedding: &[f32],
     branch: &str,
     limit: i64,
     threshold: f64,
+    workspace_slug: Option<&str>,
 ) -> sqlx::Result<Vec<(PageMeta, f64)>> {
     let emb = Vector::from(embedding.to_vec());
 
-    // Use a subquery to compute similarity then filter
+    // The inner query is the one shape pgvector can serve from the HNSW index
+    // (`ORDER BY embedding <=> $1 LIMIT n`); the similarity threshold is applied
+    // outside it. Filters (branch/workspace) post-filter the index scan, so the
+    // inner LIMIT over-fetches a bit to compensate.
     let rows = sqlx::query_as::<
         _,
         (
@@ -86,11 +96,17 @@ pub async fn find_similar(
             f64,
         ),
     >(
-        r#"SELECT id, slug, title, summary, branch, content_hash, created_at, updated_at,
-            1 - (embedding <=> $1::vector) as similarity
-        FROM pages
-        WHERE branch = $2 AND embedding IS NOT NULL
-          AND 1 - (embedding <=> $1::vector) > $3
+        r#"SELECT id, slug, title, summary, branch, content_hash, created_at, updated_at, similarity
+        FROM (
+            SELECT id, slug, title, summary, branch, content_hash, created_at, updated_at,
+                1 - (embedding <=> $1::vector) AS similarity
+            FROM pages
+            WHERE branch = $2 AND embedding IS NOT NULL
+              AND ($5::text IS NULL OR workspace_slug = $5)
+            ORDER BY embedding <=> $1::vector
+            LIMIT GREATEST($4 * 4, 50)
+        ) candidates
+        WHERE similarity > $3
         ORDER BY similarity DESC
         LIMIT $4"#,
     )
@@ -98,6 +114,7 @@ pub async fn find_similar(
     .bind(branch)
     .bind(threshold)
     .bind(limit)
+    .bind(workspace_slug)
     .fetch_all(pool)
     .await
     .map_err(|e| {
@@ -123,4 +140,105 @@ pub async fn find_similar(
             )
         })
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_pool() -> Option<PgPool> {
+        let url = std::env::var("TEST_DATABASE_URL").ok()?;
+        let pool = PgPool::connect(&url).await.ok()?;
+        let sql1 = include_str!("migrations/001_init.sql").replace("__EMBEDDING_DIM__", "768");
+        let _ = sqlx::raw_sql(&sql1).execute(&pool).await;
+        for m in [
+            include_str!("migrations/002_workspaces.sql"),
+            include_str!("migrations/003_workspace_visibility.sql"),
+            include_str!("migrations/004_role_update.sql"),
+            include_str!("migrations/005_fts.sql"),
+            include_str!("migrations/006_api_keys.sql"),
+            include_str!("migrations/007_team_permissions.sql"),
+            include_str!("migrations/008_submission_workspace.sql"),
+            include_str!("migrations/009_role_management.sql"),
+            include_str!("migrations/009_review_comments.sql"),
+            include_str!("migrations/010_notifications.sql"),
+            include_str!("migrations/010_invitation_reject_status.sql"),
+            include_str!("migrations/011_pages_workspace_scope.sql"),
+        ] {
+            let _ = sqlx::raw_sql(m).execute(&pool).await;
+        }
+        Some(pool)
+    }
+
+    async fn make_user(pool: &PgPool) -> Uuid {
+        let id = Uuid::new_v4();
+        let _ = sqlx::query(
+            "INSERT INTO users (id, name, email, api_key) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
+        )
+        .bind(id)
+        .bind(format!("u-{id}"))
+        .bind(format!("{id}@test.com"))
+        .bind(format!("key-{id}"))
+        .execute(pool)
+        .await;
+        id
+    }
+
+    /// Two workspaces sharing (slug, branch) must NOT overwrite each other, and a
+    /// workspace-scoped find_similar must not leak the other workspace's page.
+    #[tokio::test]
+    async fn pages_are_scoped_per_workspace() {
+        let Some(pool) = test_pool().await else {
+            return;
+        };
+        let u = make_user(&pool).await;
+        let emb: Vec<f32> = vec![0.1; 768];
+
+        let a = upsert(
+            &pool,
+            "retry",
+            "A title",
+            "",
+            "main",
+            "h1",
+            Some(&emb),
+            u,
+            "team-a",
+        )
+        .await
+        .unwrap();
+        let b = upsert(
+            &pool,
+            "retry",
+            "B title",
+            "",
+            "main",
+            "h2",
+            Some(&emb),
+            u,
+            "team-b",
+        )
+        .await
+        .unwrap();
+        assert_ne!(
+            a.id, b.id,
+            "same (slug, branch) in two workspaces overwrote each other"
+        );
+
+        let only_a = find_similar(&pool, &emb, "main", 10, 0.5, Some("team-a"))
+            .await
+            .unwrap();
+        assert!(only_a
+            .iter()
+            .any(|(p, _)| p.slug == "retry" && p.title == "A title"));
+        assert!(
+            only_a.iter().all(|(p, _)| p.title != "B title"),
+            "workspace-scoped search leaked another workspace's page"
+        );
+
+        let only_b = find_similar(&pool, &emb, "main", 10, 0.5, Some("team-b"))
+            .await
+            .unwrap();
+        assert!(only_b.iter().any(|(p, _)| p.title == "B title"));
+    }
 }

--- a/crates/db/src/submissions.rs
+++ b/crates/db/src/submissions.rs
@@ -127,6 +127,7 @@ mod tests {
             include_str!("migrations/009_review_comments.sql"),
             include_str!("migrations/010_notifications.sql"),
             include_str!("migrations/010_invitation_reject_status.sql"),
+            include_str!("migrations/011_pages_workspace_scope.sql"),
         ] {
             let _ = sqlx::raw_sql(m).execute(&pool).await;
         }

--- a/crates/db/src/workspaces.rs
+++ b/crates/db/src/workspaces.rs
@@ -780,6 +780,9 @@ mod tests {
         let _ = sqlx::raw_sql(include_str!("migrations/010_notifications.sql"))
             .execute(&pool)
             .await;
+        let _ = sqlx::raw_sql(include_str!("migrations/011_pages_workspace_scope.sql"))
+            .execute(&pool)
+            .await;
         Some(pool)
     }
 

--- a/crates/server/src/routes/compile.rs
+++ b/crates/server/src/routes/compile.rs
@@ -44,12 +44,13 @@ pub async fn compile_ws(
         .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     super::pages::ensure_user_branch_if_needed(&repo, &input.branch)?;
-    do_compile(&state, &repo, &input.branch).await
+    do_compile(&state, &repo, &ws_slug, &input.branch).await
 }
 
 async fn do_compile(
     state: &AppState,
     repo: &cowiki_core::git::WikiRepo,
+    ws_slug: &str,
     branch: &str,
 ) -> Result<Json<CompileResponse>> {
     // 1. Load compile state
@@ -147,6 +148,7 @@ async fn do_compile(
                     &hash,
                     Some(&emb),
                     default_user.id,
+                    ws_slug,
                 )
                 .await
                 {

--- a/crates/server/src/routes/review.rs
+++ b/crates/server/src/routes/review.rs
@@ -163,6 +163,7 @@ pub async fn review_action(
                             &hash,
                             None,
                             guard.user.id,
+                            &ws_slug,
                         )
                         .await
                         {

--- a/crates/server/src/routes/search.rs
+++ b/crates/server/src/routes/search.rs
@@ -34,8 +34,11 @@ pub async fn search(
         .await
         .map_err(AppError::Internal)?;
 
+    // TODO(#44): this global search route is not workspace-scoped. Passing None
+    // searches across all workspaces on the branch; scope it once search becomes
+    // workspace/branch-aware.
     let results =
-        cowiki_db::pages::find_similar(&state.db, &embedding, &branch, limit, 0.3).await?;
+        cowiki_db::pages::find_similar(&state.db, &embedding, &branch, limit, 0.3, None).await?;
 
     Ok(Json(
         results

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -86,7 +86,9 @@ pub async fn submit(
     // Check for duplicates
     let mut duplicates = Vec::new();
     for (slug, emb) in &embeddings {
-        if let Ok(similar) = cowiki_db::pages::find_similar(&state.db, emb, "main", 3, 0.85).await {
+        if let Ok(similar) =
+            cowiki_db::pages::find_similar(&state.db, emb, "main", 3, 0.85, Some(&ws_slug)).await
+        {
             for (page, score) in similar {
                 if page.slug != *slug {
                     duplicates.push(cowiki_core::models::DuplicateWarning {


### PR DESCRIPTION
`pages` had a `(slug, branch)` unique key and `upsert` never wrote `workspace_slug` (always `''`), so:
- two workspaces sharing a slug+branch (e.g. both `main`/`retry-patterns`) **overwrote each other** via `ON CONFLICT`;
- `find_similar` (dedup in submit, search) filtered only on `branch` → **leaked pages across tenants**.

**Changes**
- Migration **011**: drop `(slug, branch)` unique → `(slug, branch, workspace_slug)`; add **HNSW** index on `embedding` (`find_similar` was an exact full scan).
- `pages::upsert` writes `workspace_slug` + `ON CONFLICT (slug, branch, workspace_slug)`.
- `find_similar` gains an optional `workspace_slug` filter, threaded through `compile`/`review`/`submit` (all workspace-scoped).
- Global `/api/search` passes `None` (it isn't workspace-scoped — deferred to **#44**, with a TODO).
- Existing `''` rows stay legacy/unscoped (branch alone doesn't identify a workspace — no risky backfill).

New `pages_are_scoped_per_workspace` test (no cross-workspace overwrite + scoped search) passes; full `cowiki-db` suite green.

**Merge notes:** adds migration `011` (PR #61 adds `010` independently — order them 010 then 011, trivial `run_migrations`/`test_pool` conflict). May also conflict with #64 on the `compile.rs`/`review.rs` upsert calls — keep both (logging + the `ws_slug` arg).

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)