### PR TITLE
refactor(web): extract shared timeAgo helper

### DIFF
--- a/web/src/components/review/DiffView.tsx
+++ b/web/src/components/review/DiffView.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { MessageSquare, Check, ChevronDown, ChevronRight, Send, X, FileText } from 'lucide-react';
 import type { FileDiff, DiffHunk, DiffLine, ReviewComment } from '../../api';
 import { C, fonts } from '@/lib/design';
+import { timeAgo } from '../../lib/time';
 
 const mono = fonts.mono;
 
@@ -370,18 +371,6 @@ function FileDiffCard({
       )}
     </div>
   );
-}
-
-function timeAgo(iso: string): string {
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return '';
-  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
-  if (secs < 60) return `${secs}s ago`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
 }
 
 /* ── Exports ── */

--- a/web/src/components/review/ReviewDetail.tsx
+++ b/web/src/components/review/ReviewDetail.tsx
@@ -6,18 +6,7 @@ import {
 } from '../../api';
 import { DiffView } from './DiffView';
 import { C, fonts } from '@/lib/design';
-
-function timeAgo(iso: string): string {
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return '';
-  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
-  if (secs < 60) return `${secs}s ago`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
+import { timeAgo } from '../../lib/time';
 
 const statusBadge: Record<string, { bg: string; fg: string; label: string }> = {
   pending: { bg: C.amberSoft, fg: C.amber, label: 'Review needed' },

--- a/web/src/components/review/ReviewList.tsx
+++ b/web/src/components/review/ReviewList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { GitBranch, MessageSquare } from 'lucide-react';
 import { listReviews, type Submission } from '../../api';
 import { C } from '@/lib/design';
+import { timeAgo } from '../../lib/time';
 
 type Filter = 'open' | 'merged' | 'all';
 
@@ -11,18 +12,6 @@ const statusBadge: Record<string, { bg: string; fg: string; label: string }> = {
   rejected: { bg: C.accentSoft, fg: C.accent, label: 'Changes req.' },
   merged: { bg: C.blueSoft, fg: C.blue, label: 'Merged' },
 };
-
-function timeAgo(iso: string): string {
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return '';
-  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
-  if (secs < 60) return `${secs}s`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h`;
-  return `${Math.floor(hrs / 24)}d`;
-}
 
 export function ReviewList({
   workspaceSlug,
@@ -137,7 +126,7 @@ export function ReviewList({
                     </span>
                   </div>
                   <div style={{ fontSize: 12, color: C.muted, marginTop: 2 }}>
-                    {s.source_branch} · {s.page_slugs.length} file{s.page_slugs.length === 1 ? '' : 's'} · {timeAgo(s.created_at)} ago
+                    {s.source_branch} · {s.page_slugs.length} file{s.page_slugs.length === 1 ? '' : 's'} · {timeAgo(s.created_at)}
                   </div>
                 </div>
 

--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -1,0 +1,12 @@
+/** Compact relative time, e.g. "5s ago", "2h ago", "3d ago". Empty for invalid input. */
+export function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}


### PR DESCRIPTION
`timeAgo` was copy-pasted in `DiffView`, `ReviewDetail`, and `ReviewList`, and had drifted: `ReviewList` returned bare values (`2h`) and appended `' ago'` at the call site, while the others embedded `' ago'`. Extract one `lib/time.ts` (canonical `"… ago"` form) and use it in all three; fix the `ReviewList` call site to drop the now-redundant literal.

First slice of the frontend-DRY Epic (the larger `request<T>()` extraction across ~24 `api.ts` call sites, and `statusBadge` → design tokens, are tracked separately — `statusBadge` belongs with the design-tokens Epic). `npm run build` (tsc + vite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)