### PR TITLE
refactor(core): frontmatter module — slug fallback + shared builder (Epic E)

### DIFF
--- a/crates/core/src/compiler.rs
+++ b/crates/core/src/compiler.rs
@@ -138,12 +138,9 @@ fn parse_compiled_page(raw: &str) -> Page {
         }
     }
 
-    let slug = title
-        .to_lowercase()
-        .replace(|c: char| !c.is_alphanumeric() && c != ' ', "")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join("-");
+    // Use the body as the fallback seed so a symbol-only title still gets a unique,
+    // deterministic slug instead of collapsing to an empty slug (`wiki/.md`).
+    let slug = crate::frontmatter::slug_for_title(&title, &body);
 
     Page {
         slug,

--- a/crates/core/src/frontmatter.rs
+++ b/crates/core/src/frontmatter.rs
@@ -1,0 +1,77 @@
+use sha2::{Digest, Sha256};
+
+/// Build a URL-safe slug from a title. Falls back to a deterministic content-hash
+/// slug (`page-<hash8>`) when the title has no slug-able characters (e.g. a
+/// symbol/emoji-only title) — so such pages never collapse to an empty slug and
+/// overwrite each other at `wiki/.md`. CJK/accented titles are kept (they are
+/// Unicode-alphanumeric).
+pub fn slug_for_title(title: &str, fallback_seed: &str) -> String {
+    let slug = title
+        .to_lowercase()
+        .replace(|c: char| !c.is_alphanumeric() && c != ' ', "")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("-");
+    if slug.is_empty() {
+        let hash = format!("{:x}", Sha256::digest(fallback_seed.as_bytes()));
+        format!("page-{}", &hash[..8])
+    } else {
+        slug
+    }
+}
+
+/// Canonical builder for a wiki page's markdown (frontmatter + body). Single source
+/// of truth so every write path produces identical frontmatter (and never a
+/// title-less page).
+pub fn build_page_markdown(
+    title: &str,
+    summary: &str,
+    kind: &str,
+    sources: &[String],
+    body: &str,
+) -> String {
+    let sources_yaml = sources
+        .iter()
+        .map(|s| format!("  - {s}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "---\ntitle: \"{title}\"\nsummary: \"{summary}\"\nkind: {kind}\nsources:\n{sources_yaml}\n---\n\n{body}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_normal() {
+        assert_eq!(slug_for_title("Retry Patterns", "body"), "retry-patterns");
+    }
+
+    #[test]
+    fn slug_keeps_cjk() {
+        assert_eq!(slug_for_title("重试模式", "body"), "重试模式");
+    }
+
+    #[test]
+    fn slug_falls_back_for_symbol_only_titles() {
+        let a = slug_for_title("!!!", "content-a");
+        let b = slug_for_title("***", "content-b");
+        assert!(a.starts_with("page-"), "got {a}");
+        assert!(b.starts_with("page-"), "got {b}");
+        assert_ne!(a, b, "distinct content must yield distinct fallback slugs");
+        // deterministic by seed (not by the symbolic title)
+        assert_eq!(a, slug_for_title("@@@", "content-a"));
+    }
+
+    #[test]
+    fn build_round_trips_fields() {
+        let md = build_page_markdown("T", "S", "concept", &["src.md".into()], "Body.");
+        assert!(md.contains("title: \"T\""));
+        assert!(md.contains("summary: \"S\""));
+        assert!(md.contains("kind: concept"));
+        assert!(md.contains("  - src.md"));
+        assert!(md.ends_with("Body."));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ai;
 pub mod compiler;
 pub mod dedup;
+pub mod frontmatter;
 pub mod git;
 pub mod models;

--- a/crates/server/src/routes/compile.rs
+++ b/crates/server/src/routes/compile.rs
@@ -109,16 +109,12 @@ async fn do_compile(
     // 5. Write pages
     let mut result_pages = Vec::new();
     for page in &compiled {
-        let full_content = format!(
-            "---\ntitle: \"{}\"\nsummary: \"{}\"\nkind: concept\nsources:\n{}\n---\n\n{}",
-            page.title,
-            page.summary,
-            page.sources
-                .iter()
-                .map(|s| format!("  - {s}"))
-                .collect::<Vec<_>>()
-                .join("\n"),
-            page.body,
+        let full_content = cowiki_core::frontmatter::build_page_markdown(
+            &page.title,
+            &page.summary,
+            "concept",
+            &page.sources,
+            &page.body,
         );
 
         let path = format!("wiki/{}.md", page.slug);


### PR DESCRIPTION
Implements the high-value core of **Epic E** (#68), approved by codex.

New `crates/core/src/frontmatter.rs`:
- **`slug_for_title(title, fallback_seed)`** — existing slugify + a deterministic content-hash fallback (`page-<hash8>`) when the title has no slug-able characters. **Fixes** the review bug where a symbol/emoji-only title slugged to `""` → every such page collided/overwrote at `wiki/.md`. CJK/accented titles are preserved (Unicode-alphanumeric).
- **`build_page_markdown(...)`** — one canonical frontmatter+body builder.

Wired into `compiler.rs` (`parse_compiled_page` slug) and `compile.rs` (page write), replacing the inline slugify and the hand-assembled `format!("---\ntitle...")`.

Tests: normal / CJK / symbol-only (+ fallback determinism & distinctness) / build round-trip.

**Scope (per draft E):** the `pages.rs` → `frontmatter`/`wiki_tree` *file split* and the frontend `makePageMarkdown` mirror are deferred to separate lower-risk PRs — this PR delivers the slug-collision fix + shared builder. Open decision settled per the draft: **title fallback = content-hash** (`page-<hash8>`).

Verified: `cargo fmt --check`, `cargo build --workspace --locked`, `cargo test -p cowiki-core frontmatter` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)