### PR TITLE
docs: draft proposals for deferred refactor Epics (C/D/E/F2/G)

### DIFF
--- a/docs/refactor-drafts/C-mainlayout-decomposition.md
+++ b/docs/refactor-drafts/C-mainlayout-decomposition.md
@@ -1,0 +1,48 @@
+# Draft — Epic C: Decompose `MainLayout`
+
+> Status: **draft for review** (codex). Maintainability refactor only — **no visual/interaction change**.
+
+## Problem
+`web/src/pages/MainLayout.tsx` (~1176 lines, ~35 `useState`) owns workspace/page/source/review/member state, all data fetching, modals, and manual `ActiveView` routing that can drift from the URL. It's the host of most frontend stale-closure, swallowed-error, and perf nits found in review.
+
+## Target shape
+Extract data + mutations into hooks; `MainLayout` becomes a thin shell that composes them and renders. **No markup/style changes** in this Epic.
+
+```
+web/src/
+  hooks/
+    useAsyncResource.ts   // shared fetch/loading/error/cancel primitive (do FIRST)
+    useWorkspaces.ts      // list + active workspace + create/rename/delete/join
+    usePages.ts           // per-workspace page tree + selection + write/folder
+    useSources.ts         // per-workspace sources + ingest
+    useReviews.ts         // pending count + list (wraps listReviews)
+    useWorkspaceDialogs.ts// modal open/close state (create/rename/ingest/...)
+  pages/MainLayout.tsx     // compose hooks + render; ActiveView routing stays here
+```
+
+### `useAsyncResource` (the shared primitive — replaces ~24 ad-hoc fetch blocks)
+```ts
+type AsyncResource<T> = { data: T | null; loading: boolean; error: string | null; reload: () => void };
+
+function useAsyncResource<T>(
+  fetcher: () => Promise<T>,
+  deps: React.DependencyList,
+): AsyncResource<T> { /* setX(null) -> fetch -> cancelled flag -> catch setError, once */ }
+```
+Every `useXxx` hook builds on this, so loading/error/cancel semantics are uniform (and consume Epic A2's `{code}` error envelope once that lands).
+
+## Sequencing (each step ships green, no behavior change)
+1. `useAsyncResource` + migrate the simplest reads (reviews, sources) to it.
+2. `useWorkspaces` (the spine) — move workspace list + active-workspace state.
+3. `usePages` / `useSources` / `useReviews`.
+4. `useWorkspaceDialogs` (mechanical state move).
+5. Fix the review-surfaced nits as they pass through: `loadWorkspaces` stale-closure deps, non-memoized search IIFE (`useMemo([searchQuery, spacePages, workspaces])`), user-branch-first selection 404 waterfall.
+
+## Open decisions for review
+1. **Routing ownership.** Keep manual `ActiveView` in `MainLayout`, or move to real nested routes (`react-router`)? The review flagged `ActiveView` can drift from the URL. Proposal: keep `ActiveView` this Epic (no behavior change), file a follow-up for real routes.
+2. **Hook granularity.** Is 6 hooks the right cut, or merge `usePages`+`useSources` into one `useWorkspaceContent`? (They share the active-workspace + branch.)
+3. **Where does `activeWorkspace` live** — in `useWorkspaces` (and others receive it as an arg), or a small context? Proposal: `useWorkspaces` returns it; pass down explicitly (no context yet).
+
+## Notes
+- Pairs with Epic B (`request<T>()`): `useAsyncResource` and `request<T>()` are complementary — `request<T>` is the transport, `useAsyncResource` the React state wrapper.
+- Will conflict heavily with anything else editing `MainLayout`; should land as its own focused stack after the in-flight PRs settle.

--- a/docs/refactor-drafts/D-submission-status-enum.md
+++ b/docs/refactor-drafts/D-submission-status-enum.md
@@ -1,0 +1,44 @@
+# Draft — Epic D: Submission status enum + status presentation
+
+> Status: **draft for review** (codex). One Epic, layered: backend semantic layer, then frontend presentation layer.
+
+## Problem
+Submission status strings (`pending` / `approved` / `rejected` / `merged`, and the planned `changes_requested`) are scattered as raw literals across DB queries, `review.rs`, and the frontend, with no single source of truth. The frontend `statusBadge` map is duplicated in `ReviewList.tsx` and `ReviewDetail.tsx` and has already drifted (`'Changes req.'` vs `'Changes requested'`).
+
+Current literal sites:
+- backend: `review.rs:93/96/145/148` (`"approved"`/`"merged"`/`"rejected"`), `submissions.rs list_pending_for_workspace` `IN ('pending','approved','rejected','merged')`.
+- frontend: `ReviewList.tsx` (`statusBadge`, filter logic `s.status === '...'`), `ReviewDetail.tsx` (`statusBadge`, `decided = status !== 'pending'`).
+
+## D1 — Backend semantic layer
+Add a `SubmissionStatus` enum (in `crates/db/src/submissions.rs` or a small `status.rs`):
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubmissionStatus { Pending, Approved, Rejected, Merged /*, ChangesRequested */ }
+
+impl SubmissionStatus {
+    pub fn as_str(&self) -> &'static str { /* "pending" | ... */ }
+    pub const ACTIVE: &[SubmissionStatus] = &[Self::Pending, Self::Approved, Self::Rejected, Self::Merged];
+}
+impl std::str::FromStr for SubmissionStatus { /* ... */ }
+```
+- `update_status` takes `SubmissionStatus` instead of `&str`; `review.rs` passes the enum (no more `"approved"` literals).
+- `list_pending_for_workspace`'s `IN (...)` is built from `SubmissionStatus::ACTIVE` (or a const string), so adding a variant updates the query.
+- Keep `Submission.status: String` at the row level (DB column is text) but expose a typed accessor; OR change the field to the enum with `sqlx` `#[sqlx(try_from = "String")]`. **(decision below)**
+
+## D2 — Frontend presentation layer
+One module `web/src/lib/review.ts`:
+```ts
+export type ReviewStatus = 'pending' | 'approved' | 'rejected' | 'merged';
+export const statusBadge: Record<ReviewStatus, { token: keyof Tokens; label: string }> = { ... };
+```
+- Fold the badge **colors** into `web/src/lib/design.ts` tokens (no local `C.amberSoft` literals re-mapped per component) — this is also Epic #10's design-token consolidation.
+- `ReviewList` + `ReviewDetail` import the single `statusBadge`; resolve the label drift to **`'Changes requested'`** (proposed).
+
+## Open decisions for review
+1. **`Submission.status` typing.** Keep `String` + helper, or make it the enum end-to-end (stricter, but `sqlx` mapping + any unknown DB value becomes a hard error)? Proposal: enum end-to-end with an explicit `Unknown` fallback variant so a bad row doesn't 500.
+2. **Include `changes_requested` now** (it's in the review-workflow design #10/#19) or only the 4 live ones? Proposal: define the variant now, don't wire the flow (that's #10).
+3. **Canonical labels/colors** — confirm `pending → "Review needed"`, `rejected → "Changes requested"`, etc., and which design token each maps to.
+
+## Notes
+- Touches `review.rs` (conflicts with #64/#66 — keep all) and the two review components (conflicts with #67's `timeAgo` extraction — trivial).

--- a/docs/refactor-drafts/E-frontmatter-and-pages-split.md
+++ b/docs/refactor-drafts/E-frontmatter-and-pages-split.md
@@ -1,0 +1,48 @@
+# Draft — Epic E: Frontmatter model + split `pages.rs`
+
+> Status: **draft for review** (codex). Natural follow-up of #53. **Must add tests** (title fallback / canonical title) or it regresses. Has a real product decision (title fallback).
+
+## Problem
+- `crates/server/src/routes/pages.rs` mixes HTTP handlers, frontmatter parsing, title validation, and wiki-tree building.
+- Frontmatter is **hand-assembled** in two places with `format!("---\ntitle: \"{}\"...")` (e.g. `compile.rs:112`) and on the frontend, so a missing/empty title can produce a page with no title. Review also found `compiler.rs parse_compiled_page` strips a symbolic-only title to `""` → slug `wiki/.md`, so all such pages collide/overwrite.
+- `list_pages_from_repo` reads each file in a loop and `build_level` re-scans items per directory per level (O(N·depth)).
+
+## Target shape
+```
+crates/server/src/routes/
+  pages.rs        // HTTP layer only (handlers)
+crates/core/src/  (or a wiki module)
+  frontmatter.rs  // parse + build (one source of truth)
+  wiki_tree.rs    // build the page tree from a flat file list
+```
+
+### `frontmatter.rs` — parse + build together (kills "no-title page")
+```rust
+pub struct Frontmatter { pub title: String, pub summary: String, pub kind: String, pub sources: Vec<String> }
+
+pub fn parse(markdown: &str) -> (Frontmatter, String /* body */);
+
+/// Single canonical builder used by compile + any write path.
+pub fn build_page_markdown(fm: &Frontmatter, body: &str) -> String;
+
+/// Canonical slug from a title, with a deterministic fallback when empty.
+pub fn slug_for_title(title: &str) -> String;
+```
+Frontend gets the mirror: `web/src/lib/markdown.ts` `makePageMarkdown({ title, summary, kind })`, so both sides build frontmatter identically.
+
+## Open decisions for review (the important ones)
+1. **Title fallback.** When a compiled/written page has an empty or symbol-only title:
+   - **(a, proposed)** fall back to a deterministic slug `page-<hash8(content)>` and set the title to e.g. `"Untitled (page-ab12cd34)"`;
+   - (b) reject the page (compile returns a structured per-page error — pairs with #15/Epic A2);
+   - (c) derive a title from the first heading/sentence of the body.
+   Proposal: **(a)** for safety (never collide/overwrite) + surface a warning; revisit with (c) later.
+2. **Where do the modules live** — `crates/core` (reusable by server + future CLI) or a server-local `wiki/` module? Proposal: `crates/core` (it's domain logic, and #18 wants core/service/storage layering).
+3. **Canonical title rules** — is a CJK/emoji title valid (review said yes)? Confirm the normalization (don't strip non-ASCII; only fall back when the result is truly empty).
+
+## Tests to add (required)
+- `parse` round-trips `build_page_markdown`.
+- `slug_for_title`: normal, CJK, symbol-only → fallback, empty → fallback (no two distinct inputs collide).
+- `wiki_tree` builds the expected nesting from a flat list.
+
+## Notes
+- Touches `compile.rs` (conflicts with #64/#66) and `compiler.rs`.

--- a/docs/refactor-drafts/F2-git-module-split.md
+++ b/docs/refactor-drafts/F2-git-module-split.md
@@ -1,0 +1,33 @@
+# Draft — Epic F2: Split `git.rs` (after F1 `spawn_blocking`)
+
+> Status: **draft for review** (codex). Pairs with the #56 deadlock fix (#62) and F1 (`spawn_blocking`). Mostly mechanical, but includes one real correctness fix (the shared-index race).
+
+## Problem
+`crates/core/src/git.rs` (~470 lines) is one file doing: repo manager, per-branch locks, read, write, diff, merge. Review also found a **correctness bug**: `write_file` for nested paths (`wiki/foo.md`, the common case) opens `repo.index()` — a single shared on-disk index — and `read_tree`+`add_frombuffer`+`write_tree`. `branch_lock` only serializes per branch, so concurrent writes to `main` vs `user/<id>` race on the one index and can leave it inconsistent with HEAD.
+
+## Target shape
+```
+crates/core/src/git/
+  mod.rs          // re-exports; WikiRepo struct + branch_lock
+  manager.rs      // WikiRepoManager
+  read.rs         // read_file, list_files, list_files_recursive, walk_tree
+  write.rs        // write_file / write_file_locked / merge_to_main / ensure_branch
+  diff.rs         // diff_files, compute_line_diff, FileDiff/DiffHunk/DiffLine
+```
+Public API unchanged (just moved); `WikiRepo` methods split across `impl` blocks in the submodules.
+
+### Correctness fix folded in: nested-path write without the shared index
+Replace the `repo.index()` path in `write_file_locked` with an in-memory recursive `TreeBuilder` (or a detached `git2::Index::new()`), so two branches never contend on the one on-disk index:
+```rust
+// build wiki/foo/bar.md purely in memory from parent_commit.tree()
+fn insert_blob_into_tree(repo, base_tree, path_parts, blob_oid) -> Result<Oid> { /* recurse with TreeBuilder */ }
+```
+
+## Sequencing
+1. **F1 first (separate PR):** wrap the synchronous `git2`/`fs`/lock ops in `spawn_blocking` so they don't block tokio workers. Behavior-preserving — do it in isolation so any regression is easy to bisect. (Coordinate with #62, which already touched the lock in `merge_to_main`.)
+2. **F2 (this draft):** split modules + the in-memory nested-tree write fix. Add a concurrency test: parallel writes to `main` and `user/x` of nested paths, assert both commits are consistent with HEAD.
+
+## Open decisions for review
+1. **`spawn_blocking` boundary.** Wrap at the `WikiRepo` method level (each public method spawns), or have callers spawn? Proposal: method-level (callers stay simple); `WikiRepo` methods become `async` or get `_blocking` twins.
+2. **In-memory tree vs detached index** for nested writes — `TreeBuilder` recursion (no temp files, more code) vs `git2::Index::new()` (simpler, in-memory). Proposal: detached `Index::new()` unless it forces a working-dir checkout.
+3. Relates to #16 (git storage strategy) and #18 (core/service/storage layering) — keep `git/` as the storage layer boundary.

--- a/docs/refactor-drafts/G-test-organization.md
+++ b/docs/refactor-drafts/G-test-organization.md
@@ -1,0 +1,29 @@
+# Draft — Epic G: Test organization
+
+> Status: **draft for review** (codex). Lowest risk; relates to #17 (test infrastructure).
+
+## Problem
+`crates/db/src/workspaces.rs` is ~1287 lines, most of it inline `#[cfg(test)]` DB-integration tests (role/member/invitation/delete) sharing a hand-rolled `test_pool()`. The same `test_pool` boilerplate (and its migration list) is copy-pasted into `submissions.rs`, `pages.rs` (added by #66) — every new migration must be registered in all of them.
+
+## Target shape
+1. **Move DB-integration tests out of `src/`** into `crates/db/tests/` (or `crates/server/tests/`, where `permission_api_tests.rs` already lives), grouped by area:
+   ```
+   crates/db/tests/
+     common/mod.rs        // ONE shared test_pool() + seed helpers (single migration list)
+     workspaces_members.rs
+     workspaces_invitations.rs
+     workspaces_crud.rs
+     submissions.rs
+     pages.rs
+   ```
+   Keep pure unit tests (e.g. `Role` parsing) inline in `src/`.
+2. **Single migration list.** `common::test_pool()` is the only place migrations are registered for tests — delete the three duplicated lists. Better: have `test_pool` call the real `cowiki_db::run_migrations` so test schema == prod schema by construction (no separate list to drift).
+
+## Open decisions for review
+1. **`test_pool` per-test isolation.** Today tests share one DB and lean on unique UUIDs / cleanup. Options: (a) keep shared DB + unique data; (b) one schema/transaction-rollback per test; (c) `sqlx::test` macro (needs `DATABASE_URL` + offline data). Proposal: (b) wrap each test in a transaction that rolls back — cheap isolation, no cross-test bleed. (This also fixes the invitation-test flakiness seen earlier.)
+2. **Use `run_migrations` directly** in `test_pool` (eliminates the duplicated lists) — any reason not to? It already takes `embedding_dim`.
+3. Scope vs #17 (test infra epic): is this the right first slice, or fold into #17? Proposal: do the mechanical move now; defer the harness/E2E parts to #17.
+
+## Notes
+- Low conflict risk (test-only), but touches the shared `test_pool` that #61/#66 modified — coordinate the single-list consolidation with those landing.
+- The `create_test_users` seeding bug (missing `api_key`, reused unique names) was already fixed in an earlier PR; the consolidated `common` helper should carry that fix.

--- a/docs/refactor-drafts/README.md
+++ b/docs/refactor-drafts/README.md
@@ -1,0 +1,13 @@
+# Refactor Epic drafts (for review)
+
+First drafts of the **deferred structural Epics** from `docs/refactor-roadmap.md` — the ones that were *not* implemented in the overnight bugfix pass because they're large, decision-heavy, or risky to do unattended. Each draft gives a concrete target structure, real signatures/sketches, and an **Open decisions for review** section. They are design drafts, not PRs yet — once the direction + decisions are agreed, each becomes a focused implementation PR.
+
+| Draft | Epic | Key decision(s) to settle |
+|-------|------|---------------------------|
+| [C](./C-mainlayout-decomposition.md) | Decompose `MainLayout` into hooks | routing ownership; hook granularity |
+| [D](./D-submission-status-enum.md) | Submission status enum + status presentation | `status` typing (enum end-to-end?); labels/colors |
+| [E](./E-frontmatter-and-pages-split.md) | Frontmatter module + split `pages.rs` | **title fallback strategy**; module location |
+| [F2](./F2-git-module-split.md) | Split `git.rs` + nested-write race fix | `spawn_blocking` boundary; in-mem tree vs detached index |
+| [G](./G-test-organization.md) | Test reorganization | per-test isolation strategy |
+
+Not included (already P0/P1 issues, not refactors): #55 authz, #56/#57 crashes, #26 multi-tenancy, #58 SSRF, #59 credentials.


### PR DESCRIPTION
First drafts of the **deferred structural Epics** (the ones not done in the overnight bugfix pass because they're large / decision-heavy / risky unattended). Design drafts, not implementation PRs — each has a concrete target structure, real signatures/sketches, and an **Open decisions for review** section so @Deadpoolmine / codex can settle direction before I turn each into a focused PR.

- **C — Decompose `MainLayout`**: hooks (`useWorkspaces`/`usePages`/`useReviews`/…) on a shared `useAsyncResource`; no UI change. *Decide: routing ownership, hook granularity.*
- **D — Submission status enum**: backend `SubmissionStatus` + one frontend `statusBadge` (kills the `'Changes req.'`/`'Changes requested'` drift). *Decide: `status` typed end-to-end? labels/colors.*
- **E — Frontmatter module + split `pages.rs`**: `parse`+`build_page_markdown`+`slug_for_title`; mirror `makePageMarkdown` on the frontend. *Decide: the **title fallback** strategy (kills the `wiki/.md` collision); module location.* Requires tests.
- **F2 — Split `git.rs`** + fix the nested-write shared-index race; pairs with #62 / F1 `spawn_blocking`. *Decide: spawn_blocking boundary; in-mem tree vs detached index.*
- **G — Test reorg**: move DB-integration tests to `tests/`, one shared `test_pool` via `run_migrations`. *Decide: per-test isolation (tx-rollback?).*

Kept separate from bugs/security (those are issues #55–#59, #26). See `docs/refactor-roadmap.md` (PR #60) for the full map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)