### PR TITLE
fix(security): review comment routes require workspace membership (#54)

### DIFF
--- a/crates/db/src/review_comments.rs
+++ b/crates/db/src/review_comments.rs
@@ -51,6 +51,13 @@ pub async fn list_for_submission(
     .await
 }
 
+pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<ReviewComment>> {
+    sqlx::query_as::<_, ReviewComment>("SELECT * FROM review_comments WHERE id = $1")
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+}
+
 pub async fn resolve(pool: &PgPool, id: Uuid) -> sqlx::Result<ReviewComment> {
     sqlx::query_as::<_, ReviewComment>(
         "UPDATE review_comments SET resolved = TRUE, updated_at = now() WHERE id = $1 RETURNING *",

--- a/crates/db/src/review_comments.rs
+++ b/crates/db/src/review_comments.rs
@@ -51,11 +51,21 @@ pub async fn list_for_submission(
     .await
 }
 
-pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<ReviewComment>> {
-    sqlx::query_as::<_, ReviewComment>("SELECT * FROM review_comments WHERE id = $1")
-        .bind(id)
-        .fetch_optional(pool)
-        .await
+/// Look up a comment scoped to its submission. The `(id, submission_id)` predicate
+/// pushes the submission-binding check into the query, so a comment id from another
+/// submission/workspace simply returns None — callers can't forget to validate it.
+pub async fn find_by_id_and_submission(
+    pool: &PgPool,
+    id: Uuid,
+    submission_id: Uuid,
+) -> sqlx::Result<Option<ReviewComment>> {
+    sqlx::query_as::<_, ReviewComment>(
+        "SELECT * FROM review_comments WHERE id = $1 AND submission_id = $2",
+    )
+    .bind(id)
+    .bind(submission_id)
+    .fetch_optional(pool)
+    .await
 }
 
 pub async fn resolve(pool: &PgPool, id: Uuid) -> sqlx::Result<ReviewComment> {

--- a/crates/server/src/routes/comments.rs
+++ b/crates/server/src/routes/comments.rs
@@ -39,22 +39,18 @@ async fn guard_submission(
     Ok(guard)
 }
 
-/// Load a comment and check it actually hangs off the submission in the path
-/// (prevents cross-submission/workspace comment ids smuggled into the URL).
+/// Load a comment scoped to the submission in the path. The binding check lives
+/// in the SQL predicate (`find_by_id_and_submission`), so a comment id belonging
+/// to another submission/workspace returns NotFound rather than relying on a
+/// caller-side comparison that could be forgotten.
 async fn load_bound_comment(
     state: &Arc<AppState>,
     submission_id: uuid::Uuid,
     comment_id: uuid::Uuid,
 ) -> Result<cowiki_db::review_comments::ReviewComment> {
-    let comment = cowiki_db::review_comments::find_by_id(&state.db, comment_id)
+    cowiki_db::review_comments::find_by_id_and_submission(&state.db, comment_id, submission_id)
         .await?
-        .ok_or_else(|| AppError::NotFound("comment not found".into()))?;
-    if comment.submission_id != submission_id {
-        return Err(AppError::NotFound(
-            "comment not found on this submission".into(),
-        ));
-    }
-    Ok(comment)
+        .ok_or_else(|| AppError::NotFound("comment not found on this submission".into()))
 }
 
 /// List all comments for a submission — any member can read.
@@ -108,7 +104,10 @@ pub async fn create_comment(
     Ok(Json(comment))
 }
 
-/// Resolve a comment thread — reviewers/editors only.
+/// Resolve a comment thread. Intentionally a moderation action, not an
+/// ownership one: any member with EditContent can resolve/unresolve any thread
+/// (not just its author), mirroring how editors curate a review. The thread is
+/// still bound to the submission via `load_bound_comment`.
 pub async fn resolve_comment(
     State(state): State<Arc<AppState>>,
     Path((ws_slug, submission_id, comment_id)): Path<(String, uuid::Uuid, uuid::Uuid)>,

--- a/crates/server/src/routes/comments.rs
+++ b/crates/server/src/routes/comments.rs
@@ -3,8 +3,8 @@ use axum::Json;
 use serde::Deserialize;
 use std::sync::Arc;
 
-use crate::error::Result;
-use crate::routes::auth::extract_user;
+use crate::error::{AppError, Result};
+use crate::routes::guard::{self, Permission, WorkspaceGuard};
 use crate::AppState;
 
 #[derive(Deserialize)]
@@ -15,28 +15,90 @@ pub struct CreateCommentRequest {
     pub parent_id: Option<uuid::Uuid>,
 }
 
-/// List all comments for a submission
+/// Membership gate shared by every comment route (#54): the caller must be a member
+/// of `ws_slug` with at least `perm`, and the submission must belong to that
+/// workspace — otherwise any authenticated user could read or mutate review threads
+/// in workspaces they have no access to just by guessing ids.
+async fn guard_submission(
+    state: &Arc<AppState>,
+    headers: &axum::http::HeaderMap,
+    ws_slug: &str,
+    submission_id: uuid::Uuid,
+    perm: Permission,
+) -> Result<WorkspaceGuard> {
+    let guard = guard::require_membership(state, headers, ws_slug).await?;
+    guard::require(&guard, perm)?;
+    let submission = cowiki_db::submissions::find_by_id(&state.db, submission_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("submission not found".into()))?;
+    if submission.workspace_slug != ws_slug {
+        return Err(AppError::NotFound(
+            "submission not found in this workspace".into(),
+        ));
+    }
+    Ok(guard)
+}
+
+/// Load a comment and check it actually hangs off the submission in the path
+/// (prevents cross-submission/workspace comment ids smuggled into the URL).
+async fn load_bound_comment(
+    state: &Arc<AppState>,
+    submission_id: uuid::Uuid,
+    comment_id: uuid::Uuid,
+) -> Result<cowiki_db::review_comments::ReviewComment> {
+    let comment = cowiki_db::review_comments::find_by_id(&state.db, comment_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("comment not found".into()))?;
+    if comment.submission_id != submission_id {
+        return Err(AppError::NotFound(
+            "comment not found on this submission".into(),
+        ));
+    }
+    Ok(comment)
+}
+
+/// List all comments for a submission — any member can read.
 pub async fn list_comments(
     State(state): State<Arc<AppState>>,
-    Path((_ws_slug, submission_id)): Path<(String, uuid::Uuid)>,
+    Path((ws_slug, submission_id)): Path<(String, uuid::Uuid)>,
+    headers: axum::http::HeaderMap,
 ) -> Result<Json<Vec<cowiki_db::review_comments::ReviewComment>>> {
+    guard_submission(
+        &state,
+        &headers,
+        &ws_slug,
+        submission_id,
+        Permission::ViewContent,
+    )
+    .await?;
     let comments =
         cowiki_db::review_comments::list_for_submission(&state.db, submission_id).await?;
     Ok(Json(comments))
 }
 
-/// Create a comment on a submission
+/// Create a comment — any member can join the discussion (viewers included).
 pub async fn create_comment(
     State(state): State<Arc<AppState>>,
-    Path((_ws_slug, submission_id)): Path<(String, uuid::Uuid)>,
+    Path((ws_slug, submission_id)): Path<(String, uuid::Uuid)>,
     headers: axum::http::HeaderMap,
     Json(input): Json<CreateCommentRequest>,
 ) -> Result<Json<cowiki_db::review_comments::ReviewComment>> {
-    let user = extract_user(&state.db, &headers).await?;
+    let guard = guard_submission(
+        &state,
+        &headers,
+        &ws_slug,
+        submission_id,
+        Permission::ViewContent,
+    )
+    .await?;
+    if let Some(parent_id) = input.parent_id {
+        // Replies must target a thread on this same submission.
+        load_bound_comment(&state, submission_id, parent_id).await?;
+    }
     let comment = cowiki_db::review_comments::create(
         &state.db,
         submission_id,
-        user.id,
+        guard.user.id,
         &input.file_path,
         input.line_number,
         &input.body,
@@ -46,35 +108,64 @@ pub async fn create_comment(
     Ok(Json(comment))
 }
 
-/// Resolve a comment thread
+/// Resolve a comment thread — reviewers/editors only.
 pub async fn resolve_comment(
     State(state): State<Arc<AppState>>,
-    Path((_ws_slug, _submission_id, comment_id)): Path<(String, uuid::Uuid, uuid::Uuid)>,
+    Path((ws_slug, submission_id, comment_id)): Path<(String, uuid::Uuid, uuid::Uuid)>,
     headers: axum::http::HeaderMap,
 ) -> Result<Json<cowiki_db::review_comments::ReviewComment>> {
-    let _user = extract_user(&state.db, &headers).await?;
+    guard_submission(
+        &state,
+        &headers,
+        &ws_slug,
+        submission_id,
+        Permission::EditContent,
+    )
+    .await?;
+    load_bound_comment(&state, submission_id, comment_id).await?;
     let comment = cowiki_db::review_comments::resolve(&state.db, comment_id).await?;
     Ok(Json(comment))
 }
 
-/// Unresolve a comment thread
+/// Unresolve a comment thread — reviewers/editors only.
 pub async fn unresolve_comment(
     State(state): State<Arc<AppState>>,
-    Path((_ws_slug, _submission_id, comment_id)): Path<(String, uuid::Uuid, uuid::Uuid)>,
+    Path((ws_slug, submission_id, comment_id)): Path<(String, uuid::Uuid, uuid::Uuid)>,
     headers: axum::http::HeaderMap,
 ) -> Result<Json<cowiki_db::review_comments::ReviewComment>> {
-    let _user = extract_user(&state.db, &headers).await?;
+    guard_submission(
+        &state,
+        &headers,
+        &ws_slug,
+        submission_id,
+        Permission::EditContent,
+    )
+    .await?;
+    load_bound_comment(&state, submission_id, comment_id).await?;
     let comment = cowiki_db::review_comments::unresolve(&state.db, comment_id).await?;
     Ok(Json(comment))
 }
 
-/// Delete a comment
+/// Delete a comment — its author, or a member with EditContent (moderation).
 pub async fn delete_comment(
     State(state): State<Arc<AppState>>,
-    Path((_ws_slug, _submission_id, comment_id)): Path<(String, uuid::Uuid, uuid::Uuid)>,
+    Path((ws_slug, submission_id, comment_id)): Path<(String, uuid::Uuid, uuid::Uuid)>,
     headers: axum::http::HeaderMap,
 ) -> Result<Json<serde_json::Value>> {
-    let _user = extract_user(&state.db, &headers).await?;
+    let guard = guard_submission(
+        &state,
+        &headers,
+        &ws_slug,
+        submission_id,
+        Permission::ViewContent,
+    )
+    .await?;
+    let comment = load_bound_comment(&state, submission_id, comment_id).await?;
+    if comment.user_id != guard.user.id {
+        guard::require(&guard, Permission::EditContent).map_err(|_| {
+            AppError::Forbidden("only the comment author or an editor can delete it".into())
+        })?;
+    }
     cowiki_db::review_comments::delete(&state.db, comment_id).await?;
     Ok(Json(serde_json::json!({"ok": true})))
 }

--- a/crates/server/tests/comment_authz_tests.rs
+++ b/crates/server/tests/comment_authz_tests.rs
@@ -1,0 +1,301 @@
+// ── Review-comment authorization tests (#54) ─────────────────────────
+// Black-box HTTP tests (same harness style as permission_api_tests.rs).
+// Self-skip unless TEST_API_URL is set, e.g.:
+//   TEST_API_URL=http://localhost:3000/api cargo test -p cowiki-server
+//
+// Cover the authorization boundaries added in PR #86:
+//  - cross-workspace submission-id guessing → 404
+//  - cross-submission reply smuggling via parent_id → 404
+//  - delete authorization matrix (author vs editor vs viewer)
+
+use std::process::Command;
+
+fn api_request(method: &str, path: &str, body: Option<&str>, api_key: &str) -> (String, i32) {
+    let mut args = vec!["-s", "-o", "/dev/stderr", "-w", "%{http_code}"];
+    if let Some(b) = body {
+        args.push("-d");
+        args.push(b);
+    }
+    args.push("-H");
+    let auth_header = format!("Authorization: Bearer {}", api_key);
+    args.push(&auth_header);
+    args.push("-H");
+    args.push("Content-Type: application/json");
+    args.push("-X");
+    args.push(method);
+
+    let base_url =
+        std::env::var("TEST_API_URL").unwrap_or_else(|_| "http://localhost:3000/api".into());
+    let url = format!("{}{}", base_url, path);
+    args.push(&url);
+
+    let output = Command::new("curl")
+        .args(&args)
+        .output()
+        .expect("failed to execute curl");
+    let status = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<i32>()
+        .unwrap_or(-1);
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (stderr, status)
+}
+
+fn register_user(name: &str) -> (String, String) {
+    let unique = format!(
+        "{}-{}",
+        name,
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
+    let body = format!(r#"{{"name":"{}"}}"#, unique);
+    let (resp, status) = api_request("POST", "/auth/register", Some(&body), "");
+    assert_eq!(status, 200, "register failed: {}", resp);
+    let json: serde_json::Value = serde_json::from_str(&resp).unwrap();
+    (
+        json["user"]["id"].as_str().unwrap().to_string(),
+        json["api_key"].as_str().unwrap().to_string(),
+    )
+}
+
+fn new_slug(prefix: &str) -> String {
+    format!(
+        "{}-{}",
+        prefix,
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    )
+}
+
+fn create_workspace(api_key: &str, slug: &str) {
+    let body = format!(
+        r#"{{"name":"Comment Authz WS","slug":"{}","visibility":"public"}}"#,
+        slug
+    );
+    let (resp, status) = api_request("POST", "/workspaces", Some(&body), api_key);
+    assert_eq!(status, 200, "create workspace failed: {}", resp);
+}
+
+fn join_workspace(api_key: &str, slug: &str) {
+    let (resp, status) = api_request("POST", &format!("/workspaces/{}/join", slug), None, api_key);
+    assert_eq!(status, 200, "join failed: {}", resp);
+}
+
+fn set_role(owner_key: &str, slug: &str, user_id: &str, role: &str) {
+    let body = format!(r#"{{"user_id":"{}","role":"{}"}}"#, user_id, role);
+    let (resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/members/role", slug),
+        Some(&body),
+        owner_key,
+    );
+    assert_eq!(status, 200, "set role failed: {}", resp);
+}
+
+/// Write a page on the author's own draft branch and submit it for review.
+/// Returns the submission id.
+fn make_submission(author_key: &str, author_id: &str, slug: &str, page: &str) -> String {
+    let branch = format!("user/{}", author_id);
+    let write_body = format!(
+        r#"{{"slug":"{}","body":"body text","branch":"{}","title":"T"}}"#,
+        page, branch
+    );
+    let (resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/pages", slug),
+        Some(&write_body),
+        author_key,
+    );
+    assert_eq!(status, 200, "write page failed: {}", resp);
+
+    let submit_body = format!(r#"{{"branch":"{}","page_slugs":["{}"]}}"#, branch, page);
+    let (resp, status) = api_request(
+        "POST",
+        &format!("/workspaces/{}/submit", slug),
+        Some(&submit_body),
+        author_key,
+    );
+    assert_eq!(status, 200, "submit failed: {}", resp);
+    let json: serde_json::Value = serde_json::from_str(&resp).unwrap();
+    json["submission_id"].as_str().unwrap().to_string()
+}
+
+fn create_comment(api_key: &str, slug: &str, sub_id: &str, body_text: &str) -> (String, i32) {
+    let body = format!(
+        r#"{{"file_path":"wiki/{}.md","body":"{}"}}"#,
+        "p", body_text
+    );
+    api_request(
+        "POST",
+        &format!("/workspaces/{}/reviews/{}/comments", slug, sub_id),
+        Some(&body),
+        api_key,
+    )
+}
+
+fn skip() -> bool {
+    if std::env::var("TEST_API_URL").is_err() {
+        eprintln!("Skipping: TEST_API_URL not set");
+        true
+    } else {
+        false
+    }
+}
+
+#[test]
+fn test_comment_cross_workspace_denied() {
+    if skip() {
+        return;
+    }
+    // Submission lives in WS-A; attacker owns an unrelated WS-B.
+    let (a_id, a_key) = register_user("ca-owner-a");
+    let (_b_id, b_key) = register_user("ca-owner-b");
+    let ws_a = new_slug("ca-a");
+    let ws_b = new_slug("ca-b");
+    create_workspace(&a_key, &ws_a);
+    create_workspace(&b_key, &ws_b);
+    let sub = make_submission(&a_key, &a_id, &ws_a, "p");
+
+    // Listing/commenting on WS-A's submission via the WS-B path → 404 (not in WS-B).
+    let (_, s) = api_request(
+        "GET",
+        &format!("/workspaces/{}/reviews/{}/comments", ws_b, sub),
+        None,
+        &b_key,
+    );
+    assert_eq!(s, 404, "cross-workspace list comments → 404, got {s}");
+
+    let (_, s) = create_comment(&b_key, &ws_b, &sub, "sneaky");
+    assert_eq!(s, 404, "cross-workspace create comment → 404, got {s}");
+}
+
+#[test]
+fn test_comment_requires_membership() {
+    if skip() {
+        return;
+    }
+    let (a_id, a_key) = register_user("ca-priv-owner");
+    let (_x_id, outsider) = register_user("ca-outsider");
+    let ws = new_slug("ca-priv");
+    // Private so the outsider has no membership.
+    let body = format!(r#"{{"name":"P","slug":"{}","visibility":"private"}}"#, ws);
+    let (resp, status) = api_request("POST", "/workspaces", Some(&body), &a_key);
+    assert_eq!(status, 200, "create private ws: {}", resp);
+    let sub = make_submission(&a_key, &a_id, &ws, "p");
+
+    let (_, s) = api_request(
+        "GET",
+        &format!("/workspaces/{}/reviews/{}/comments", ws, sub),
+        None,
+        &outsider,
+    );
+    assert!(
+        s == 403 || s == 404,
+        "outsider list comments → 403/404, got {s}"
+    );
+
+    // Unauthenticated → 401.
+    let (_, s) = api_request(
+        "GET",
+        &format!("/workspaces/{}/reviews/{}/comments", ws, sub),
+        None,
+        "",
+    );
+    assert_eq!(s, 401, "unauthenticated list comments → 401, got {s}");
+}
+
+#[test]
+fn test_reply_smuggling_denied() {
+    if skip() {
+        return;
+    }
+    // Two submissions in the same workspace; a reply must not target a thread on
+    // a different submission.
+    let (a_id, a_key) = register_user("ca-smug-owner");
+    let ws = new_slug("ca-smug");
+    create_workspace(&a_key, &ws);
+    let sub1 = make_submission(&a_key, &a_id, &ws, "p1");
+    let sub2 = make_submission(&a_key, &a_id, &ws, "p2");
+
+    // Create a comment on sub1.
+    let (resp, s) = create_comment(&a_key, &ws, &sub1, "root on sub1");
+    assert_eq!(s, 200, "create comment on sub1 → 200: {resp}");
+    let c1: serde_json::Value = serde_json::from_str(&resp).unwrap();
+    let c1_id = c1["id"].as_str().unwrap();
+
+    // Reply on sub2 with parent_id pointing at sub1's comment → 404.
+    let body = format!(
+        r#"{{"file_path":"wiki/p2.md","body":"reply","parent_id":"{}"}}"#,
+        c1_id
+    );
+    let (_, s) = api_request(
+        "POST",
+        &format!("/workspaces/{}/reviews/{}/comments", ws, sub2),
+        Some(&body),
+        &a_key,
+    );
+    assert_eq!(s, 404, "reply smuggling across submissions → 404, got {s}");
+}
+
+#[test]
+fn test_delete_authorization_matrix() {
+    if skip() {
+        return;
+    }
+    // Owner (editor+), plus two members we'll demote to viewer.
+    let (owner_id, owner) = register_user("ca-del-owner");
+    let (author_id, author) = register_user("ca-del-author");
+    let (other_id, other) = register_user("ca-del-other");
+    let ws = new_slug("ca-del");
+    create_workspace(&owner, &ws);
+    join_workspace(&author, &ws); // editor
+    join_workspace(&other, &ws); // editor
+
+    let sub = make_submission(&owner, &owner_id, &ws, "p");
+
+    // Demote both to viewer so we can test the author-can-delete-own path for a viewer.
+    set_role(&owner, &ws, &author_id, "viewer");
+    set_role(&owner, &ws, &other_id, "viewer");
+
+    // Viewer author posts a comment (members can comment).
+    let (resp, s) = create_comment(&author, &ws, &sub, "by viewer author");
+    assert_eq!(s, 200, "viewer can comment → 200: {resp}");
+    let cid = serde_json::from_str::<serde_json::Value>(&resp).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Another viewer (non-author) cannot delete it → 403.
+    let (_, s) = api_request(
+        "DELETE",
+        &format!("/workspaces/{}/reviews/{}/comments/{}", ws, sub, cid),
+        None,
+        &other,
+    );
+    assert_eq!(s, 403, "viewer non-author delete → 403, got {s}");
+
+    // The author (even as a viewer) can delete their own comment → 200.
+    let (_, s) = api_request(
+        "DELETE",
+        &format!("/workspaces/{}/reviews/{}/comments/{}", ws, sub, cid),
+        None,
+        &author,
+    );
+    assert_eq!(s, 200, "viewer author delete own → 200, got {s}");
+
+    // A non-author editor (owner) can delete someone else's comment (moderation).
+    let (resp, s) = create_comment(&author, &ws, &sub, "second comment");
+    assert_eq!(s, 200, "viewer comment again → 200: {resp}");
+    let cid2 = serde_json::from_str::<serde_json::Value>(&resp).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let (_, s) = api_request(
+        "DELETE",
+        &format!("/workspaces/{}/reviews/{}/comments/{}", ws, sub, cid2),
+        None,
+        &owner,
+    );
+    assert_eq!(
+        s, 200,
+        "editor non-author delete (moderation) → 200, got {s}"
+    );
+}


### PR DESCRIPTION
## Problem
All five comment routes (`list/create/resolve/unresolve/delete`) only did global API-key auth — `list_comments` didn't authenticate at all. Any user could read or mutate review threads in **any** workspace by guessing uuids.

## Fix
- Shared `guard_submission`: workspace membership + permission, and the submission must belong to the `ws_slug` in the path
- Comment ids are bound-checked to the submission (no cross-submission/workspace smuggling); replies must target a thread on the same submission
- Permission model: **read & comment** = any member (viewers can discuss) · **resolve/unresolve** = EditContent · **delete** = comment author or EditContent (moderation)
- db: adds `review_comments::find_by_id` for the binding checks

All suites green. Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)