### PR TITLE
refactor: SubmissionStatus enum + shared frontend statusBadge (Epic D)

### DIFF
--- a/crates/db/src/submissions.rs
+++ b/crates/db/src/submissions.rs
@@ -2,6 +2,56 @@ use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;
 
+/// Canonical submission lifecycle states — the single source of truth for the
+/// status strings used across the DB and handlers (the frontend mirrors these
+/// in `web/src/lib/review.ts`). Extending: add a variant + update `as_str`,
+/// `FromStr`, and `ACTIVE` (and the DB CHECK if one is added).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmissionStatus {
+    Pending,
+    Approved,
+    Rejected,
+    Merged,
+    /// Reserved for the changes-requested review flow (#10) — defined, not yet wired.
+    ChangesRequested,
+}
+
+impl SubmissionStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Approved => "approved",
+            Self::Rejected => "rejected",
+            Self::Merged => "merged",
+            Self::ChangesRequested => "changes_requested",
+        }
+    }
+
+    /// States shown in the review queue.
+    pub const ACTIVE: &'static [SubmissionStatus] =
+        &[Self::Pending, Self::Approved, Self::Rejected, Self::Merged];
+}
+
+impl std::str::FromStr for SubmissionStatus {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "approved" => Ok(Self::Approved),
+            "rejected" => Ok(Self::Rejected),
+            "merged" => Ok(Self::Merged),
+            "changes_requested" => Ok(Self::ChangesRequested),
+            other => Err(format!("invalid submission status: {other}")),
+        }
+    }
+}
+
+impl std::fmt::Display for SubmissionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct Submission {
     pub id: Uuid,
@@ -47,20 +97,27 @@ pub async fn list_pending_for_workspace(
     pool: &PgPool,
     workspace_slug: &str,
 ) -> sqlx::Result<Vec<Submission>> {
-    sqlx::query_as::<_, Submission>(
+    // IN-clause built from the canonical ACTIVE list (static, no injection risk).
+    let in_list = SubmissionStatus::ACTIVE
+        .iter()
+        .map(|s| format!("'{}'", s.as_str()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let query = format!(
         "SELECT s.*, u.name AS author_name, r.name AS reviewer_name FROM submissions s \
          JOIN users u ON u.id = s.user_id \
          LEFT JOIN users r ON r.id = s.reviewed_by \
-         WHERE s.status IN ('pending', 'approved', 'rejected', 'merged') AND s.workspace_slug = $1 \
-         ORDER BY s.created_at DESC",
-    )
-    .bind(workspace_slug)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| {
-        tracing::error!("DB list submissions for workspace failed: {e}");
-        e
-    })
+         WHERE s.status IN ({in_list}) AND s.workspace_slug = $1 \
+         ORDER BY s.created_at DESC"
+    );
+    sqlx::query_as::<_, Submission>(&query)
+        .bind(workspace_slug)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB list submissions for workspace failed: {e}");
+            e
+        })
 }
 
 pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Submission>> {
@@ -82,14 +139,14 @@ pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Submissi
 pub async fn update_status(
     pool: &PgPool,
     id: Uuid,
-    status: &str,
+    status: SubmissionStatus,
     reviewer_id: Uuid,
 ) -> sqlx::Result<Submission> {
     sqlx::query_as::<_, Submission>(
         "UPDATE submissions SET status = $2, reviewed_by = $3, reviewed_at = now() WHERE id = $1 RETURNING *",
     )
     .bind(id)
-    .bind(status)
+    .bind(status.as_str())
     .bind(reviewer_id)
     .fetch_one(pool)
     .await
@@ -215,13 +272,13 @@ mod tests {
         .await
         .unwrap();
 
-        update_status(&pool, approved.id, "approved", user)
+        update_status(&pool, approved.id, SubmissionStatus::Approved, user)
             .await
             .unwrap();
-        update_status(&pool, merged.id, "merged", user)
+        update_status(&pool, merged.id, SubmissionStatus::Merged, user)
             .await
             .unwrap();
-        update_status(&pool, rejected.id, "rejected", user)
+        update_status(&pool, rejected.id, SubmissionStatus::Rejected, user)
             .await
             .unwrap();
 

--- a/crates/server/src/routes/review.rs
+++ b/crates/server/src/routes/review.rs
@@ -87,12 +87,19 @@ pub async fn review_action(
     let guard = guard::require_membership(&state, &headers, &ws_slug).await?;
     guard::require(&guard, Permission::EditContent)?;
 
+    use cowiki_db::submissions::SubmissionStatus;
     match input.action.as_str() {
         "approve" => {
-            cowiki_db::submissions::update_status(&state.db, id, "approved", guard.user.id).await?;
+            cowiki_db::submissions::update_status(
+                &state.db,
+                id,
+                SubmissionStatus::Approved,
+                guard.user.id,
+            )
+            .await?;
         }
         "merge" => {
-            if submission.status != "approved" {
+            if submission.status != SubmissionStatus::Approved.as_str() {
                 return Err(AppError::BadRequest(
                     "submission must be approved before merge".into(),
                 ));
@@ -135,8 +142,13 @@ pub async fn review_action(
                 cowiki_core::git::MergeOutcome::Merged => {}
                 cowiki_core::git::MergeOutcome::Conflict(paths) => {
                     repo.cleanup_submission(&submission.id.to_string());
-                    cowiki_db::submissions::update_status(&state.db, id, "rejected", guard.user.id)
-                        .await?;
+                    cowiki_db::submissions::update_status(
+                        &state.db,
+                        id,
+                        SubmissionStatus::Rejected,
+                        guard.user.id,
+                    )
+                    .await?;
                     return Err(AppError::Conflict(format!(
                         "main has moved and this snapshot now conflicts ({}); submission closed — sync your branch and submit again",
                         paths.join(", ")
@@ -176,14 +188,26 @@ pub async fn review_action(
             repo.cleanup_submission(&submission.id.to_string());
             let _ = repo.rebase_onto_main(&submission.source_branch);
 
-            cowiki_db::submissions::update_status(&state.db, id, "merged", guard.user.id).await?;
+            cowiki_db::submissions::update_status(
+                &state.db,
+                id,
+                SubmissionStatus::Merged,
+                guard.user.id,
+            )
+            .await?;
         }
         "reject" => {
             // Drop the snapshot refs; the author keeps their changes on `source_branch`.
             if let Ok(repo) = state.repo_manager.get(&ws_slug) {
                 repo.cleanup_submission(&submission.id.to_string());
             }
-            cowiki_db::submissions::update_status(&state.db, id, "rejected", guard.user.id).await?;
+            cowiki_db::submissions::update_status(
+                &state.db,
+                id,
+                SubmissionStatus::Rejected,
+                guard.user.id,
+            )
+            .await?;
         }
         _ => return Err(AppError::BadRequest("invalid action".into())),
     }
@@ -218,7 +242,10 @@ pub async fn edit_review(
     let guard = guard::require_membership(&state, &headers, &ws_slug).await?;
     guard::require(&guard, Permission::EditContent)?;
 
-    if submission.status == "merged" || submission.status == "rejected" {
+    use cowiki_db::submissions::SubmissionStatus;
+    if submission.status == SubmissionStatus::Merged.as_str()
+        || submission.status == SubmissionStatus::Rejected.as_str()
+    {
         return Err(AppError::BadRequest(
             "submission is closed; cannot edit".into(),
         ));
@@ -240,8 +267,14 @@ pub async fn edit_review(
     .map_err(|e| AppError::Internal(e.to_string()))?;
 
     // A post-approval edit must be re-reviewed: reset to pending so it can't merge unseen.
-    if submission.status == "approved" {
-        cowiki_db::submissions::update_status(&state.db, id, "pending", guard.user.id).await?;
+    if submission.status == SubmissionStatus::Approved.as_str() {
+        cowiki_db::submissions::update_status(
+            &state.db,
+            id,
+            SubmissionStatus::Pending,
+            guard.user.id,
+        )
+        .await?;
     }
 
     Ok(Json(serde_json::json!({"ok": true})))

--- a/web/src/components/review/ReviewDetail.tsx
+++ b/web/src/components/review/ReviewDetail.tsx
@@ -8,13 +8,8 @@ import { DiffView } from './DiffView';
 import { C, fonts } from '@/lib/design';
 import { timeAgo } from '../../lib/time';
 import { AvatarBadge } from '@/components/ui/avatar-badge';
+import { statusBadge } from '@/lib/review';
 
-const statusBadge: Record<string, { bg: string; fg: string; label: string }> = {
-  pending: { bg: C.amberSoft, fg: C.amber, label: 'Review needed' },
-  approved: { bg: C.greenSoft, fg: C.green, label: 'Approved' },
-  rejected: { bg: C.accentSoft, fg: C.accent, label: 'Changes requested' },
-  merged: { bg: C.blueSoft, fg: C.blue, label: 'Merged' },
-};
 
 export function ReviewDetail({
   workspaceSlug,

--- a/web/src/components/review/ReviewList.tsx
+++ b/web/src/components/review/ReviewList.tsx
@@ -4,15 +4,9 @@ import { listReviews, type Submission } from '../../api';
 import { C } from '@/lib/design';
 import { timeAgo } from '../../lib/time';
 import { AvatarBadge } from '@/components/ui/avatar-badge';
+import { statusBadge } from '@/lib/review';
 
 type Filter = 'open' | 'merged' | 'all';
-
-const statusBadge: Record<string, { bg: string; fg: string; label: string }> = {
-  pending: { bg: C.amberSoft, fg: C.amber, label: 'Review needed' },
-  approved: { bg: C.greenSoft, fg: C.green, label: 'Approved' },
-  rejected: { bg: C.accentSoft, fg: C.accent, label: 'Changes req.' },
-  merged: { bg: C.blueSoft, fg: C.blue, label: 'Merged' },
-};
 
 export function ReviewList({
   workspaceSlug,

--- a/web/src/lib/review.ts
+++ b/web/src/lib/review.ts
@@ -1,0 +1,12 @@
+import { C } from './design';
+
+/**
+ * Single source of truth for review-status badge styling + labels.
+ * Mirrors the backend `SubmissionStatus` enum (crates/db/src/submissions.rs).
+ */
+export const statusBadge: Record<string, { bg: string; fg: string; label: string }> = {
+  pending: { bg: C.amberSoft, fg: C.amber, label: 'Review needed' },
+  approved: { bg: C.greenSoft, fg: C.green, label: 'Approved' },
+  rejected: { bg: C.accentSoft, fg: C.accent, label: 'Changes requested' },
+  merged: { bg: C.blueSoft, fg: C.blue, label: 'Merged' },
+};


### PR DESCRIPTION
Implements **Epic D** from the refactor drafts (#68), approved by codex.

**Backend** — `SubmissionStatus` enum (`crates/db/src/submissions.rs`) is the single source of truth for status strings: `as_str` / `FromStr` / `ACTIVE`. `update_status` is now typed (`SubmissionStatus`, not `&str`), `list_pending_for_workspace` builds its `IN (...)` from `ACTIVE`, and `review.rs` uses the enum instead of `"approved"`/`"merged"`/`"rejected"` literals. Defines a reserved `ChangesRequested` variant (not wired — #10).

**Frontend** — the `statusBadge` map was duplicated in `ReviewList` + `ReviewDetail` and had **drifted** (`'Changes req.'` vs `'Changes requested'`). Extracted to `web/src/lib/review.ts`, mirroring the backend enum; canonical label `'Changes requested'`.

Scope note (per draft open-decision #1): `Submission.status` stays `String` at the row level — the full sqlx-typed field with an `Unknown` fallback is a lower-priority follow-up; this PR removes the literal-drift risk without the sqlx-mapping change.

Verified: `cargo fmt --check`, `cargo build --workspace --locked`, `cargo test -p cowiki-db` (DB), `npm run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)