### PR TITLE
feat: branch/submission/merge model — frozen PR snapshots, linear squash merge (ADR 0004)

### DIFF
--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -87,6 +87,106 @@ fn compute_line_diff(old: &str, new: &str) -> (Vec<DiffHunk>, usize, usize) {
     (hunks, total_adds, total_dels)
 }
 
+/// Outcome of merging a submission's `pr/{id}` branch into `main`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MergeOutcome {
+    /// Merged cleanly; `main` advanced by one linear squash commit.
+    Merged,
+    /// Conflicts with `main`. Nothing was written; carries the conflicting paths.
+    Conflict(Vec<String>),
+}
+
+/// Outcome of bringing a user branch up to date with `main`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RebaseOutcome {
+    /// Branch already contains all of `main`; nothing to do.
+    UpToDate,
+    /// `main`'s changes were folded into the branch; the branch advanced.
+    Updated,
+    /// Branch conflicts with `main`. The branch was left **untouched**;
+    /// carries the conflicting paths for the UI to surface.
+    Conflict(Vec<String>),
+}
+
+/// Build a git signature from a user display name. libgit2 rejects names containing
+/// angle brackets (and control chars), so we strip those and fall back to a service
+/// identity when nothing usable remains — a real user name must never 500 a write.
+fn signature(author: &str) -> Result<Signature<'static>, git2::Error> {
+    let cleaned: String = author
+        .chars()
+        .filter(|c| !matches!(c, '<' | '>') && !c.is_control())
+        .collect();
+    let name = match cleaned.trim() {
+        "" => "cowiki",
+        n => n,
+    };
+    Signature::now(name, "noreply@cowiki")
+}
+
+/// Set one file `segments` (possibly nested, e.g. `["wiki", "a", "b.md"]`) to `blob`
+/// inside `base_tree`, rebuilding only the touched subtrees **in memory** — no working
+/// directory, no shared on-disk index. Returns the new tree oid.
+fn set_path_in_tree(
+    repo: &Repository,
+    base_tree: Option<&git2::Tree>,
+    segments: &[&str],
+    blob: git2::Oid,
+) -> Result<git2::Oid, git2::Error> {
+    let mut builder = repo.treebuilder(base_tree)?;
+    let existing = base_tree.and_then(|t| t.get_name(segments[0]));
+    if segments.len() == 1 {
+        if existing.as_ref().and_then(|e| e.kind()) == Some(git2::ObjectType::Tree) {
+            return Err(git2::Error::from_str(&format!(
+                "cannot write file over existing directory '{}'",
+                segments[0]
+            )));
+        }
+        builder.insert(segments[0], blob, 0o100644)?;
+    } else {
+        if existing.as_ref().and_then(|e| e.kind()) == Some(git2::ObjectType::Blob) {
+            return Err(git2::Error::from_str(&format!(
+                "cannot create directory over existing file '{}'",
+                segments[0]
+            )));
+        }
+        let sub_base = existing.and_then(|e| repo.find_tree(e.id()).ok());
+        let sub_oid = set_path_in_tree(repo, sub_base.as_ref(), &segments[1..], blob)?;
+        builder.insert(segments[0], sub_oid, 0o040000)?;
+    }
+    builder.write()
+}
+
+/// Create a commit object for `tree_oid` with the given parents, **without** moving any
+/// ref (the caller updates refs explicitly). Lock-free; returns the new commit oid.
+fn commit_tree(
+    repo: &Repository,
+    tree_oid: git2::Oid,
+    message: &str,
+    author: &str,
+    parents: &[&git2::Commit],
+) -> Result<git2::Oid, git2::Error> {
+    let tree = repo.find_tree(tree_oid)?;
+    let sig = signature(author)?;
+    repo.commit(None, &sig, &sig, message, &tree, parents)
+}
+
+/// Collect conflicting `wiki/...` paths from a merge index.
+fn conflict_paths(index: &mut git2::Index) -> Vec<String> {
+    index
+        .conflicts()
+        .map(|cs| {
+            cs.filter_map(|c| c.ok())
+                .filter_map(|c| {
+                    c.our
+                        .or(c.their)
+                        .or(c.ancestor)
+                        .and_then(|e| String::from_utf8(e.path).ok())
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn rename_master_to_main(repo_path: &Path) {
     // Use git CLI to avoid libgit2 borrow issues
     let has_master = Command::new("git")
@@ -217,6 +317,12 @@ impl WikiRepo {
         Ok(branch_name.to_string())
     }
 
+    /// Apply one edit to `branch` as a single in-progress working commit.
+    ///
+    /// The branch carries exactly one commit on top of `merge-base(branch, main)`: each
+    /// write rebuilds the tree from the current tip and re-commits with that merge-base
+    /// as the parent, so repeated edits **amend** one commit instead of piling up
+    /// autosave commits. Pure in-memory — no working directory, no shared on-disk index.
     pub fn write_file(
         &self,
         branch: &str,
@@ -229,74 +335,28 @@ impl WikiRepo {
         let _guard = lock.write().unwrap();
         let repo = self.repo()?;
 
-        // Write file to working directory
-        let full_path = self.path.join(file_path);
-        if let Some(parent) = full_path.parent() {
-            fs::create_dir_all(parent).ok();
-        }
-        fs::write(&full_path, content)
-            .map_err(|e| git2::Error::from_str(&format!("write failed: {e}")))?;
+        let main_oid = repo
+            .find_branch("main", BranchType::Local)?
+            .get()
+            .peel_to_commit()?
+            .id();
+        let tip = repo
+            .find_branch(branch, BranchType::Local)?
+            .get()
+            .peel_to_commit()?;
 
-        // Get the branch's current commit
-        let branch_ref = repo.find_branch(branch, BranchType::Local)?;
-        let parent_commit = branch_ref.get().peel_to_commit()?;
+        // Parent = merge-base(branch, main): keeps the branch to one working commit on
+        // top of main. On a freshly forked branch (tip == main) this is the first commit.
+        let base_oid = repo
+            .merge_base(tip.id(), main_oid)
+            .unwrap_or_else(|_| tip.id());
+        let base = repo.find_commit(base_oid)?;
 
-        // Build a new tree from the parent tree + the new file
-        let blob_oid = repo.blob(content)?;
-        let mut builder = repo.treebuilder(Some(&parent_commit.tree()?))?;
-
-        // Handle nested paths by building subtrees
-        let parts: Vec<&str> = file_path.split('/').collect();
-        if parts.len() == 1 {
-            builder.insert(parts[0], blob_oid, 0o100644)?;
-        } else {
-            // For nested paths, we need to rebuild the tree hierarchy
-            // Simplified: use index-based approach
-            let mut index = repo.index()?;
-            // Reset index to parent tree
-            index.read_tree(&parent_commit.tree()?)?;
-            index.add_frombuffer(
-                &git2::IndexEntry {
-                    ctime: git2::IndexTime::new(0, 0),
-                    mtime: git2::IndexTime::new(0, 0),
-                    dev: 0,
-                    ino: 0,
-                    mode: 0o100644,
-                    uid: 0,
-                    gid: 0,
-                    file_size: content.len() as u32,
-                    id: blob_oid,
-                    flags: 0,
-                    flags_extended: 0,
-                    path: file_path.as_bytes().to_vec(),
-                },
-                content,
-            )?;
-            let tree_oid = index.write_tree()?;
-            let tree = repo.find_tree(tree_oid)?;
-            let sig = Signature::now(author, &format!("{author}@cowiki"))?;
-            repo.commit(
-                Some(&format!("refs/heads/{branch}")),
-                &sig,
-                &sig,
-                message,
-                &tree,
-                &[&parent_commit],
-            )?;
-            return Ok(());
-        }
-
-        let tree_oid = builder.write()?;
-        let tree = repo.find_tree(tree_oid)?;
-        let sig = Signature::now(author, &format!("{author}@cowiki"))?;
-        repo.commit(
-            Some(&format!("refs/heads/{branch}")),
-            &sig,
-            &sig,
-            message,
-            &tree,
-            &[&parent_commit],
-        )?;
+        let blob = repo.blob(content)?;
+        let segments: Vec<&str> = file_path.split('/').collect();
+        let tree_oid = set_path_in_tree(&repo, Some(&tip.tree()?), &segments, blob)?;
+        let new_oid = commit_tree(&repo, tree_oid, message, author, &[&base])?;
+        repo.reference(&format!("refs/heads/{branch}"), new_oid, true, message)?;
         Ok(())
     }
 
@@ -435,20 +495,516 @@ impl WikiRepo {
         Ok(diffs)
     }
 
-    pub fn merge_to_main(
+    /// Bring `branch` up to date with `main` (the user's "sync" / rebase button, and the
+    /// mandatory pre-submit step). Folds `main`'s changes into the branch as a single
+    /// commit on top of `main`; on conflict the branch is left **untouched** so the user
+    /// can resolve. Single-lock, lock-free body — no nested git locking, no deadlock.
+    pub fn rebase_onto_main(&self, branch: &str) -> Result<RebaseOutcome, git2::Error> {
+        if branch == "main" {
+            return Ok(RebaseOutcome::UpToDate);
+        }
+        let lock = self.branch_lock(branch);
+        let _guard = lock.write().unwrap();
+        let repo = self.repo()?;
+
+        let main_commit = repo
+            .find_branch("main", BranchType::Local)?
+            .get()
+            .peel_to_commit()?;
+        let branch_commit = repo
+            .find_branch(branch, BranchType::Local)?
+            .get()
+            .peel_to_commit()?;
+
+        if main_commit.id() == branch_commit.id()
+            || repo.graph_descendant_of(branch_commit.id(), main_commit.id())?
+        {
+            return Ok(RebaseOutcome::UpToDate);
+        }
+
+        // ours = branch, theirs = main → pull main's changes into the branch.
+        let mut idx = repo.merge_commits(&branch_commit, &main_commit, None)?;
+        if idx.has_conflicts() {
+            return Ok(RebaseOutcome::Conflict(conflict_paths(&mut idx)));
+        }
+        let tree_oid = idx.write_tree_to(&repo)?;
+        // Collapse to a single commit on top of main: the branch becomes
+        // "main + this user's net changes".
+        let new_oid = commit_tree(
+            &repo,
+            tree_oid,
+            "sync: rebase onto main",
+            "cowiki",
+            &[&main_commit],
+        )?;
+        repo.reference(&format!("refs/heads/{branch}"), new_oid, true, "sync")?;
+        Ok(RebaseOutcome::Updated)
+    }
+
+    /// Freeze the current state of `user_branch` as submission `id`'s reviewable snapshot:
+    /// `pr/{id}` (the PR tip that gets reviewed and merged) plus a frozen base ref, both at
+    /// commit `S`. The caller must rebase `user_branch` onto `main` first (submit does), so
+    /// `S` is already main-based. The live `user_branch` is not touched.
+    pub fn create_pr_snapshot(&self, user_branch: &str, id: &str) -> Result<(), git2::Error> {
+        let pr = format!("pr/{id}");
+        let lock = self.branch_lock(&pr);
+        let _guard = lock.write().unwrap();
+        let repo = self.repo()?;
+        let tip = repo
+            .find_branch(user_branch, BranchType::Local)?
+            .get()
+            .peel_to_commit()?
+            .id();
+        repo.reference(
+            &format!("refs/heads/{pr}"),
+            tip,
+            true,
+            "submit: pr snapshot",
+        )?;
+        repo.reference(
+            &format!("refs/cowiki/base/{id}"),
+            tip,
+            true,
+            "submit: frozen base",
+        )?;
+        Ok(())
+    }
+
+    /// Apply a review-requested change to submission `id` as a single commit `R` on top of
+    /// the frozen snapshot `S`, **amended** across rounds (`S` never moves, so `S`→`R` is
+    /// always the clean "what review changed" diff).
+    pub fn write_review_fix(
         &self,
-        branch: &str,
-        file_paths: &[String],
+        id: &str,
+        file_path: &str,
+        content: &[u8],
+        message: &str,
+        author: &str,
+    ) -> Result<(), git2::Error> {
+        let pr = format!("pr/{id}");
+        let lock = self.branch_lock(&pr);
+        let _guard = lock.write().unwrap();
+        let repo = self.repo()?;
+
+        let base_oid = repo.refname_to_id(&format!("refs/cowiki/base/{id}"))?;
+        let base = repo.find_commit(base_oid)?;
+        let tip = repo
+            .find_branch(&pr, BranchType::Local)?
+            .get()
+            .peel_to_commit()?;
+
+        let blob = repo.blob(content)?;
+        let segments: Vec<&str> = file_path.split('/').collect();
+        let tree_oid = set_path_in_tree(&repo, Some(&tip.tree()?), &segments, blob)?;
+        // Parent is always the frozen base `S`, so this stays one amended commit on top of S.
+        let r_oid = commit_tree(&repo, tree_oid, message, author, &[&base])?;
+        repo.reference(&format!("refs/heads/{pr}"), r_oid, true, message)?;
+        Ok(())
+    }
+
+    /// Merge submission `id`'s `pr/{id}` into `main`: a 3-way against the *current* `main`,
+    /// squashed into one commit and fast-forwarded. `main` stays **linear** — the commit
+    /// has a single parent (`main`), no two-parent merge node. Authored by the submitter.
+    /// Conflict with `main` → nothing is written.
+    pub fn merge_pr(
+        &self,
+        id: &str,
         author: &str,
         message: &str,
-    ) -> Result<(), git2::Error> {
+    ) -> Result<MergeOutcome, git2::Error> {
         let lock = self.branch_lock("main");
         let _guard = lock.write().unwrap();
-        for path in file_paths {
-            if let Some(content) = self.read_file(branch, path)? {
-                self.write_file("main", path, &content, message, author)?;
+        let repo = self.repo()?;
+
+        let main_commit = repo
+            .find_branch("main", BranchType::Local)?
+            .get()
+            .peel_to_commit()?;
+        let pr = format!("pr/{id}");
+        let pr_commit = repo
+            .find_branch(&pr, BranchType::Local)?
+            .get()
+            .peel_to_commit()?;
+
+        // ours = main, theirs = pr.
+        let mut idx = repo.merge_commits(&main_commit, &pr_commit, None)?;
+        if idx.has_conflicts() {
+            return Ok(MergeOutcome::Conflict(conflict_paths(&mut idx)));
+        }
+        let tree_oid = idx.write_tree_to(&repo)?;
+        // Single parent = main → linear squash commit.
+        let m_oid = commit_tree(&repo, tree_oid, message, author, &[&main_commit])?;
+        repo.reference("refs/heads/main", m_oid, true, message)?;
+        Ok(MergeOutcome::Merged)
+    }
+
+    /// Delete a submission's git refs (`pr/{id}` and its frozen base) — called after a
+    /// successful merge or a reject/abandon. Best-effort; missing refs are ignored.
+    pub fn cleanup_submission(&self, id: &str) {
+        let Ok(repo) = self.repo() else { return };
+        for name in [
+            format!("refs/heads/pr/{id}"),
+            format!("refs/cowiki/base/{id}"),
+        ] {
+            if let Ok(mut r) = repo.find_reference(&name) {
+                let _ = r.delete();
             }
         }
-        Ok(())
+    }
+
+    /// Whole-tree diff of a ref (e.g. `pr/{id}` or a `user/{id}` branch) against `main`,
+    /// as per-file `FileDiff`s for the changed `wiki/*.md` pages. Drives the review UI.
+    pub fn diff_ref_against_main(&self, ref_name: &str) -> Result<Vec<FileDiff>, git2::Error> {
+        let repo = self.repo()?;
+        let main_tree = repo
+            .find_branch("main", BranchType::Local)?
+            .get()
+            .peel_to_commit()?
+            .tree()?;
+        let ref_tree = repo.revparse_single(ref_name)?.peel_to_commit()?.tree()?;
+
+        let diff = repo.diff_tree_to_tree(Some(&main_tree), Some(&ref_tree), None)?;
+        let mut paths: Vec<String> = Vec::new();
+        diff.foreach(
+            &mut |delta, _| {
+                if let Some(p) = delta
+                    .new_file()
+                    .path()
+                    .or_else(|| delta.old_file().path())
+                    .and_then(|p| p.to_str())
+                {
+                    if p.starts_with("wiki/") && p.ends_with(".md") {
+                        paths.push(p.to_string());
+                    }
+                }
+                true
+            },
+            None,
+            None,
+            None,
+        )?;
+        paths.sort();
+        paths.dedup();
+
+        let mut out = Vec::new();
+        for path in paths {
+            let old = self
+                .read_file("main", &path)?
+                .map(|b| String::from_utf8_lossy(&b).into_owned());
+            let new = self
+                .read_file(ref_name, &path)?
+                .map(|b| String::from_utf8_lossy(&b).into_owned());
+            let (hunks, additions, deletions) =
+                compute_line_diff(old.as_deref().unwrap_or(""), new.as_deref().unwrap_or(""));
+            out.push(FileDiff {
+                path,
+                old_content: old,
+                new_content: new,
+                hunks,
+                additions,
+                deletions,
+            });
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MergeOutcome, RebaseOutcome, WikiRepo};
+    use git2::{BranchType, Repository};
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    fn temp_repo(tag: &str) -> (Arc<WikiRepo>, std::path::PathBuf) {
+        let dir =
+            std::env::temp_dir().join(format!("cowiki-git-test-{}-{}", std::process::id(), tag));
+        let _ = std::fs::remove_dir_all(&dir);
+        let repo = Arc::new(WikiRepo::open_or_init(dir.to_str().unwrap()).unwrap());
+        (repo, dir)
+    }
+
+    fn read(repo: &WikiRepo, branch: &str, path: &str) -> Option<String> {
+        repo.read_file(branch, path)
+            .unwrap()
+            .map(|b| String::from_utf8_lossy(&b).into_owned())
+    }
+
+    fn git(dir: &std::path::Path) -> Repository {
+        Repository::open(dir.join("repo")).unwrap()
+    }
+    fn tip(g: &Repository, branch: &str) -> git2::Oid {
+        g.find_branch(branch, BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap()
+            .id()
+    }
+
+    /// Every edit amends ONE working commit: the branch stays exactly one commit above
+    /// main (its single parent is main's tip), accumulating all pages of the task.
+    #[test]
+    fn edits_keep_a_single_working_commit() {
+        let (repo, dir) = temp_repo("single-commit");
+        repo.ensure_branch_exists("user/a").unwrap();
+        for i in 0..4 {
+            repo.write_file(
+                "user/a",
+                "wiki/p.md",
+                format!("v{i}\n").as_bytes(),
+                "edit",
+                "a",
+            )
+            .unwrap();
+        }
+        repo.write_file("user/a", "wiki/q.md", b"q\n", "edit", "a")
+            .unwrap();
+
+        let g = git(&dir);
+        let main_tip = tip(&g, "main");
+        let commit = g
+            .find_branch("user/a", BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap();
+        assert_eq!(commit.parent_count(), 1, "single working commit");
+        assert_eq!(commit.parent_id(0).unwrap(), main_tip, "parented on main");
+        assert_eq!(read(&repo, "user/a", "wiki/p.md").as_deref(), Some("v3\n"));
+        assert_eq!(read(&repo, "user/a", "wiki/q.md").as_deref(), Some("q\n"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Snapshot freezes S; review fixes are a single commit R on top of S, amended across
+    /// rounds — S (the frozen base ref) never moves.
+    #[test]
+    fn snapshot_then_review_fix_amends_on_frozen_base() {
+        let (repo, dir) = temp_repo("review-fix");
+        repo.ensure_branch_exists("user/b").unwrap();
+        repo.write_file("user/b", "wiki/p.md", b"original\n", "edit", "b")
+            .unwrap();
+        repo.create_pr_snapshot("user/b", "sub1").unwrap();
+
+        let g = git(&dir);
+        let base = g.refname_to_id("refs/cowiki/base/sub1").unwrap();
+        assert_eq!(
+            tip(&g, "pr/sub1"),
+            base,
+            "pr tip == frozen base before any fix"
+        );
+
+        repo.write_review_fix("sub1", "wiki/p.md", b"fixed\n", "fix", "b")
+            .unwrap();
+        let r1 = g.find_commit(tip(&g, "pr/sub1")).unwrap();
+        assert_eq!(r1.parent_id(0).unwrap(), base, "R is parented on frozen S");
+        assert_eq!(
+            g.refname_to_id("refs/cowiki/base/sub1").unwrap(),
+            base,
+            "base ref unchanged"
+        );
+
+        repo.write_review_fix("sub1", "wiki/p.md", b"fixed2\n", "fix2", "b")
+            .unwrap();
+        let r2 = g.find_commit(tip(&g, "pr/sub1")).unwrap();
+        assert_eq!(
+            r2.parent_id(0).unwrap(),
+            base,
+            "still one commit on frozen S"
+        );
+        assert_eq!(
+            read(&repo, "pr/sub1", "wiki/p.md").as_deref(),
+            Some("fixed2\n")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// merge_pr is linear (single parent = main), authored by the submitter, lands content.
+    #[test]
+    fn merge_pr_is_linear_and_lands_content() {
+        let (repo, dir) = temp_repo("merge-linear");
+        repo.ensure_branch_exists("user/c").unwrap();
+        repo.write_file("user/c", "wiki/p.md", b"hello\n", "edit", "carol")
+            .unwrap();
+        repo.create_pr_snapshot("user/c", "subc").unwrap();
+
+        let g = git(&dir);
+        let main_before = tip(&g, "main");
+        assert_eq!(
+            repo.merge_pr("subc", "carol", "approve: p").unwrap(),
+            MergeOutcome::Merged
+        );
+        let m = g
+            .find_branch("main", BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap();
+        assert_eq!(m.parent_count(), 1, "linear: single parent, no merge node");
+        assert_eq!(m.parent_id(0).unwrap(), main_before);
+        assert_eq!(m.author().name(), Some("carol"), "authored by submitter");
+        assert_eq!(read(&repo, "main", "wiki/p.md").as_deref(), Some("hello\n"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Post-submit edits on the live user branch must NOT change what gets merged — the
+    /// snapshot is frozen. (This is the core bug the redesign fixes.)
+    #[test]
+    fn post_submit_edits_do_not_leak_into_merge() {
+        let (repo, dir) = temp_repo("no-leak");
+        repo.ensure_branch_exists("user/j").unwrap();
+        repo.write_file("user/j", "wiki/p.md", b"reviewed\n", "edit", "j")
+            .unwrap();
+        repo.create_pr_snapshot("user/j", "subj").unwrap();
+        // keep editing the live branch AFTER submit
+        repo.write_file("user/j", "wiki/p.md", b"sneaky\n", "edit", "j")
+            .unwrap();
+        assert_eq!(
+            repo.merge_pr("subj", "j", "approve").unwrap(),
+            MergeOutcome::Merged
+        );
+        assert_eq!(
+            read(&repo, "main", "wiki/p.md").as_deref(),
+            Some("reviewed\n"),
+            "merge lands the reviewed snapshot, not the post-submit edit"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// merge_pr detects a real conflict (main changed the same page after snapshot) and
+    /// writes nothing.
+    #[test]
+    fn merge_pr_detects_conflict_and_writes_nothing() {
+        let (repo, dir) = temp_repo("merge-conflict");
+        // seed main with p = base
+        repo.ensure_branch_exists("user/d").unwrap();
+        repo.write_file("user/d", "wiki/p.md", b"base\n", "edit", "d")
+            .unwrap();
+        repo.create_pr_snapshot("user/d", "subd").unwrap();
+        repo.merge_pr("subd", "d", "seed").unwrap();
+
+        // user E snapshots p = mine (based on p = base)
+        repo.ensure_branch_exists("user/e").unwrap();
+        repo.write_file("user/e", "wiki/p.md", b"mine\n", "edit", "e")
+            .unwrap();
+        repo.create_pr_snapshot("user/e", "sube").unwrap();
+
+        // meanwhile main advances p = theirs via user F
+        repo.ensure_branch_exists("user/f").unwrap();
+        repo.write_file("user/f", "wiki/p.md", b"theirs\n", "edit", "f")
+            .unwrap();
+        repo.create_pr_snapshot("user/f", "subf").unwrap();
+        repo.merge_pr("subf", "f", "land theirs").unwrap();
+
+        let main_before = tip(&git(&dir), "main");
+        match repo.merge_pr("sube", "e", "land mine").unwrap() {
+            MergeOutcome::Conflict(paths) => {
+                assert!(
+                    paths.iter().any(|p| p.contains("p.md")),
+                    "conflict names p.md"
+                )
+            }
+            other => panic!("expected conflict, got {other:?}"),
+        }
+        assert_eq!(
+            tip(&git(&dir), "main"),
+            main_before,
+            "main untouched on conflict"
+        );
+        assert_eq!(
+            read(&repo, "main", "wiki/p.md").as_deref(),
+            Some("theirs\n")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// rebase_onto_main: up-to-date, updated (main advanced a different page), conflict.
+    #[test]
+    fn rebase_onto_main_outcomes() {
+        let (repo, dir) = temp_repo("rebase");
+        repo.ensure_branch_exists("user/g").unwrap();
+        assert_eq!(
+            repo.rebase_onto_main("user/g").unwrap(),
+            RebaseOutcome::UpToDate,
+            "fresh branch == main"
+        );
+
+        // main advances a DIFFERENT page
+        repo.ensure_branch_exists("user/h").unwrap();
+        repo.write_file("user/h", "wiki/other.md", b"other\n", "edit", "h")
+            .unwrap();
+        repo.create_pr_snapshot("user/h", "subh").unwrap();
+        repo.merge_pr("subh", "h", "land other").unwrap();
+
+        repo.write_file("user/g", "wiki/p.md", b"mine\n", "edit", "g")
+            .unwrap();
+        assert_eq!(
+            repo.rebase_onto_main("user/g").unwrap(),
+            RebaseOutcome::Updated
+        );
+        assert_eq!(
+            read(&repo, "user/g", "wiki/other.md").as_deref(),
+            Some("other\n")
+        );
+        assert_eq!(
+            read(&repo, "user/g", "wiki/p.md").as_deref(),
+            Some("mine\n")
+        );
+
+        // conflict: main changes p; user/g already changed p differently
+        repo.ensure_branch_exists("user/i").unwrap();
+        repo.write_file("user/i", "wiki/p.md", b"theirs\n", "edit", "i")
+            .unwrap();
+        repo.create_pr_snapshot("user/i", "subi").unwrap();
+        repo.merge_pr("subi", "i", "land theirs p").unwrap();
+        match repo.rebase_onto_main("user/g").unwrap() {
+            RebaseOutcome::Conflict(paths) => {
+                assert!(paths.iter().any(|p| p.contains("p.md")))
+            }
+            other => panic!("expected conflict, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Regression for the old `merge_to_main` self-deadlock (it held the "main" lock then
+    /// called `write_file("main", …)`, re-acquiring the same non-reentrant lock). The new
+    /// merge never nests locks; run it on a worker thread with a timeout so a regression
+    /// fails fast instead of hanging the suite.
+    #[test]
+    fn full_cycle_does_not_deadlock() {
+        let (repo, dir) = temp_repo("deadlock");
+        repo.ensure_branch_exists("user/x").unwrap();
+        repo.write_file("user/x", "wiki/p.md", b"hi\n", "edit", "x")
+            .unwrap();
+        repo.create_pr_snapshot("user/x", "subx").unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        let r2 = Arc::clone(&repo);
+        std::thread::spawn(move || {
+            let _ = tx.send(r2.merge_pr("subx", "x", "approve"));
+        });
+        match rx.recv_timeout(Duration::from_secs(10)) {
+            Ok(Ok(MergeOutcome::Merged)) => {}
+            Ok(other) => panic!("unexpected merge result: {other:?}"),
+            Err(_) => panic!("merge_pr deadlocked (timed out after 10s)"),
+        }
+        assert_eq!(read(&repo, "main", "wiki/p.md").as_deref(), Some("hi\n"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// cleanup_submission removes the pr/{id} branch and the frozen base ref.
+    #[test]
+    fn cleanup_removes_submission_refs() {
+        let (repo, dir) = temp_repo("cleanup");
+        repo.ensure_branch_exists("user/k").unwrap();
+        repo.write_file("user/k", "wiki/p.md", b"x\n", "edit", "k")
+            .unwrap();
+        repo.create_pr_snapshot("user/k", "subk").unwrap();
+        let g = git(&dir);
+        assert!(g.find_branch("pr/subk", BranchType::Local).is_ok());
+        repo.cleanup_submission("subk");
+        assert!(g.find_branch("pr/subk", BranchType::Local).is_err());
+        assert!(g.refname_to_id("refs/cowiki/base/subk").is_err());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/db/src/submissions.rs
+++ b/crates/db/src/submissions.rs
@@ -82,6 +82,17 @@ pub async fn update_status(
     .await
 }
 
+/// Replace a submission's summary (used by the background AI-summary task; submit stores a
+/// diff-based placeholder immediately so it never blocks on the LLM).
+pub async fn update_summary(pool: &PgPool, id: Uuid, summary: &str) -> sqlx::Result<()> {
+    sqlx::query("UPDATE submissions SET summary = $2 WHERE id = $1")
+        .bind(id)
+        .bind(summary)
+        .execute(pool)
+        .await
+        .map(|_| ())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -10,6 +10,8 @@ pub enum AppError {
     BadRequest(String),
     Unauthorized(String),
     Forbidden(String),
+    /// The branch/submission conflicts with `main`; the author must rebase and resolve.
+    Conflict(String),
 }
 
 impl IntoResponse for AppError {
@@ -20,6 +22,7 @@ impl IntoResponse for AppError {
             AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
             AppError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
             AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg),
+            AppError::Conflict(msg) => (StatusCode::CONFLICT, msg),
         };
         (status, msg).into_response()
     }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -245,6 +245,11 @@ async fn main() {
             "/api/workspaces/{ws_slug}/submit",
             post(routes::submit::submit),
         )
+        // Rebase / sync a branch onto main (the "sync with main" button)
+        .route(
+            "/api/workspaces/{ws_slug}/rebase",
+            post(routes::submit::rebase),
+        )
         // Reviews (workspace-scoped)
         .route(
             "/api/workspaces/{ws_slug}/reviews",
@@ -257,6 +262,11 @@ async fn main() {
         .route(
             "/api/workspaces/{ws_slug}/reviews/{id}",
             post(routes::review::review_action),
+        )
+        // Review-requested change: edit the submission's pr/{id} snapshot
+        .route(
+            "/api/workspaces/{ws_slug}/reviews/{id}/edit",
+            post(routes::review::edit_review),
         )
         // Review comments
         .route(

--- a/crates/server/src/routes/review.rs
+++ b/crates/server/src/routes/review.rs
@@ -48,9 +48,11 @@ pub async fn get_review(
         .repo_manager
         .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
+    // Diff the frozen `pr/{id}` snapshot against main (whole branch). Once merged/rejected
+    // the snapshot refs are cleaned up, so fall back to an empty diff for historical rows.
     let diffs = repo
-        .diff_files(&submission.source_branch, &submission.page_slugs)
-        .map_err(|e| AppError::Internal(e.to_string()))?;
+        .diff_ref_against_main(&format!("pr/{}", submission.id))
+        .unwrap_or_default();
 
     let comments = cowiki_db::review_comments::list_for_submission(&state.db, id).await?;
 
@@ -101,62 +103,140 @@ pub async fn review_action(
                 .get(&ws_slug)
                 .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
 
-            let file_paths: Vec<String> = submission
-                .page_slugs
-                .iter()
-                .map(|s| format!("wiki/{s}.md"))
+            let pr_ref = format!("pr/{}", submission.id);
+            // Pages changed by this submission (for search indexing after the merge).
+            let changed: Vec<String> = repo
+                .diff_ref_against_main(&pr_ref)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|d| d.path)
                 .collect();
 
-            for (slug, path) in submission.page_slugs.iter().zip(file_paths.iter()) {
-                let content = repo
-                    .read_file(&submission.source_branch, path)
-                    .map_err(|e| AppError::Internal(e.to_string()))?
-                    .ok_or_else(|| AppError::BadRequest(format!("page {slug} not found")))?;
-                let text = String::from_utf8_lossy(&content);
-                super::pages::require_page_title(&text)?;
+            // Merge is authored by the original submitter, not the reviewer.
+            let author = cowiki_db::users::find_by_id(&state.db, submission.user_id)
+                .await
+                .ok()
+                .flatten()
+                .map(|u| u.name)
+                .unwrap_or_else(|| guard.user.name.clone());
+
+            // Linear squash + rebase + fast-forward. A conflict with the current main
+            // means the author must rebase and resolve — surface it as 409.
+            match repo
+                .merge_pr(
+                    &submission.id.to_string(),
+                    &author,
+                    &format!("approve: {}", submission.summary),
+                )
+                .map_err(|e| AppError::Internal(e.to_string()))?
+            {
+                cowiki_core::git::MergeOutcome::Merged => {}
+                cowiki_core::git::MergeOutcome::Conflict(paths) => {
+                    return Err(AppError::Conflict(format!(
+                        "merge conflicts with main; author must rebase and resolve: {}",
+                        paths.join(", ")
+                    )));
+                }
             }
 
-            repo.merge_to_main(
-                &submission.source_branch,
-                &file_paths,
-                &guard.user.name,
-                &format!("approve: {}", submission.summary),
-            )
-            .map_err(|e| AppError::Internal(e.to_string()))?;
-
-            // Merge should not block on embedding; search indexing can catch up separately.
-            for slug in &submission.page_slugs {
-                let path = format!("wiki/{slug}.md");
-                if let Some(content) = repo
-                    .read_file("main", &path)
-                    .map_err(|e| AppError::Internal(e.to_string()))?
-                {
+            // Index changed pages from main (best-effort; search can catch up separately).
+            for path in &changed {
+                let slug = path
+                    .strip_prefix("wiki/")
+                    .and_then(|s| s.strip_suffix(".md"))
+                    .unwrap_or(path);
+                if let Ok(Some(content)) = repo.read_file("main", path) {
                     let text = String::from_utf8_lossy(&content);
-                    let (title, summary) = super::pages::require_page_title(&text)?;
-                    let hash = format!("{:x}", Sha256::digest(text.as_bytes()));
-                    if let Err(e) = cowiki_db::pages::upsert(
-                        &state.db,
-                        slug,
-                        &title,
-                        &summary,
-                        "main",
-                        &hash,
-                        None,
-                        guard.user.id,
-                    )
-                    .await
-                    {
-                        tracing::warn!("failed to index merged page '{slug}' for search: {e}");
+                    if let Ok((title, summary)) = super::pages::require_page_title(&text) {
+                        let hash = format!("{:x}", Sha256::digest(text.as_bytes()));
+                        if let Err(e) = cowiki_db::pages::upsert(
+                            &state.db,
+                            slug,
+                            &title,
+                            &summary,
+                            "main",
+                            &hash,
+                            None,
+                            guard.user.id,
+                        )
+                        .await
+                        {
+                            tracing::warn!("failed to index merged page '{slug}': {e}");
+                        }
                     }
                 }
             }
 
+            // Drop the snapshot refs and catch the author's branch up to the new main.
+            repo.cleanup_submission(&submission.id.to_string());
+            let _ = repo.rebase_onto_main(&submission.source_branch);
+
             cowiki_db::submissions::update_status(&state.db, id, "merged", guard.user.id).await?;
         }
         "reject" => {
+            // Drop the snapshot refs; the author keeps their changes on `source_branch`.
+            if let Ok(repo) = state.repo_manager.get(&ws_slug) {
+                repo.cleanup_submission(&submission.id.to_string());
+            }
             cowiki_db::submissions::update_status(&state.db, id, "rejected", guard.user.id).await?;
         }
         _ => return Err(AppError::BadRequest("invalid action".into())),
+    }
+
+    Ok(Json(serde_json::json!({"ok": true})))
+}
+
+#[derive(Deserialize)]
+pub struct ReviewEdit {
+    /// Repo path, e.g. "wiki/foo.md".
+    pub path: String,
+    pub content: String,
+}
+
+/// Apply a review-requested change to a submission's `pr/{id}` snapshot (a single amended
+/// commit `R` on top of the frozen base `S`). Edits happen in the review screen against the
+/// snapshot branch, never the author's live `user/{id}` branch.
+pub async fn edit_review(
+    State(state): State<Arc<AppState>>,
+    Path((ws_slug, id)): Path<(String, uuid::Uuid)>,
+    headers: axum::http::HeaderMap,
+    Json(input): Json<ReviewEdit>,
+) -> Result<Json<serde_json::Value>> {
+    let submission = cowiki_db::submissions::find_by_id(&state.db, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("submission not found".into()))?;
+    if submission.workspace_slug != ws_slug {
+        return Err(AppError::NotFound(
+            "submission not found in this workspace".into(),
+        ));
+    }
+    let guard = guard::require_membership(&state, &headers, &ws_slug).await?;
+    guard::require(&guard, Permission::EditContent)?;
+
+    if submission.status == "merged" || submission.status == "rejected" {
+        return Err(AppError::BadRequest(
+            "submission is closed; cannot edit".into(),
+        ));
+    }
+
+    super::pages::require_page_title(&input.content)?;
+
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
+        .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
+    repo.write_review_fix(
+        &submission.id.to_string(),
+        &input.path,
+        input.content.as_bytes(),
+        "review fix",
+        &guard.user.name,
+    )
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // A post-approval edit must be re-reviewed: reset to pending so it can't merge unseen.
+    if submission.status == "approved" {
+        cowiki_db::submissions::update_status(&state.db, id, "pending", guard.user.id).await?;
     }
 
     Ok(Json(serde_json::json!({"ok": true})))

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -93,7 +93,10 @@ pub async fn submit(
         }
     }
 
-    let diff_desc = diffs
+    // Submit returns immediately with a diff-based summary; the AI one-liner is generated
+    // in the background after the submission is created (see below), so a slow or
+    // unreachable LLM never blocks submit.
+    let summary = diffs
         .iter()
         .map(|d| {
             if d.is_new() {
@@ -104,18 +107,6 @@ pub async fn submit(
         })
         .collect::<Vec<_>>()
         .join("\n");
-
-    let summary = match state
-        .compiler
-        .generate_summary(&format!("Submission changes:\n{diff_desc}"))
-        .await
-    {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!("summary generation failed, falling back to diff description: {e}");
-            diff_desc
-        }
-    };
 
     if input.skip_review {
         // Authorization: skip_review only allowed for personal workspaces (private + owner)
@@ -175,6 +166,30 @@ pub async fn submit(
     .await?;
     repo.create_pr_snapshot(&input.branch, &submission.id.to_string())
         .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // Replace the diff-based placeholder summary with an AI one-liner in the background, so
+    // submit itself never waits on the LLM. Failure just leaves the placeholder in place.
+    {
+        let state = state.clone();
+        let sub_id = submission.id;
+        let content = summary.clone();
+        tokio::spawn(async move {
+            match state
+                .compiler
+                .generate_summary(&format!("Submission changes:\n{content}"))
+                .await
+            {
+                Ok(s) => {
+                    if let Err(e) =
+                        cowiki_db::submissions::update_summary(&state.db, sub_id, &s).await
+                    {
+                        tracing::warn!("failed to store async summary for {sub_id}: {e}");
+                    }
+                }
+                Err(e) => tracing::warn!("async summary generation failed for {sub_id}: {e}"),
+            }
+        });
+    }
 
     Ok(Json(SubmitResponse {
         submission_id: submission.id,

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -37,6 +37,18 @@ pub async fn submit(
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     super::pages::ensure_user_branch_if_needed(&repo, &input.branch)?;
 
+    // Mandatory pre-submit rebase: bring the branch up to date with main. A conflict
+    // blocks submit — the author rebases (resolves) first, then resubmits.
+    if let cowiki_core::git::RebaseOutcome::Conflict(paths) =
+        repo.rebase_onto_main(&input.branch)
+            .map_err(|e| AppError::Internal(e.to_string()))?
+    {
+        return Err(AppError::Conflict(format!(
+            "your branch conflicts with main; rebase and resolve first: {}",
+            paths.join(", ")
+        )));
+    }
+
     let diffs = match repo.diff_files(&input.branch, &input.page_slugs) {
         Ok(d) => d,
         Err(e) => {
@@ -124,19 +136,23 @@ pub async fn submit(
             ));
         }
 
-        // Personal Space: merge directly to main, no review needed
-        let file_paths: Vec<String> = input
-            .page_slugs
-            .iter()
-            .map(|s| format!("wiki/{s}.md"))
-            .collect();
-        repo.merge_to_main(
-            &input.branch,
-            &file_paths,
-            &user.name,
-            &format!("commit: {summary}"),
-        )
-        .map_err(|e| AppError::Internal(e.to_string()))?;
+        // Personal Space: snapshot the whole branch and merge straight to main. One
+        // writer, so this never conflicts — every submit is effectively a commit.
+        let pr_id = format!("personal-{}", input.branch.replace('/', "-"));
+        repo.create_pr_snapshot(&input.branch, &pr_id)
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        let outcome = repo
+            .merge_pr(&pr_id, &user.name, &format!("commit: {summary}"))
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        repo.cleanup_submission(&pr_id);
+        if let cowiki_core::git::MergeOutcome::Conflict(paths) = outcome {
+            return Err(AppError::Conflict(format!(
+                "branch conflicts with main: {}",
+                paths.join(", ")
+            )));
+        }
+        // Catch the branch up so its untouched pages reflect the new main.
+        let _ = repo.rebase_onto_main(&input.branch);
 
         return Ok(Json(SubmitResponse {
             submission_id: uuid::Uuid::nil(),
@@ -145,7 +161,9 @@ pub async fn submit(
         }));
     }
 
-    // Team Space: create a review submission
+    // Team Space: create a review submission, then freeze its reviewable snapshot
+    // (`pr/{id}`) from the just-rebased branch. Review and merge read the snapshot, never
+    // the live branch, so edits after submit can't change what was reviewed.
     let submission = cowiki_db::submissions::create(
         &state.db,
         user.id,
@@ -155,10 +173,51 @@ pub async fn submit(
         &ws_slug,
     )
     .await?;
+    repo.create_pr_snapshot(&input.branch, &submission.id.to_string())
+        .map_err(|e| AppError::Internal(e.to_string()))?;
 
     Ok(Json(SubmitResponse {
         submission_id: submission.id,
         summary,
         duplicates,
     }))
+}
+
+#[derive(Deserialize)]
+pub struct RebaseRequest {
+    pub branch: String,
+}
+
+#[derive(Serialize)]
+pub struct RebaseResponse {
+    /// "up_to_date" | "updated" | "conflict"
+    pub status: String,
+    pub conflicts: Vec<String>,
+}
+
+/// Bring a user branch up to date with `main` (the "sync with main" button). Returns the
+/// outcome; on conflict the branch is left untouched and the conflicting paths are listed
+/// so the UI can guide the author to resolve.
+pub async fn rebase(
+    State(state): State<Arc<AppState>>,
+    Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
+    Json(input): Json<RebaseRequest>,
+) -> Result<Json<RebaseResponse>> {
+    let _user = extract_user(&state.db, &headers).await?;
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
+        .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
+    super::pages::ensure_user_branch_if_needed(&repo, &input.branch)?;
+
+    let (status, conflicts) = match repo
+        .rebase_onto_main(&input.branch)
+        .map_err(|e| AppError::Internal(e.to_string()))?
+    {
+        cowiki_core::git::RebaseOutcome::UpToDate => ("up_to_date".to_string(), Vec::new()),
+        cowiki_core::git::RebaseOutcome::Updated => ("updated".to_string(), Vec::new()),
+        cowiki_core::git::RebaseOutcome::Conflict(paths) => ("conflict".to_string(), paths),
+    };
+    Ok(Json(RebaseResponse { status, conflicts }))
 }

--- a/docs/adr/0004-branch-view-model.md
+++ b/docs/adr/0004-branch-view-model.md
@@ -1,4 +1,4 @@
-# Branch View Model — unresolved design problem
+# Branch View, Submission & Merge Model
 
 ## The Problem
 
@@ -40,10 +40,40 @@ User's branch is a full copy of main at the time they branched. Any page they ha
 
 ## Decision
 
-Not decided yet. Current implementation uses approach A (overlay) as a temporary solution. The search indexing problem needs to be solved before adding PostgreSQL FTS.
+We adopt approach **C (working copy)** for the view, plus a concrete **submission + merge lifecycle**. Together these resolve all four problems above.
+
+### View — read the user's branch directly (approach C)
+
+A user always sees **their own `user/{id}` branch**, nothing else. The branch is a full tree (it was forked from `main`), so:
+
+- **Which version (1):** always the branch's version — no "try branch, fall back to main" hack.
+- **Search (2):** index the branch's tree (the user's effective view) — no cross-branch dedup.
+- **Page identity (4):** a page is its slug on the user's branch; `main` is just where merged content lands.
+
+Pages the user hasn't touched stay equal to `main` because the branch is kept current by **rebasing onto `main`** (see lifecycle). Staleness (3) is therefore a rebase concern, not a view concern.
+
+### Branches
+
+- **`user/{id}`** — the user's long-lived working branch (what they see and edit). Every write re-commits with `parent = merge-base(user/{id}, main)`, so the branch carries **exactly one in-progress working commit** on top of `main` — not a pile of autosave commits. Continuing a task keeps amending that one commit.
+- **`pr/{submission-id}`** — a **snapshot branch** created at submit time, kept separate from the live `user/{id}` so review is stable. It is the unit that gets reviewed and merged.
+
+### Lifecycle
+
+1. **Edit** → amend the single working commit on `user/{id}`.
+2. **Submit** (whole branch; user chooses when, typically after finishing one task) → rebase the work onto the current `main`, then snapshot it as `pr/{id}` with a frozen base commit `S`.
+3. **Review changes** → made through the **review UI** against `pr/{id}`: a single review-fix commit `R` is added on top of `S` and **amended** across further change requests. `S` never moves, so `S` vs `R` is always a clean "what review changed" diff.
+4. **Merge** → squash `S + R` into one commit, rebase onto the current `main`, **fast-forward**. `main` stays **linear** — no two-parent merge commits. A rebase conflict returns **409** for the author to resolve.
+5. **After merge** → `user/{id}` is rebased onto the new `main` (lazily, on next access). Because the merged content came from this user, this is usually a no-op or trivial; genuine conflicts are surfaced for the user to resolve.
+
+### Deliberately out of scope (for now)
+
+- **No branch switching in the main editing UI.** A user only ever edits `user/{id}` directly; editing a PR happens inside the review screen, against `pr/{id}`.
+- **One in-flight submission per branch** (matches the "finish a task, then submit" workflow). Concurrent PRs per user are not supported yet.
 
 ## Impact
 
-- Search should index the user's "effective view" (overlay of main + their drafts)
-- Avoid surfacing duplicate versions of the same page
-- Need a rebase/sync mechanism for stale drafts
+- View reads a single branch — no overlay/dedup logic; search indexes the user's branch tree.
+- Replaces the placeholder reviewer-authored re-commit (no conflict detection) with a real rebase + squash merge; see #56.
+- A submission references the frozen `pr/{id}` snapshot, **not** the live `user/{id}` tip — edits made after submit can never silently change what was reviewed.
+- `main` history is linear: one squash commit per merged submission, authored by the submitter.
+- Stale drafts (problem 3) are resolved by rebasing `user/{id}` onto `main`; conflicts are the user's to resolve.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -606,3 +606,23 @@ export async function rejectTransfer(transferId: string): Promise<TransferRespon
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
+
+export interface SyncResult {
+  /** "up_to_date" | "updated" | "conflict" */
+  status: string;
+  conflicts: string[];
+}
+
+/** Rebase a draft branch onto main (the "Sync with main" button). */
+export async function syncBranch(workspaceSlug: string, branch: string): Promise<SyncResult> {
+  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/rebase`, {
+    method: 'POST',
+    headers: h({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ branch }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || `Request failed: ${res.status}`);
+  }
+  return res.json();
+}

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -21,7 +21,7 @@ import {
   compile, submit, renameWorkspace,
   deleteWorkspace,
   listPublicWorkspaces, joinWorkspace,
-  listSources, getSource, listReviews,
+  listSources, getSource, listReviews, syncBranch,
   type Workspace, type PageMeta, type PageFull, type SourceItem, type SourceContent,
 } from '../api';
 import { AddSourceDialog } from '@/components/AddSourceDialog';
@@ -90,6 +90,7 @@ export function MainLayout() {
   }, [message]);
   const [searchQuery, setSearchQuery] = useState('');
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [syncing, setSyncing] = useState(false);
 
   // Team space management state
   const [showInviteDialog, setShowInviteDialog] = useState<Workspace | null>(null);
@@ -388,6 +389,30 @@ export function MainLayout() {
     }
   };
 
+  // Sync the user's draft branch with main (rebase). Conflicts are surfaced for now;
+  // proper in-app resolution is a follow-up.
+  const handleSync = async () => {
+    if (!activeWorkspace) return;
+    setSyncing(true);
+    setMessage(null);
+    try {
+      const res = await syncBranch(activeWorkspace.slug, userBranch);
+      if (res.status === 'conflict') {
+        setMessage({ text: `Conflict with main — resolve: ${res.conflicts.join(', ')}`, type: 'error' });
+      } else {
+        setMessage({
+          text: res.status === 'updated' ? 'Synced with main.' : 'Already up to date.',
+          type: 'success',
+        });
+        if (res.status === 'updated') loadWorkspaces();
+      }
+    } catch (e) {
+      setMessage({ text: e instanceof Error ? e.message : 'Sync failed', type: 'error' });
+    } finally {
+      setSyncing(false);
+    }
+  };
+
   // Tab navigation
   const handleTabChange = (tab: NavTab) => {
     if (!activeWorkspace) return;
@@ -633,6 +658,18 @@ export function MainLayout() {
                 </div>
 
 
+
+                {/* Sync draft branch with main */}
+                {activeWorkspace && (
+                  <button
+                    onClick={handleSync}
+                    disabled={syncing}
+                    style={{ ...headerBtnStyle, opacity: syncing ? 0.4 : 1 }}
+                    title="Sync your draft with the latest main"
+                  >
+                    <RefreshCw size={13} className={syncing ? 'animate-spin' : ''} /> Sync
+                  </button>
+                )}
 
                 {/* Wiki-specific actions */}
                 {activeTab === 'wiki' && (activeView?.kind === 'page' || activeView?.kind === 'source') && (


### PR DESCRIPTION
## What & why

Implements the submission/merge model settled in **ADR 0004** and replaces the placeholder "merge". Supersedes #62/#72 (closed), closes #56.

The old merge re-read each page from the live branch and re-committed it onto `main` as the **reviewer**, with no conflict detection, and **self-deadlocked** on the first real approve. Worse, a submission referenced the live `user/{id}` tip — edits after submit silently changed what got merged (reviewed content ≠ merged content).

## The model (ADR 0004)

- **`user/{id}`** — the user's only working branch. Every edit re-commits with `parent = merge-base(branch, main)` → the branch always carries **exactly one working commit** (amend, no autosave piles).
- **Submit** = mandatory rebase onto `main` (**409** on conflict) → freeze the whole branch as **`pr/{id}`** + frozen base ref `S`. No partial/per-page submission.
- **Review changes** = a single commit `R` on top of frozen `S`, **amended** across rounds (edited via the review screen: `POST .../reviews/{id}/edit`). `S` never moves → `S→R` is always the clean review diff. Post-approval edits reset status to pending.
- **Merge** = squash `S+R` into **one single-parent commit**, fast-forward `main` — linear history, authored by the **submitter**; conflict → **409**, nothing written. Snapshot refs cleaned up afterwards; author's branch is caught up to the new main.
- **Sync button** (`POST .../rebase` + header UI) lets users rebase their draft onto main anytime; it's also enforced before submit.
- Personal-space `skip_review` = snapshot → merge immediately (submit ≈ commit).

## Key guarantees (all unit-tested, 8 tests)

- **No post-submit leak**: edits after submit can never change what was reviewed/merged (`post_submit_edits_do_not_leak_into_merge`)
- **No deadlock**: single lock per op, lock-free bodies; timeout-guarded regression test
- **Linear `main`**: one squash commit per submission, no two-parent merge nodes
- Conflict detection at rebase & merge, surfaced as HTTP **409**

## Also

- `perf(submit)`: AI summary now generated in the background — submit returns immediately with a diff-based placeholder (was ~9s blocking on the LLM, ~75s hang when OpenAI unreachable)
- Page **deletion** is out of scope → tracked in #75
- `cargo fmt` / `build --workspace` / all tests green (git 8, db 65, server 28, others)

## Commits (reviewable in order)

1. `docs(adr)` — the decided model in ADR 0004
2. `feat(git)` — core git engine + server wiring (one implementation commit)
3. `feat(web)` — Sync-with-main header button
4. `perf(submit)` — async AI summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)