### PR TITLE
feat: in-page editing, rename/delete paths, review UI per design + #78 security fixes

### DIFF
--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -156,6 +156,76 @@ fn set_path_in_tree(
     builder.write()
 }
 
+/// Insert an arbitrary object (blob or subtree) at `segments` inside `base_tree`,
+/// rebuilding only the touched subtrees in memory. `filemode` is `0o100644` for files
+/// and `0o040000` for trees. Returns the new tree oid.
+fn insert_entry_in_tree(
+    repo: &Repository,
+    base_tree: Option<&git2::Tree>,
+    segments: &[&str],
+    oid: git2::Oid,
+    filemode: i32,
+) -> Result<git2::Oid, git2::Error> {
+    let mut builder = repo.treebuilder(base_tree)?;
+    let existing = base_tree.and_then(|t| t.get_name(segments[0]));
+    if segments.len() == 1 {
+        builder.insert(segments[0], oid, filemode)?;
+    } else {
+        if existing.as_ref().and_then(|e| e.kind()) == Some(git2::ObjectType::Blob) {
+            return Err(git2::Error::from_str(&format!(
+                "cannot create directory over existing file '{}'",
+                segments[0]
+            )));
+        }
+        let sub_base = existing.and_then(|e| repo.find_tree(e.id()).ok());
+        let sub_oid = insert_entry_in_tree(repo, sub_base.as_ref(), &segments[1..], oid, filemode)?;
+        builder.insert(segments[0], sub_oid, 0o040000)?;
+    }
+    builder.write()
+}
+
+/// Remove the entry at `segments` from `base_tree`, rebuilding only the touched subtrees
+/// in memory and pruning subtrees that become empty. Returns the new tree oid, or `None`
+/// if the tree itself ended up empty (the caller then removes the parent entry).
+/// Errors if the path does not exist.
+fn remove_path_in_tree(
+    repo: &Repository,
+    base_tree: &git2::Tree,
+    segments: &[&str],
+) -> Result<Option<git2::Oid>, git2::Error> {
+    let mut builder = repo.treebuilder(Some(base_tree))?;
+    if segments.len() == 1 {
+        if base_tree.get_name(segments[0]).is_none() {
+            return Err(git2::Error::from_str(&format!(
+                "path component '{}' not found",
+                segments[0]
+            )));
+        }
+        builder.remove(segments[0])?;
+    } else {
+        let entry = base_tree.get_name(segments[0]).ok_or_else(|| {
+            git2::Error::from_str(&format!("path component '{}' not found", segments[0]))
+        })?;
+        let sub = repo
+            .find_tree(entry.id())
+            .map_err(|_| git2::Error::from_str(&format!("'{}' is not a directory", segments[0])))?;
+        match remove_path_in_tree(repo, &sub, &segments[1..])? {
+            Some(sub_oid) => {
+                builder.insert(segments[0], sub_oid, 0o040000)?;
+            }
+            None => {
+                builder.remove(segments[0])?;
+            }
+        }
+    }
+    let oid = builder.write()?;
+    if repo.find_tree(oid)?.len() == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(oid))
+    }
+}
+
 /// Create a commit object for `tree_oid` with the given parents, **without** moving any
 /// ref (the caller updates refs explicitly). Lock-free; returns the new commit oid.
 fn commit_tree(
@@ -355,6 +425,96 @@ impl WikiRepo {
         let blob = repo.blob(content)?;
         let segments: Vec<&str> = file_path.split('/').collect();
         let tree_oid = set_path_in_tree(&repo, Some(&tip.tree()?), &segments, blob)?;
+        let new_oid = commit_tree(&repo, tree_oid, message, author, &[&base])?;
+        repo.reference(&format!("refs/heads/{branch}"), new_oid, true, message)?;
+        Ok(())
+    }
+
+    /// Delete a file or an entire directory at `path` on `branch`, folded into the
+    /// branch's single working commit (same amend semantics as `write_file`). Deletions
+    /// flow through submit → snapshot → merge like any other change: the 3-way merge
+    /// propagates the removal, and a main-side edit to a deleted page conflicts.
+    pub fn delete_path(
+        &self,
+        branch: &str,
+        path: &str,
+        message: &str,
+        author: &str,
+    ) -> Result<(), git2::Error> {
+        let lock = self.branch_lock(branch);
+        let _guard = lock.write().unwrap();
+        let repo = self.repo()?;
+
+        let main_oid = repo
+            .find_branch("main", BranchType::Local)?
+            .get()
+            .peel_to_commit()?
+            .id();
+        let tip = repo
+            .find_branch(branch, BranchType::Local)?
+            .get()
+            .peel_to_commit()?;
+        let base_oid = repo
+            .merge_base(tip.id(), main_oid)
+            .unwrap_or_else(|_| tip.id());
+        let base = repo.find_commit(base_oid)?;
+
+        let segments: Vec<&str> = path.split('/').collect();
+        let tree_oid = remove_path_in_tree(&repo, &tip.tree()?, &segments)?
+            .unwrap_or_else(|| tip.tree().map(|t| t.id()).unwrap_or_else(|_| base_oid));
+        let new_oid = commit_tree(&repo, tree_oid, message, author, &[&base])?;
+        repo.reference(&format!("refs/heads/{branch}"), new_oid, true, message)?;
+        Ok(())
+    }
+
+    /// Rename/move a file or an entire directory from `from` to `to` on `branch`, folded
+    /// into the branch's single working commit. The object (blob or whole subtree) is
+    /// re-inserted at the new path, then removed from the old one — content unchanged.
+    pub fn rename_path(
+        &self,
+        branch: &str,
+        from: &str,
+        to: &str,
+        message: &str,
+        author: &str,
+    ) -> Result<(), git2::Error> {
+        let lock = self.branch_lock(branch);
+        let _guard = lock.write().unwrap();
+        let repo = self.repo()?;
+
+        let main_oid = repo
+            .find_branch("main", BranchType::Local)?
+            .get()
+            .peel_to_commit()?
+            .id();
+        let tip = repo
+            .find_branch(branch, BranchType::Local)?
+            .get()
+            .peel_to_commit()?;
+        let base_oid = repo
+            .merge_base(tip.id(), main_oid)
+            .unwrap_or_else(|_| tip.id());
+        let base = repo.find_commit(base_oid)?;
+        let tip_tree = tip.tree()?;
+
+        let entry = tip_tree
+            .get_path(Path::new(from))
+            .map_err(|_| git2::Error::from_str(&format!("'{from}' not found")))?;
+        let (oid, mode) = match entry.kind() {
+            Some(git2::ObjectType::Blob) => (entry.id(), 0o100644),
+            Some(git2::ObjectType::Tree) => (entry.id(), 0o040000),
+            _ => return Err(git2::Error::from_str(&format!("'{from}' is not movable"))),
+        };
+        if tip_tree.get_path(Path::new(to)).is_ok() {
+            return Err(git2::Error::from_str(&format!("'{to}' already exists")));
+        }
+
+        let to_segments: Vec<&str> = to.split('/').collect();
+        let with_new = insert_entry_in_tree(&repo, Some(&tip_tree), &to_segments, oid, mode)?;
+        let from_segments: Vec<&str> = from.split('/').collect();
+        let with_new_tree = repo.find_tree(with_new)?;
+        let tree_oid =
+            remove_path_in_tree(&repo, &with_new_tree, &from_segments)?.unwrap_or(with_new);
         let new_oid = commit_tree(&repo, tree_oid, message, author, &[&base])?;
         repo.reference(&format!("refs/heads/{branch}"), new_oid, true, message)?;
         Ok(())
@@ -614,6 +774,10 @@ impl WikiRepo {
     ) -> Result<MergeOutcome, git2::Error> {
         let lock = self.branch_lock("main");
         let _guard = lock.write().unwrap();
+        // Also hold the PR-branch lock so a concurrent review-fix can't move the tip
+        // mid-merge. Lock order is always main → pr (no caller takes pr → main).
+        let pr_lock = self.branch_lock(&format!("pr/{id}"));
+        let _pr_guard = pr_lock.write().unwrap();
         let repo = self.repo()?;
 
         let main_commit = repo
@@ -1005,6 +1169,121 @@ mod tests {
         repo.cleanup_submission("subk");
         assert!(g.find_branch("pr/subk", BranchType::Local).is_err());
         assert!(g.refname_to_id("refs/cowiki/base/subk").is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// delete_path removes a page (and prunes emptied directories), keeps the branch at a
+    /// single working commit, and the deletion survives snapshot + merge into main.
+    #[test]
+    fn delete_page_flows_through_merge() {
+        let (repo, dir) = temp_repo("delete");
+        // land a nested page on main first
+        repo.ensure_branch_exists("user/d1").unwrap();
+        repo.write_file("user/d1", "wiki/guides/a.md", b"a\n", "edit", "d")
+            .unwrap();
+        repo.write_file("user/d1", "wiki/keep.md", b"keep\n", "edit", "d")
+            .unwrap();
+        repo.create_pr_snapshot("user/d1", "s1").unwrap();
+        repo.merge_pr("s1", "d", "land").unwrap();
+        let _ = repo.rebase_onto_main("user/d1");
+
+        // delete the nested page on the branch
+        repo.delete_path("user/d1", "wiki/guides/a.md", "delete a", "d")
+            .unwrap();
+        assert!(read(&repo, "user/d1", "wiki/guides/a.md").is_none());
+        assert_eq!(
+            read(&repo, "user/d1", "wiki/keep.md").as_deref(),
+            Some("keep\n")
+        );
+        // still a single working commit on top of main
+        let g = git(&dir);
+        let c = g
+            .find_branch("user/d1", BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap();
+        assert_eq!(c.parent_count(), 1);
+        assert_eq!(c.parent_id(0).unwrap(), tip(&g, "main"));
+
+        // deletion lands on main through snapshot + merge
+        repo.create_pr_snapshot("user/d1", "s2").unwrap();
+        assert_eq!(
+            repo.merge_pr("s2", "d", "rm").unwrap(),
+            MergeOutcome::Merged
+        );
+        assert!(read(&repo, "main", "wiki/guides/a.md").is_none());
+        assert_eq!(
+            read(&repo, "main", "wiki/keep.md").as_deref(),
+            Some("keep\n")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// delete_path on a directory removes the whole subtree.
+    #[test]
+    fn delete_folder_removes_subtree() {
+        let (repo, dir) = temp_repo("delete-folder");
+        repo.ensure_branch_exists("user/d2").unwrap();
+        repo.write_file("user/d2", "wiki/proj/_index.md", b"i\n", "e", "d")
+            .unwrap();
+        repo.write_file("user/d2", "wiki/proj/x.md", b"x\n", "e", "d")
+            .unwrap();
+        repo.write_file("user/d2", "wiki/other.md", b"o\n", "e", "d")
+            .unwrap();
+        repo.delete_path("user/d2", "wiki/proj", "rm folder", "d")
+            .unwrap();
+        assert!(read(&repo, "user/d2", "wiki/proj/_index.md").is_none());
+        assert!(read(&repo, "user/d2", "wiki/proj/x.md").is_none());
+        assert_eq!(
+            read(&repo, "user/d2", "wiki/other.md").as_deref(),
+            Some("o\n")
+        );
+        // deleting a missing path errors
+        assert!(repo
+            .delete_path("user/d2", "wiki/proj", "again", "d")
+            .is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// rename_path moves a file and an entire folder subtree, refusing to overwrite.
+    #[test]
+    fn rename_file_and_folder() {
+        let (repo, dir) = temp_repo("rename");
+        repo.ensure_branch_exists("user/r").unwrap();
+        repo.write_file("user/r", "wiki/old.md", b"body\n", "e", "r")
+            .unwrap();
+        repo.rename_path("user/r", "wiki/old.md", "wiki/new.md", "mv", "r")
+            .unwrap();
+        assert!(read(&repo, "user/r", "wiki/old.md").is_none());
+        assert_eq!(
+            read(&repo, "user/r", "wiki/new.md").as_deref(),
+            Some("body\n")
+        );
+
+        // folder move keeps children
+        repo.write_file("user/r", "wiki/dir/a.md", b"a\n", "e", "r")
+            .unwrap();
+        repo.write_file("user/r", "wiki/dir/sub/b.md", b"b\n", "e", "r")
+            .unwrap();
+        repo.rename_path("user/r", "wiki/dir", "wiki/moved", "mv dir", "r")
+            .unwrap();
+        assert!(read(&repo, "user/r", "wiki/dir/a.md").is_none());
+        assert_eq!(
+            read(&repo, "user/r", "wiki/moved/a.md").as_deref(),
+            Some("a\n")
+        );
+        assert_eq!(
+            read(&repo, "user/r", "wiki/moved/sub/b.md").as_deref(),
+            Some("b\n")
+        );
+
+        // refuses to overwrite an existing target
+        repo.write_file("user/r", "wiki/exists.md", b"x\n", "e", "r")
+            .unwrap();
+        assert!(repo
+            .rename_path("user/r", "wiki/new.md", "wiki/exists.md", "mv", "r")
+            .is_err());
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/db/src/submissions.rs
+++ b/crates/db/src/submissions.rs
@@ -14,6 +14,12 @@ pub struct Submission {
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub reviewed_by: Option<Uuid>,
     pub reviewed_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Display name of the submitting user (joined in read queries; absent on writes).
+    #[sqlx(default)]
+    pub author_name: Option<String>,
+    /// Display name of the reviewer, when reviewed (joined in read queries).
+    #[sqlx(default)]
+    pub reviewer_name: Option<String>,
 }
 
 pub async fn create(
@@ -42,9 +48,11 @@ pub async fn list_pending_for_workspace(
     workspace_slug: &str,
 ) -> sqlx::Result<Vec<Submission>> {
     sqlx::query_as::<_, Submission>(
-        "SELECT * FROM submissions \
-         WHERE status IN ('pending', 'approved', 'rejected', 'merged') AND workspace_slug = $1 \
-         ORDER BY created_at DESC",
+        "SELECT s.*, u.name AS author_name, r.name AS reviewer_name FROM submissions s \
+         JOIN users u ON u.id = s.user_id \
+         LEFT JOIN users r ON r.id = s.reviewed_by \
+         WHERE s.status IN ('pending', 'approved', 'rejected', 'merged') AND s.workspace_slug = $1 \
+         ORDER BY s.created_at DESC",
     )
     .bind(workspace_slug)
     .fetch_all(pool)
@@ -56,14 +64,19 @@ pub async fn list_pending_for_workspace(
 }
 
 pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Submission>> {
-    sqlx::query_as::<_, Submission>("SELECT * FROM submissions WHERE id = $1")
-        .bind(id)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| {
-            tracing::error!("DB find submission by id failed: {e}");
-            e
-        })
+    sqlx::query_as::<_, Submission>(
+        "SELECT s.*, u.name AS author_name, r.name AS reviewer_name FROM submissions s \
+         JOIN users u ON u.id = s.user_id \
+         LEFT JOIN users r ON r.id = s.reviewed_by \
+         WHERE s.id = $1",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!("DB find submission by id failed: {e}");
+        e
+    })
 }
 
 pub async fn update_status(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -217,6 +217,15 @@ async fn main() {
             "/api/workspaces/{ws_slug}/folders",
             post(routes::pages::create_folder_ws),
         )
+        // Path ops on the caller's draft branch (files & folders under wiki/ only)
+        .route(
+            "/api/workspaces/{ws_slug}/paths/rename",
+            post(routes::pages::rename_path_ws),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/paths/delete",
+            post(routes::pages::delete_path_ws),
+        )
         .route(
             "/api/workspaces/{ws_slug}/pages/{*slug}",
             get(routes::pages::get_page_ws),

--- a/crates/server/src/routes/pages.rs
+++ b/crates/server/src/routes/pages.rs
@@ -173,8 +173,14 @@ pub async fn get_page_ws(
 pub async fn write_page_ws(
     State(state): State<Arc<AppState>>,
     Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
     Json(input): Json<WritePage>,
 ) -> Result<Json<serde_json::Value>> {
+    // Writes go through membership + write permission and only ever land on the caller's
+    // own draft branch; main changes exclusively via merge_pr.
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
+    require_own_branch(&input.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)
@@ -187,7 +193,7 @@ pub async fn write_page_ws(
         &path,
         input.body.as_bytes(),
         &format!("edit: {}", input.slug),
-        &input.branch,
+        &guard.user.name,
     )
     .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(Json(serde_json::json!({"ok": true, "slug": input.slug})))
@@ -196,8 +202,12 @@ pub async fn write_page_ws(
 pub async fn create_folder_ws(
     State(state): State<Arc<AppState>>,
     Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
     Json(input): Json<CreateFolder>,
 ) -> Result<Json<serde_json::Value>> {
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
+    require_own_branch(&input.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)
@@ -224,7 +234,7 @@ pub async fn create_folder_ws(
         &index_path,
         body.as_bytes(),
         &format!("create folder: {}", input.name),
-        &input.branch,
+        &guard.user.name,
     )
     .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(Json(
@@ -393,4 +403,101 @@ fn list_pages_from_repo(
 
     let tree = build_level(&items, "", branch);
     Ok(Json(tree))
+}
+
+// ── Path operations: rename / delete (files and folders under wiki/) ──
+
+/// Validate a repo path for destructive ops: must be inside `wiki/` (so `sources/` and
+/// other special trees are untouchable), no traversal, no empty segments, and never the
+/// `wiki` root itself.
+fn validate_wiki_path(p: &str) -> Result<()> {
+    let ok = p.starts_with("wiki/")
+        && p.len() > 5
+        && !p.ends_with('/')
+        && p.split('/')
+            .all(|seg| !seg.is_empty() && seg != "." && seg != "..");
+    if !ok {
+        return Err(AppError::BadRequest(format!(
+            "invalid path '{p}': only paths inside wiki/ can be modified"
+        )));
+    }
+    Ok(())
+}
+
+/// Mutating ops only touch the caller's own draft branch — never main, pr/* snapshots,
+/// or other users' branches (all writes flow to main exclusively through merge_pr).
+pub(crate) fn require_own_branch(branch: &str, user_id: uuid::Uuid) -> Result<()> {
+    if branch != format!("user/{user_id}") {
+        return Err(AppError::Forbidden(
+            "writes are only allowed on your own draft branch".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+pub struct RenamePathRequest {
+    pub branch: String,
+    pub from: String,
+    pub to: String,
+}
+
+pub async fn rename_path_ws(
+    State(state): State<Arc<AppState>>,
+    Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
+    Json(input): Json<RenamePathRequest>,
+) -> Result<Json<serde_json::Value>> {
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
+    require_own_branch(&input.branch, guard.user.id)?;
+    validate_wiki_path(&input.from)?;
+    validate_wiki_path(&input.to)?;
+
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
+        .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
+    ensure_user_branch_if_needed(&repo, &input.branch)?;
+    repo.rename_path(
+        &input.branch,
+        &input.from,
+        &input.to,
+        &format!("rename: {} -> {}", input.from, input.to),
+        &guard.user.name,
+    )
+    .map_err(|e| AppError::BadRequest(e.to_string()))?;
+    Ok(Json(serde_json::json!({"ok": true})))
+}
+
+#[derive(Deserialize)]
+pub struct DeletePathRequest {
+    pub branch: String,
+    pub path: String,
+}
+
+pub async fn delete_path_ws(
+    State(state): State<Arc<AppState>>,
+    Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
+    Json(input): Json<DeletePathRequest>,
+) -> Result<Json<serde_json::Value>> {
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
+    require_own_branch(&input.branch, guard.user.id)?;
+    validate_wiki_path(&input.path)?;
+
+    let repo = state
+        .repo_manager
+        .get(&ws_slug)
+        .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
+    ensure_user_branch_if_needed(&repo, &input.branch)?;
+    repo.delete_path(
+        &input.branch,
+        &input.path,
+        &format!("delete: {}", input.path),
+        &guard.user.name,
+    )
+    .map_err(|e| AppError::BadRequest(e.to_string()))?;
+    Ok(Json(serde_json::json!({"ok": true})))
 }

--- a/crates/server/src/routes/review.rs
+++ b/crates/server/src/routes/review.rs
@@ -120,8 +120,10 @@ pub async fn review_action(
                 .map(|u| u.name)
                 .unwrap_or_else(|| guard.user.name.clone());
 
-            // Linear squash + rebase + fast-forward. A conflict with the current main
-            // means the author must rebase and resolve — surface it as 409.
+            // Linear squash + rebase + fast-forward. The snapshot is frozen, so a
+            // conflict with the now-advanced main can't be fixed in place — close this
+            // submission (refs cleaned up) and tell the author to sync & resubmit; the
+            // resubmit takes a fresh snapshot off the rebased branch.
             match repo
                 .merge_pr(
                     &submission.id.to_string(),
@@ -132,8 +134,11 @@ pub async fn review_action(
             {
                 cowiki_core::git::MergeOutcome::Merged => {}
                 cowiki_core::git::MergeOutcome::Conflict(paths) => {
+                    repo.cleanup_submission(&submission.id.to_string());
+                    cowiki_db::submissions::update_status(&state.db, id, "rejected", guard.user.id)
+                        .await?;
                     return Err(AppError::Conflict(format!(
-                        "merge conflicts with main; author must rebase and resolve: {}",
+                        "main has moved and this snapshot now conflicts ({}); submission closed — sync your branch and submit again",
                         paths.join(", ")
                     )));
                 }

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::error::{AppError, Result};
-use crate::routes::auth::extract_user;
+
 use crate::AppState;
 use cowiki_core::models::DuplicateWarning;
 
@@ -30,7 +30,13 @@ pub async fn submit(
     headers: axum::http::HeaderMap,
     Json(input): Json<SubmitRequest>,
 ) -> Result<Json<SubmitResponse>> {
-    let user = extract_user(&state.db, &headers).await?;
+    // Membership + write permission, and the branch must be the caller's own draft —
+    // submit force-rewrites the named ref (rebase), so an arbitrary branch here would
+    // let any user rewrite another user's branch or a frozen pr/* snapshot.
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
+    super::pages::require_own_branch(&input.branch, guard.user.id)?;
+    let user = guard.user.clone();
     let repo = state
         .repo_manager
         .get(&ws_slug)
@@ -129,7 +135,10 @@ pub async fn submit(
 
         // Personal Space: snapshot the whole branch and merge straight to main. One
         // writer, so this never conflicts — every submit is effectively a commit.
-        let pr_id = format!("personal-{}", input.branch.replace('/', "-"));
+        // Unique per submit: a branch-derived id would collide across concurrent submits
+        // (double-click/retry) — one request's cleanup would delete the ref the other is
+        // about to merge.
+        let pr_id = format!("personal-{}", uuid::Uuid::new_v4());
         repo.create_pr_snapshot(&input.branch, &pr_id)
             .map_err(|e| AppError::Internal(e.to_string()))?;
         let outcome = repo
@@ -219,7 +228,12 @@ pub async fn rebase(
     headers: axum::http::HeaderMap,
     Json(input): Json<RebaseRequest>,
 ) -> Result<Json<RebaseResponse>> {
-    let _user = extract_user(&state.db, &headers).await?;
+    // Same gate as submit: members with write permission only, and only on the caller's
+    // own draft branch — rebase force-rewrites the ref, so pr/*, main, and other users'
+    // branches must be unreachable from here.
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
+    super::pages::require_own_branch(&input.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -626,3 +626,23 @@ export async function syncBranch(workspaceSlug: string, branch: string): Promise
   }
   return res.json();
 }
+
+/** Rename/move a file or folder on your draft branch. Paths are repo paths (wiki/...). */
+export async function renamePath(workspaceSlug: string, branch: string, from: string, to: string): Promise<void> {
+  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/paths/rename`, {
+    method: 'POST',
+    headers: h({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ branch, from, to }),
+  });
+  if (!res.ok) throw new Error(await res.text().catch(() => `Request failed: ${res.status}`));
+}
+
+/** Delete a file or an entire folder on your draft branch. Path is a repo path (wiki/...). */
+export async function deletePath(workspaceSlug: string, branch: string, path: string): Promise<void> {
+  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/paths/delete`, {
+    method: 'POST',
+    headers: h({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ branch, path }),
+  });
+  if (!res.ok) throw new Error(await res.text().catch(() => `Request failed: ${res.status}`));
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -31,6 +31,8 @@ export interface Submission {
   created_at: string;
   reviewed_by: string | null;
   reviewed_at: string | null;
+  author_name: string | null;
+  reviewer_name: string | null;
 }
 
 export interface DiffLine {
@@ -643,6 +645,16 @@ export async function deletePath(workspaceSlug: string, branch: string, path: st
     method: 'POST',
     headers: h({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({ branch, path }),
+  });
+  if (!res.ok) throw new Error(await res.text().catch(() => `Request failed: ${res.status}`));
+}
+
+/** Apply a review-requested change to a submission's pr/{id} snapshot (review screen edit). */
+export async function editReview(workspaceSlug: string, submissionId: string, path: string, content: string): Promise<void> {
+  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/reviews/${submissionId}/edit`, {
+    method: 'POST',
+    headers: h({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ path, content }),
   });
   if (!res.ok) throw new Error(await res.text().catch(() => `Request failed: ${res.status}`));
 }

--- a/web/src/components/PageEditor.tsx
+++ b/web/src/components/PageEditor.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Check, X } from 'lucide-react';
+import { C, fonts } from '@/lib/design';
+
+/**
+ * In-page markdown editor with GitHub-style Write / Preview tabs.
+ * Edits the raw page body (including the frontmatter block that defines
+ * title/summary); preview renders the body without frontmatter.
+ */
+export function PageEditor({
+  initialBody,
+  stripFrontmatter,
+  onSave,
+  onCancel,
+}: {
+  initialBody: string;
+  /** Same body→rendered-markdown transform the page view uses. */
+  stripFrontmatter: (body: string) => string;
+  onSave: (body: string) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [body, setBody] = useState(initialBody);
+  const [tab, setTab] = useState<'write' | 'preview'>('write');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const dirty = body !== initialBody;
+
+  // Cmd/Ctrl+S saves, Esc cancels.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault();
+        void handleSave();
+      } else if (e.key === 'Escape') {
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [body, saving]);
+
+  const handleSave = async () => {
+    if (saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(body);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save');
+      setSaving(false);
+      return;
+    }
+    setSaving(false);
+  };
+
+  const tabBtn = (key: 'write' | 'preview', label: string) => (
+    <button
+      onClick={() => setTab(key)}
+      style={{
+        padding: '7px 16px', fontSize: 13, fontWeight: tab === key ? 600 : 450,
+        color: tab === key ? C.ink : C.muted, background: tab === key ? C.panel : 'transparent',
+        border: 'none', borderBottom: tab === key ? `2px solid ${C.accent}` : '2px solid transparent',
+        cursor: 'pointer', marginBottom: -1,
+      }}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div style={{ border: `1px solid ${C.line}`, borderRadius: 12, overflow: 'hidden', background: C.panel }}>
+      {/* Tab bar */}
+      <div style={{
+        display: 'flex', alignItems: 'center', background: C.bg,
+        borderBottom: `1px solid ${C.line}`, padding: '0 8px',
+      }}>
+        {tabBtn('write', 'Write')}
+        {tabBtn('preview', 'Preview')}
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px' }}>
+          {error && <span style={{ fontSize: 12.5, color: C.red, maxWidth: 380, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{error}</span>}
+          <button
+            onClick={onCancel}
+            disabled={saving}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 5, padding: '6px 12px', borderRadius: 7,
+              fontSize: 12.5, fontWeight: 550, color: C.ink2, background: '#fff',
+              border: `1px solid ${C.line}`, cursor: 'pointer',
+            }}
+          >
+            <X size={13} /> Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || !dirty}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 5, padding: '6px 14px', borderRadius: 7,
+              fontSize: 12.5, fontWeight: 600, color: '#fff',
+              background: dirty ? C.accent : C.faint,
+              border: 'none', cursor: dirty ? 'pointer' : 'default',
+              opacity: saving ? 0.6 : 1,
+            }}
+          >
+            <Check size={13} /> {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+
+      {/* Body */}
+      {tab === 'write' ? (
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          spellCheck={false}
+          autoFocus
+          style={{
+            display: 'block', width: '100%', minHeight: 460, padding: '16px 20px',
+            border: 'none', outline: 'none', resize: 'vertical', boxSizing: 'border-box',
+            fontFamily: fonts.mono, fontSize: 13.5, lineHeight: 1.65, color: C.ink,
+            background: C.panel,
+          }}
+        />
+      ) : (
+        <div className="prose" style={{ padding: '16px 24px', minHeight: 460 }}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{stripFrontmatter(body)}</ReactMarkdown>
+        </div>
+      )}
+
+      {/* Footer hint */}
+      <div style={{
+        padding: '7px 14px', borderTop: `1px solid ${C.lineSoft}`, background: C.bg,
+        fontSize: 11.5, color: C.faint, display: 'flex', gap: 14,
+      }}>
+        <span>Markdown supported</span>
+        <span>The top <code style={{ fontFamily: fonts.mono }}>---</code> frontmatter block sets the page title & summary</span>
+        <span style={{ marginLeft: 'auto' }}>⌘S to save · Esc to cancel</span>
+      </div>
+    </div>
+  );
+}
+
+export default PageEditor;

--- a/web/src/components/layout/SpacePanel.tsx
+++ b/web/src/components/layout/SpacePanel.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import {
   ChevronRight, FileText, Folder, Upload, Wand2,
   MoreHorizontal, Plus, FolderPlus, Settings, BookOpen, GitPullRequest, Users, Activity,
-  CheckCircle2, Clock, FileCode,
+  CheckCircle2, Clock, FileCode, Pencil, Trash2,
 } from 'lucide-react';
 import type { Workspace, PageMeta, SourceItem } from '../../api';
 import {
@@ -29,6 +29,9 @@ interface SpacePanelProps {
   onNewFolder: () => void;
   onAddPageInFolder: (folderPath: string) => void;
   onAddFolderInFolder: (parentPath: string) => void;
+  /** path is the repo path: wiki/<slug>.md for pages, wiki/<dir> for folders */
+  onRenamePath: (path: string, isFolder: boolean, title: string) => void;
+  onDeletePath: (path: string, isFolder: boolean, title: string) => void;
   onShowIngest: () => void;
   onCompile: () => void;
   onSettings?: () => void;
@@ -51,6 +54,8 @@ export function SpacePanel({
   onNewFolder,
   onAddPageInFolder,
   onAddFolderInFolder,
+  onRenamePath,
+  onDeletePath,
   onShowIngest,
   onCompile,
   onSettings,
@@ -191,6 +196,8 @@ export function SpacePanel({
                 onSelectPage={onSelectPage}
                 onAddPageInFolder={onAddPageInFolder}
                 onAddFolderInFolder={onAddFolderInFolder}
+                onRenamePath={onRenamePath}
+                onDeletePath={onDeletePath}
               />
             ))
           )}
@@ -305,6 +312,8 @@ function PageTreeItem({
   onSelectPage,
   onAddPageInFolder,
   onAddFolderInFolder,
+  onRenamePath,
+  onDeletePath,
 }: {
   page: PageMeta;
   activePage: string | null;
@@ -312,10 +321,13 @@ function PageTreeItem({
   onSelectPage: (slug: string) => void;
   onAddPageInFolder: (folderPath: string) => void;
   onAddFolderInFolder: (parentPath: string) => void;
+  onRenamePath: (path: string, isFolder: boolean, title: string) => void;
+  onDeletePath: (path: string, isFolder: boolean, title: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const pl = depth * 14;
   const isActive = activePage === page.slug;
+  const title = page.title || page.slug;
 
   if (page.kind === 'folder') {
     const folderPath = 'wiki/' + page.slug.replace('/_index', '');
@@ -329,32 +341,36 @@ function PageTreeItem({
           }}
           onMouseEnter={(e) => {
             e.currentTarget.style.background = C.rail;
-            const btn = e.currentTarget.querySelector('[data-folder-add]') as HTMLElement | null;
+            const btn = e.currentTarget.querySelector('[data-row-menu]') as HTMLElement | null;
             if (btn) btn.style.opacity = '1';
           }}
           onMouseLeave={(e) => {
             e.currentTarget.style.background = 'transparent';
-            const btn = e.currentTarget.querySelector('[data-folder-add]') as HTMLElement | null;
+            const btn = e.currentTarget.querySelector('[data-row-menu]') as HTMLElement | null;
             if (btn) btn.style.opacity = '0';
           }}
         >
           <span onClick={() => setOpen(!open)} style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, userSelect: 'none', minWidth: 0 }}>
             <ChevronRight size={12} style={{ transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 0.15s', flexShrink: 0 }} />
             <Folder size={14} style={{ flexShrink: 0 }} />
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{page.title || page.slug}</span>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{title}</span>
           </span>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button data-folder-add onClick={(e) => e.stopPropagation()} style={{
+              <button data-row-menu onClick={(e) => e.stopPropagation()} style={{
                 background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: C.faint, display: 'flex',
                 opacity: 0, transition: 'opacity 0.1s',
               }}>
-                <Plus size={13} />
+                <MoreHorizontal size={13} />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuContent align="end" className="w-44">
               <DropdownMenuItem onClick={() => onAddPageInFolder(folderPath)}><FileText size={14} className="mr-2" /> New Page</DropdownMenuItem>
               <DropdownMenuItem onClick={() => onAddFolderInFolder(folderPath)}><FolderPlus size={14} className="mr-2" /> New Folder</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onRenamePath(folderPath, true, title)}><Pencil size={14} className="mr-2" /> Rename</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onDeletePath(folderPath, true, title)} className="text-red-600 focus:text-red-600">
+                <Trash2 size={14} className="mr-2" /> Delete folder
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
@@ -367,32 +383,58 @@ function PageTreeItem({
             onSelectPage={onSelectPage}
             onAddPageInFolder={onAddPageInFolder}
             onAddFolderInFolder={onAddFolderInFolder}
+            onRenamePath={onRenamePath}
+            onDeletePath={onDeletePath}
           />
         ))}
       </>
     );
   }
 
+  const pagePath = `wiki/${page.slug}.md`;
   return (
-    <button
-      onClick={() => onSelectPage(page.slug)}
+    <div
       style={{
-        display: 'flex', alignItems: 'center', gap: 8, width: '100%',
+        display: 'flex', alignItems: 'center', gap: 8,
         padding: '6px 10px', paddingLeft: 10 + pl, borderRadius: 6,
-        border: 'none', cursor: 'pointer', textAlign: 'left',
+        cursor: 'pointer', fontSize: 14,
         background: isActive ? 'rgba(0,0,0,0.05)' : 'transparent',
-        color: isActive ? C.ink : C.ink2, fontSize: 14,
+        color: isActive ? C.ink : C.ink2,
         fontWeight: isActive ? 550 : 400,
         boxShadow: isActive ? '0 1px 2px rgba(0,0,0,0.04)' : 'none',
       }}
-      onMouseEnter={(e) => { if (!isActive) e.currentTarget.style.background = C.rail; }}
-      onMouseLeave={(e) => { if (!isActive) e.currentTarget.style.background = 'transparent'; }}
+      onMouseEnter={(e) => {
+        if (!isActive) e.currentTarget.style.background = C.rail;
+        const btn = e.currentTarget.querySelector('[data-row-menu]') as HTMLElement | null;
+        if (btn) btn.style.opacity = '1';
+      }}
+      onMouseLeave={(e) => {
+        if (!isActive) e.currentTarget.style.background = 'transparent';
+        const btn = e.currentTarget.querySelector('[data-row-menu]') as HTMLElement | null;
+        if (btn) btn.style.opacity = '0';
+      }}
     >
-      <FileText size={14} />
-      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-        {page.title || page.slug}
+      <span onClick={() => onSelectPage(page.slug)} style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+        <FileText size={14} style={{ flexShrink: 0 }} />
+        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{title}</span>
       </span>
-    </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button data-row-menu onClick={(e) => e.stopPropagation()} style={{
+            background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: C.faint, display: 'flex',
+            opacity: 0, transition: 'opacity 0.1s',
+          }}>
+            <MoreHorizontal size={13} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuItem onClick={() => onRenamePath(pagePath, false, title)}><Pencil size={14} className="mr-2" /> Rename</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onDeletePath(pagePath, false, title)} className="text-red-600 focus:text-red-600">
+            <Trash2 size={14} className="mr-2" /> Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }
 

--- a/web/src/components/review/DiffView.tsx
+++ b/web/src/components/review/DiffView.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { MessageSquare, Check, ChevronDown, ChevronRight, Send, X, FileText } from 'lucide-react';
+import { MessageSquare, Check, ChevronDown, ChevronRight, Send, X, FileText, Pencil } from 'lucide-react';
 import type { FileDiff, DiffHunk, DiffLine, ReviewComment } from '../../api';
 import { C, fonts } from '@/lib/design';
 import { timeAgo } from '../../lib/time';
@@ -285,6 +285,7 @@ function FileDiffCard({
   onResolve,
   onUnresolve,
   onReply,
+  onEditSave,
 }: {
   file: FileDiff;
   comments: ReviewComment[];
@@ -292,9 +293,14 @@ function FileDiffCard({
   onResolve?: (id: string) => void;
   onUnresolve?: (id: string) => void;
   onReply?: (body: string, parentId: string) => void;
+  onEditSave?: (path: string, content: string) => Promise<void>;
 }) {
   const [collapsed, setCollapsed] = useState(false);
   const [composingLine, setComposingLine] = useState<number | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
   const status = fileStatus(file);
   const sc = statusColors[status];
   const fileComments = comments.filter((c) => c.file_path === file.path);
@@ -303,6 +309,27 @@ function FileDiffCard({
     onAddComment?.(file.path, lineNumber, body);
     setComposingLine(null);
   }, [file.path, onAddComment]);
+
+  const startEdit = () => {
+    setDraft(file.new_content ?? '');
+    setEditError(null);
+    setEditing(true);
+    setCollapsed(false);
+  };
+
+  const saveEdit = async () => {
+    if (!onEditSave || saving) return;
+    setSaving(true);
+    setEditError(null);
+    try {
+      await onEditSave(file.path, draft);
+      setEditing(false);
+    } catch (e) {
+      setEditError(e instanceof Error ? e.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <div style={{ border: `1px solid ${C.line}`, borderRadius: 12, overflow: 'hidden', background: '#fff' }}>
@@ -330,7 +357,67 @@ function FileDiffCard({
           {' '}
           <span style={{ color: C.red }}>-{file.deletions}</span>
         </span>
+        {onEditSave && file.new_content != null && !editing && (
+          <button
+            onClick={(e) => { e.stopPropagation(); startEdit(); }}
+            title="Edit this file in the review (amends the submission snapshot)"
+            style={{
+              display: 'flex', alignItems: 'center', gap: 4, padding: '3px 9px', borderRadius: 6,
+              border: `1px solid ${C.line}`, background: '#fff', color: C.ink2,
+              fontSize: 12, fontWeight: 550, cursor: 'pointer',
+            }}
+          >
+            <Pencil size={12} /> Edit
+          </button>
+        )}
       </div>
+
+      {/* Review-fix editor (edits the pr snapshot; S stays frozen, R is amended) */}
+      {editing && (
+        <div style={{ borderBottom: `1px solid ${C.line}` }}>
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            spellCheck={false}
+            autoFocus
+            style={{
+              display: 'block', width: '100%', minHeight: 280, padding: '12px 16px',
+              border: 'none', outline: 'none', resize: 'vertical', boxSizing: 'border-box',
+              fontFamily: mono, fontSize: 13, lineHeight: 1.6, color: C.ink, background: '#fff',
+            }}
+          />
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px',
+            background: C.bg, borderTop: `1px solid ${C.lineSoft}`,
+          }}>
+            <span style={{ fontSize: 12, color: C.faint }}>
+              Saves as a review fix on this submission — the diff below updates to include it.
+            </span>
+            {editError && <span style={{ fontSize: 12, color: C.red }}>{editError}</span>}
+            <button
+              onClick={() => setEditing(false)}
+              disabled={saving}
+              style={{
+                marginLeft: 'auto', padding: '5px 12px', borderRadius: 6, fontSize: 12.5, fontWeight: 550,
+                border: `1px solid ${C.line}`, background: '#fff', color: C.ink2, cursor: 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={saveEdit}
+              disabled={saving || draft === (file.new_content ?? '')}
+              style={{
+                padding: '5px 14px', borderRadius: 6, fontSize: 12.5, fontWeight: 600,
+                border: 'none', background: draft !== (file.new_content ?? '') ? C.accent : C.faint,
+                color: '#fff', cursor: 'pointer', opacity: saving ? 0.6 : 1,
+              }}
+            >
+              {saving ? 'Saving…' : 'Save review fix'}
+            </button>
+          </div>
+        </div>
+      )}
       {/* Diff body */}
       {!collapsed && (
         <div style={{ overflowX: 'auto' }}>
@@ -381,6 +468,7 @@ export function DiffView({
   onResolve,
   onUnresolve,
   onReply,
+  onEditSave,
 }: {
   diffs: FileDiff[];
   comments?: ReviewComment[];
@@ -388,6 +476,7 @@ export function DiffView({
   onResolve?: (id: string) => void;
   onUnresolve?: (id: string) => void;
   onReply?: (body: string, parentId: string) => void;
+  onEditSave?: (path: string, content: string) => Promise<void>;
 }) {
   if (!diffs.length) {
     return <p style={{ color: C.muted, fontSize: 14 }}>No file changes.</p>;
@@ -404,6 +493,7 @@ export function DiffView({
           onResolve={onResolve}
           onUnresolve={onUnresolve}
           onReply={onReply}
+          onEditSave={onEditSave}
         />
       ))}
     </div>

--- a/web/src/components/review/ReviewDetail.tsx
+++ b/web/src/components/review/ReviewDetail.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState, useCallback } from 'react';
 import { ArrowLeft, MessageSquare, XCircle, GitMerge, Check, AlertCircle, Plus } from 'lucide-react';
 import {
-  getReview, reviewAction, createComment, resolveComment, unresolveComment,
+  getReview, reviewAction, createComment, resolveComment, unresolveComment, editReview,
   type ReviewDetail as ReviewDetailData, type ReviewComment,
 } from '../../api';
 import { DiffView } from './DiffView';
 import { C, fonts } from '@/lib/design';
 import { timeAgo } from '../../lib/time';
+import { AvatarBadge } from '@/components/ui/avatar-badge';
 
 const statusBadge: Record<string, { bg: string; fg: string; label: string }> = {
   pending: { bg: C.amberSoft, fg: C.amber, label: 'Review needed' },
@@ -91,6 +92,15 @@ export function ReviewDetail({
     } catch { /* */ }
   }, [workspaceSlug, submissionId]);
 
+  // Review-screen edit of the pr/{id} snapshot. The backend amends a single review-fix
+  // commit on the frozen base and resets an approved submission to pending.
+  const handleEditFile = useCallback(async (path: string, content: string) => {
+    await editReview(workspaceSlug, submissionId, path, content);
+    const d = await getReview(workspaceSlug, submissionId);
+    setData(d);
+    setComments(d.comments ?? []);
+  }, [workspaceSlug, submissionId]);
+
   const handleReply = useCallback(async (body: string, parentId: string) => {
     const parent = comments.find((c) => c.id === parentId);
     if (!parent) return;
@@ -168,14 +178,8 @@ export function ReviewDetail({
         </div>
 
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 6, fontSize: 13, color: C.muted }}>
-          <div style={{
-            width: 22, height: 22, borderRadius: '50%', background: C.rail,
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            fontSize: 10, fontWeight: 600, color: C.ink2,
-          }}>
-            {(submission.user_id ?? 'U').slice(0, 1).toUpperCase()}
-          </div>
-          <span style={{ fontWeight: 550, color: C.ink2 }}>{(submission.user_id ?? 'unknown').slice(0, 8)}</span>
+          <AvatarBadge name={submission.author_name || submission.user_id} size={22} />
+          <span style={{ fontWeight: 550, color: C.ink2 }}>{submission.author_name || submission.user_id.slice(0, 8)}</span>
           <span>wants to merge</span>
           <code style={{
             fontSize: 12, padding: '2px 7px', borderRadius: 6,
@@ -212,6 +216,7 @@ export function ReviewDetail({
             onResolve={handleResolve}
             onUnresolve={handleUnresolve}
             onReply={handleReply}
+            onEditSave={submission.status === 'merged' || submission.status === 'rejected' ? undefined : handleEditFile}
           />
 
           {/* Finish your review box */}
@@ -300,14 +305,8 @@ export function ReviewDetail({
             </div>
             {submission.reviewed_by ? (
               <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                <div style={{
-                  width: 26, height: 26, borderRadius: '50%', background: C.rail,
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  fontSize: 11, fontWeight: 600, color: C.ink2,
-                }}>
-                  {submission.reviewed_by.slice(0, 1).toUpperCase()}
-                </div>
-                <span style={{ fontSize: 13.5, color: C.ink2, flex: 1 }}>{submission.reviewed_by.slice(0, 8)}</span>
+                <AvatarBadge name={submission.reviewer_name || submission.reviewed_by} size={26} />
+                <span style={{ fontSize: 13.5, color: C.ink2, flex: 1 }}>{submission.reviewer_name || submission.reviewed_by.slice(0, 8)}</span>
                 {/* Status pip */}
                 <div style={{
                   width: 18, height: 18, borderRadius: '50%',

--- a/web/src/components/review/ReviewList.tsx
+++ b/web/src/components/review/ReviewList.tsx
@@ -3,6 +3,7 @@ import { GitBranch, MessageSquare } from 'lucide-react';
 import { listReviews, type Submission } from '../../api';
 import { C } from '@/lib/design';
 import { timeAgo } from '../../lib/time';
+import { AvatarBadge } from '@/components/ui/avatar-badge';
 
 type Filter = 'open' | 'merged' | 'all';
 
@@ -62,29 +63,25 @@ export function ReviewList({
         </h1>
       </div>
 
-      {/* Filter tabs */}
-      <div style={{
-        display: 'flex', gap: 2, marginBottom: 16, padding: 2, background: C.rail, borderRadius: 8,
-        width: 'fit-content',
-      }}>
+      {/* Filter pills (design: active pill = ink, others plain) */}
+      <div style={{ display: 'flex', gap: 8, marginBottom: 18, fontSize: 13.5 }}>
         {([
-          { key: 'open' as Filter, label: `Open (${openCount})` },
-          { key: 'merged' as Filter, label: `Merged (${mergedCount})` },
-          { key: 'all' as Filter, label: `All (${subs.length})` },
+          { key: 'open' as Filter, label: 'Open', count: openCount },
+          { key: 'merged' as Filter, label: 'Merged', count: mergedCount },
+          { key: 'all' as Filter, label: 'All', count: subs.length },
         ]).map((tab) => (
           <button
             key={tab.key}
             onClick={() => setFilter(tab.key)}
             style={{
-              padding: '5px 14px', borderRadius: 6, border: 'none', cursor: 'pointer',
-              fontSize: 12, fontWeight: filter === tab.key ? 600 : 400,
-              background: filter === tab.key ? '#fff' : 'transparent',
-              color: filter === tab.key ? C.ink : C.muted,
-              boxShadow: filter === tab.key ? '0 1px 2px rgba(0,0,0,0.06)' : 'none',
+              padding: '6px 12px', borderRadius: 7, border: 'none', cursor: 'pointer',
+              fontWeight: 550,
+              background: filter === tab.key ? C.ink : 'transparent',
+              color: filter === tab.key ? '#fff' : C.muted,
               transition: 'all 0.15s',
             }}
           >
-            {tab.label}
+            {tab.label} · {tab.count}
           </button>
         ))}
       </div>
@@ -98,59 +95,52 @@ export function ReviewList({
           No {filter === 'all' ? '' : filter} reviews.
         </div>
       ) : (
-        <div style={{ border: `1px solid ${C.line}`, borderRadius: 8, overflow: 'hidden' }}>
+        <div style={{ border: `1px solid ${C.line}`, borderRadius: 12, overflow: 'hidden', background: C.panel }}>
           {filtered?.map((s, i) => {
             const sb = statusBadge[s.status] ?? statusBadge.pending;
+            const author = s.author_name || s.user_id.slice(0, 8);
             return (
               <button
                 key={s.id}
                 onClick={() => onOpen(s.id)}
                 style={{
-                  display: 'flex', alignItems: 'center', gap: 12,
-                  padding: '12px 16px', background: C.panel, border: 'none',
-                  borderBottom: i < (filtered.length - 1) ? `1px solid ${C.line}` : 'none',
+                  display: 'flex', alignItems: 'center', gap: 14,
+                  padding: '15px 18px', background: C.panel, border: 'none',
+                  borderTop: i ? `1px solid ${C.line}` : 'none',
                   textAlign: 'left', cursor: 'pointer', width: '100%',
                   transition: 'background 0.1s',
                 }}
                 onMouseEnter={(e) => { e.currentTarget.style.background = C.sidebar; }}
                 onMouseLeave={(e) => { e.currentTarget.style.background = C.panel; }}
               >
-                {/* Branch icon */}
-                <GitBranch size={16} color={s.status === 'pending' ? C.green : s.status === 'merged' ? C.purple : C.muted} />
+                <GitBranch size={17} color={C.faint} />
 
                 {/* Main content */}
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <span style={{ fontSize: 14, fontWeight: 500, color: C.ink, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {s.summary || s.page_slugs.join(', ') || 'Submission'}
-                    </span>
+                  <div style={{ fontSize: 15, fontWeight: 550, color: C.ink, marginBottom: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {s.summary || s.page_slugs.join(', ') || 'Submission'}
                   </div>
-                  <div style={{ fontSize: 12, color: C.muted, marginTop: 2 }}>
-                    {s.source_branch} · {s.page_slugs.length} file{s.page_slugs.length === 1 ? '' : 's'} · {timeAgo(s.created_at)}
+                  <div style={{ fontSize: 12.5, color: C.muted, display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span>{author}</span>
+                    <span>·</span>
+                    <span>{s.page_slugs.length} file{s.page_slugs.length === 1 ? '' : 's'}</span>
+                    <span>·</span>
+                    <span>{timeAgo(s.created_at)}</span>
                   </div>
                 </div>
 
                 {/* Right side */}
                 <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
-                  {/* Comment count placeholder */}
-                  <span style={{ display: 'flex', alignItems: 'center', gap: 3, fontSize: 12, color: C.faint }}>
-                    <MessageSquare size={13} /> 0
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12.5, color: C.faint }}>
+                    <MessageSquare size={14} /> 0
                   </span>
-                  {/* Status badge */}
                   <span style={{
-                    fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 12,
+                    fontSize: 12, fontWeight: 600, padding: '5px 10px', borderRadius: 999,
                     background: sb.bg, color: sb.fg, whiteSpace: 'nowrap',
                   }}>
                     {sb.label}
                   </span>
-                  {/* Avatar */}
-                  <div style={{
-                    width: 24, height: 24, borderRadius: '50%', background: C.rail,
-                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    fontSize: 11, fontWeight: 600, color: C.ink2,
-                  }}>
-                    {s.user_id.slice(0, 1).toUpperCase()}
-                  </div>
+                  <AvatarBadge name={author} size={26} />
                 </div>
               </button>
             );

--- a/web/src/components/ui/avatar-badge.tsx
+++ b/web/src/components/ui/avatar-badge.tsx
@@ -1,0 +1,40 @@
+import { C } from '@/lib/design';
+
+/** Deterministic avatar palette from the design handoff (muted, warm-compatible). */
+const PALETTE = ['#2f6bb0', '#2f8a5b', '#8b5cf6', '#c2410c', '#3f6c8c', '#5d8a6c', '#9a6f93', '#b5790f'];
+
+export function nameColor(name: string): string {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  return PALETTE[h % PALETTE.length];
+}
+
+/** Colored-initials avatar matching the design (Avatar in cowiki-shell). */
+export function AvatarBadge({ name, size = 24, color }: { name: string; size?: number; color?: string }) {
+  const initials = name
+    .split(/\s+/)
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase() || '?';
+  return (
+    <div
+      title={name}
+      style={{
+        width: size, height: size, borderRadius: 999,
+        background: color ?? nameColor(name), color: '#fff',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: size * 0.4, fontWeight: 600, flexShrink: 0, letterSpacing: '0.02em',
+        userSelect: 'none',
+      }}
+    >
+      {initials}
+    </div>
+  );
+}
+
+export default AvatarBadge;
+
+// keep design tokens import referenced for future tints
+void C;

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Compass, FileText, Search,
   Upload, Zap, ArrowUpRight, MoreHorizontal, RefreshCw,
-  CheckCircle2, Clock,
+  CheckCircle2, Clock, Pencil,
 } from 'lucide-react';
 import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
@@ -33,6 +33,7 @@ import { ReviewList } from '../components/review/ReviewList';
 import { ReviewDetail } from '../components/review/ReviewDetail';
 import { MembersView } from '../components/views/MembersView';
 import { InviteDialog } from '../components/InviteDialog';
+import { PageEditor } from '../components/PageEditor';
 import { TransferDialog } from '../components/TransferDialog';
 import { C } from '@/lib/design';
 
@@ -91,6 +92,7 @@ export function MainLayout() {
   const [searchQuery, setSearchQuery] = useState('');
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [syncing, setSyncing] = useState(false);
+  const [editingPage, setEditingPage] = useState(false);
 
   // Team space management state
   const [showInviteDialog, setShowInviteDialog] = useState<Workspace | null>(null);
@@ -260,6 +262,7 @@ export function MainLayout() {
   const selectPage = async (ws: Workspace, slug: string) => {
     setActiveWorkspace(ws);
     setActiveTab('wiki');
+    setEditingPage(false);
     setActiveView({ kind: 'page', slug, content: null });
     navigate(`/${ws.slug}/${slug}`, { replace: true });
 
@@ -534,6 +537,21 @@ export function MainLayout() {
     return body;
   };
 
+  // Save an in-page edit to the user's draft branch, then refresh the page + tree.
+  const handleSavePage = async (body: string) => {
+    if (!activeWorkspace || activeView?.kind !== 'page') return;
+    const ws = activeWorkspace;
+    const slug = activeView.slug;
+    await writePage(slug, body, userBranch, ws.slug);
+    setEditingPage(false);
+    setMessage({ text: 'Saved to your draft.', type: 'success' });
+    try {
+      const page = await getPage(slug, userBranch, ws.slug);
+      setActiveView((prev) => (prev?.kind === 'page' ? { ...prev, content: page } : prev));
+    } catch { /* keep the stale view; tree reload below still runs */ }
+    loadSpacePages(ws);
+  };
+
   const personal = activeWorkspace ? isPersonalSpace(activeWorkspace) : false;
   const isOwner = activeWorkspace?.role === 'owner';
 
@@ -674,6 +692,15 @@ export function MainLayout() {
                 {/* Wiki-specific actions */}
                 {activeTab === 'wiki' && (activeView?.kind === 'page' || activeView?.kind === 'source') && (
                   <>
+                    {activeView?.kind === 'page' && activeView.content && !editingPage && (
+                      <button
+                        onClick={() => setEditingPage(true)}
+                        style={headerBtnStyle}
+                        title="Edit this page (saved to your draft branch)"
+                      >
+                        <Pencil size={13} /> Edit
+                      </button>
+                    )}
                     <button
                       onClick={() => setShowIngest(true)}
                       style={headerBtnStyle}
@@ -854,9 +881,19 @@ export function MainLayout() {
 
               /* Page view */
               ) : activeView?.kind === 'page' && activeView.content ? (
-                <article className="prose">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{renderBody(activeView.content.body)}</ReactMarkdown>
-                </article>
+                editingPage ? (
+                  <PageEditor
+                    key={activeView.slug}
+                    initialBody={activeView.content.body}
+                    stripFrontmatter={renderBody}
+                    onSave={handleSavePage}
+                    onCancel={() => setEditingPage(false)}
+                  />
+                ) : (
+                  <article className="prose">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{renderBody(activeView.content.body)}</ReactMarkdown>
+                  </article>
+                )
 
               /* Discover */
               ) : location.pathname === '/discover' ? (

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -21,7 +21,7 @@ import {
   compile, submit, renameWorkspace,
   deleteWorkspace,
   listPublicWorkspaces, joinWorkspace,
-  listSources, getSource, listReviews, syncBranch,
+  listSources, getSource, listReviews, syncBranch, renamePath, deletePath,
   type Workspace, type PageMeta, type PageFull, type SourceItem, type SourceContent,
 } from '../api';
 import { AddSourceDialog } from '@/components/AddSourceDialog';
@@ -93,6 +93,12 @@ export function MainLayout() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [editingPage, setEditingPage] = useState(false);
+  // Tree path ops (rename/delete of pages & folders on the draft branch)
+  const [pathOp, setPathOp] = useState<
+    | { kind: 'rename'; path: string; isFolder: boolean; title: string; value: string }
+    | { kind: 'delete'; path: string; isFolder: boolean; title: string }
+    | null
+  >(null);
 
   // Team space management state
   const [showInviteDialog, setShowInviteDialog] = useState<Workspace | null>(null);
@@ -537,6 +543,42 @@ export function MainLayout() {
     return body;
   };
 
+  // Execute a pending rename/delete from the tree menus.
+  const handlePathOp = async () => {
+    if (!pathOp || !activeWorkspace) return;
+    const ws = activeWorkspace;
+    try {
+      if (pathOp.kind === 'rename') {
+        const slugified = pathOp.value
+          .toLowerCase()
+          .replace(/[^a-z0-9\s-]/g, '')
+          .trim()
+          .replace(/\s+/g, '-');
+        if (!slugified) { setMessage({ text: 'Name cannot be empty', type: 'error' }); return; }
+        const parent = pathOp.path.slice(0, pathOp.path.lastIndexOf('/'));
+        const to = pathOp.isFolder ? `${parent}/${slugified}` : `${parent}/${slugified}.md`;
+        if (to === pathOp.path) { setPathOp(null); return; }
+        await renamePath(ws.slug, userBranch, pathOp.path, to);
+        setMessage({ text: 'Renamed in your draft.', type: 'success' });
+      } else {
+        await deletePath(ws.slug, userBranch, pathOp.path);
+        setMessage({ text: `Deleted ${pathOp.isFolder ? 'folder' : 'page'} from your draft.`, type: 'success' });
+      }
+      setPathOp(null);
+      // If the open page lived under the changed path, drop the stale view.
+      if (activeView?.kind === 'page') {
+        const viewPath = `wiki/${activeView.slug}.md`;
+        if (viewPath === pathOp.path || viewPath.startsWith(pathOp.path + '/')) {
+          setActiveView(null);
+          navigate(`/`, { replace: true });
+        }
+      }
+      loadSpacePages(ws);
+    } catch (e) {
+      setMessage({ text: e instanceof Error ? e.message : 'Operation failed', type: 'error' });
+    }
+  };
+
   // Save an in-page edit to the user's draft branch, then refresh the page + tree.
   const handleSavePage = async (body: string) => {
     if (!activeWorkspace || activeView?.kind !== 'page') return;
@@ -593,6 +635,8 @@ export function MainLayout() {
             onNewFolder={() => { if (activeWorkspace) { setShowNewFolder(activeWorkspace); setNewName(''); setNewFolderParent(null); } }}
             onAddPageInFolder={(folderPath) => { if (activeWorkspace) { setShowNewPage(activeWorkspace); setNewName(''); setNewPageFolder(folderPath); } }}
             onAddFolderInFolder={(parentPath) => { if (activeWorkspace) { setShowNewFolder(activeWorkspace); setNewName(''); setNewFolderParent(parentPath); } }}
+            onRenamePath={(path, isFolder, title) => setPathOp({ kind: 'rename', path, isFolder, title, value: title })}
+            onDeletePath={(path, isFolder, title) => setPathOp({ kind: 'delete', path, isFolder, title })}
             onShowIngest={() => setShowIngest(true)}
             onCompile={handleCompile}
             onSettings={() => setSettingsOpen(true)}
@@ -1019,6 +1063,46 @@ export function MainLayout() {
             <div className="flex justify-end gap-2">
               <Button variant="outline" onClick={() => setShowDeleteConfirm(null)}>Cancel</Button>
               <Button variant="destructive" onClick={handleDeleteWorkspace}>Delete Workspace</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Rename page/folder */}
+      <Dialog open={pathOp?.kind === 'rename'} onOpenChange={(open) => !open && setPathOp(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader><DialogTitle>Rename {pathOp?.isFolder ? 'Folder' : 'Page'}</DialogTitle></DialogHeader>
+          <div className="space-y-4 mt-2">
+            <Input
+              value={pathOp?.kind === 'rename' ? pathOp.value : ''}
+              onChange={(e) => setPathOp((p) => (p?.kind === 'rename' ? { ...p, value: e.target.value } : p))}
+              onKeyDown={(e) => e.key === 'Enter' && handlePathOp()}
+              autoFocus
+            />
+            <p className="text-xs text-[var(--color-text-secondary)]">
+              Renames the {pathOp?.isFolder ? 'folder path' : 'page slug'} in your draft; links to the old name will need updating.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setPathOp(null)}>Cancel</Button>
+              <Button onClick={handlePathOp}>Rename</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete page/folder confirm */}
+      <Dialog open={pathOp?.kind === 'delete'} onOpenChange={(open) => !open && setPathOp(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader><DialogTitle>Delete {pathOp?.isFolder ? 'Folder' : 'Page'}</DialogTitle></DialogHeader>
+          <div className="space-y-4 mt-2">
+            <p className="text-sm text-[var(--color-text-secondary)]">
+              Delete <strong>{pathOp?.title}</strong>
+              {pathOp?.isFolder ? ' and everything inside it' : ''} from your draft?
+              The change lands on the shared wiki when your submission is merged.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setPathOp(null)}>Cancel</Button>
+              <Button variant="destructive" onClick={handlePathOp}>Delete</Button>
             </div>
           </div>
         </DialogContent>


### PR DESCRIPTION
## What's in here

Three user-facing features plus security fixes from an adversarial post-merge review of #78.

### 1. In-page markdown editing
**Edit** button on every page → GitHub-style **Write / Preview** editor (raw markdown incl. frontmatter; preview renders like the page). Saves to your draft branch; ⌘S / Esc.

### 2. Rename & delete pages/folders (progress on #75)
- `git.rs`: in-memory tree ops — delete a path (pruning emptied dirs) or move a blob/whole subtree, folded into the branch's single working commit. **Deletions flow through submit → snapshot → merge** like any edit (covered by a test: a deleted page disappears from main after merge; a main-side edit to a deleted page conflicts).
- Routes `POST /paths/rename` & `/paths/delete`: members with EditContent, own draft branch only, paths validated to stay inside `wiki/` — **`sources/` and the wiki root are untouchable**.
- Tree UI: hover `⋯` menu on every page/folder row (rename dialog + delete confirm).

### 3. Review UI per the design handoff (Team Space Option 3 / PR Review)
- Real author/reviewer names + colored-initials avatars (submissions API now joins users) — no more uuid prefixes
- List rows & filter pills restyled to the design
- **Edit-in-review**: per-file Edit in the review screen amends the single review-fix commit on the frozen snapshot (`POST reviews/{id}/edit`), per ADR 0004

### 4. Security fixes (post-merge review of #78)
- **P1**: `submit` and `rebase` only did global auth and accepted an **arbitrary branch** — any authenticated user could force-rewrite another user's draft or a frozen `pr/{id}` snapshot. Both (plus `write_page`/`create_folder`) now require membership + EditContent and only operate on the caller's own `user/{id}`.
- **P2**: personal-space `pr_id` was branch-derived → concurrent submits raced (cleanup deleted the ref the other request was merging); now unique per submit.
- **P2**: `merge_pr` now also holds the `pr/{id}` lock (main → pr order) so a concurrent review-fix can't move the tip mid-merge.
- **P2**: a merge conflict on a frozen snapshot now closes the submission with an actionable message (the old 409 suggested a rebase that could never fix it).

## Tests
3 new git tests (delete-through-merge, folder subtree ops, rename file/folder + overwrite refusal); all 123 backend tests green; `cargo fmt` clean; frontend `tsc + vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)