### PR TITLE
fix(security): membership-gate read paths and compile/ingest (#55)

### DIFF
--- a/crates/server/src/routes/compile.rs
+++ b/crates/server/src/routes/compile.rs
@@ -44,7 +44,7 @@ pub async fn compile_ws(
     // only, and only onto the caller's own draft branch.
     let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
-    super::pages::require_own_branch(&input.branch, guard.user.id)?;
+    super::guard::require_own_branch(&input.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)

--- a/crates/server/src/routes/compile.rs
+++ b/crates/server/src/routes/compile.rs
@@ -37,8 +37,14 @@ pub(crate) struct CompileState {
 pub async fn compile_ws(
     State(state): State<Arc<AppState>>,
     Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
     Json(input): Json<CompileRequest>,
 ) -> Result<Json<CompileResponse>> {
+    // Compile writes pages to the named branch — members with write permission
+    // only, and only onto the caller's own draft branch.
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
+    super::pages::require_own_branch(&input.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)

--- a/crates/server/src/routes/guard.rs
+++ b/crates/server/src/routes/guard.rs
@@ -81,6 +81,28 @@ pub fn require(guard: &WorkspaceGuard, permission: Permission) -> Result<()> {
     }
 }
 
+/// Reads may target the shared `main` or the caller's own draft branch — never
+/// another user's branch (their un-reviewed drafts are private until submitted).
+pub fn require_readable_branch(branch: &str, user_id: uuid::Uuid) -> Result<()> {
+    if branch == "main" || branch == format!("user/{user_id}") {
+        return Ok(());
+    }
+    Err(AppError::Forbidden(
+        "reads are limited to main or your own draft branch".into(),
+    ))
+}
+
+/// Mutating ops only touch the caller's own draft branch — never main, pr/* snapshots,
+/// or other users' branches (all writes flow to main exclusively through merge_pr).
+pub fn require_own_branch(branch: &str, user_id: uuid::Uuid) -> Result<()> {
+    if branch != format!("user/{user_id}") {
+        return Err(AppError::Forbidden(
+            "writes are only allowed on your own draft branch".into(),
+        ));
+    }
+    Ok(())
+}
+
 // ── Unit Tests ──────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/crates/server/src/routes/ingest.rs
+++ b/crates/server/src/routes/ingest.rs
@@ -25,8 +25,15 @@ pub struct IngestResponse {
 pub async fn ingest_ws(
     State(state): State<Arc<AppState>>,
     Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
     Json(input): Json<IngestRequest>,
 ) -> Result<Json<IngestResponse>> {
+    // Ingest writes a source file to the named branch — members with write
+    // permission only, and only onto the caller's own draft branch (previously
+    // this even allowed branch == "main").
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
+    super::pages::require_own_branch(&input.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)

--- a/crates/server/src/routes/ingest.rs
+++ b/crates/server/src/routes/ingest.rs
@@ -33,7 +33,7 @@ pub async fn ingest_ws(
     // this even allowed branch == "main").
     let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
-    super::pages::require_own_branch(&input.branch, guard.user.id)?;
+    super::guard::require_own_branch(&input.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)

--- a/crates/server/src/routes/pages.rs
+++ b/crates/server/src/routes/pages.rs
@@ -201,7 +201,7 @@ pub async fn list_pages_ws(
         .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     let branch = params.branch.unwrap_or_else(|| "main".into());
-    require_readable_branch(&branch, guard.user.id)?;
+    crate::routes::guard::require_readable_branch(&branch, guard.user.id)?;
     ensure_user_branch_if_needed(&repo, &branch)?;
 
     let dir = params.dir.as_deref().unwrap_or("wiki");
@@ -231,7 +231,7 @@ pub async fn get_page_ws(
         .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     let branch = params.branch.unwrap_or_else(|| "main".into());
-    require_readable_branch(&branch, guard.user.id)?;
+    crate::routes::guard::require_readable_branch(&branch, guard.user.id)?;
     ensure_user_branch_if_needed(&repo, &branch)?;
     let dir = params.dir.as_deref().unwrap_or("wiki");
     if dir == "all" {
@@ -265,7 +265,7 @@ pub async fn write_page_ws(
     // own draft branch; main changes exclusively via merge_pr.
     let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
-    require_own_branch(&input.branch, guard.user.id)?;
+    crate::routes::guard::require_own_branch(&input.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)
@@ -314,7 +314,7 @@ pub async fn create_folder_ws(
 ) -> Result<Json<serde_json::Value>> {
     let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
-    require_own_branch(&input.branch, guard.user.id)?;
+    crate::routes::guard::require_own_branch(&input.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)
@@ -538,28 +538,6 @@ fn validate_wiki_path(p: &str) -> Result<()> {
     Ok(())
 }
 
-/// Reads may target the shared `main` or the caller's own draft branch — never
-/// another user's branch (their un-reviewed drafts are private until submitted).
-pub(crate) fn require_readable_branch(branch: &str, user_id: uuid::Uuid) -> Result<()> {
-    if branch == "main" || branch == format!("user/{user_id}") {
-        return Ok(());
-    }
-    Err(AppError::Forbidden(
-        "reads are limited to main or your own draft branch".into(),
-    ))
-}
-
-/// Mutating ops only touch the caller's own draft branch — never main, pr/* snapshots,
-/// or other users' branches (all writes flow to main exclusively through merge_pr).
-pub(crate) fn require_own_branch(branch: &str, user_id: uuid::Uuid) -> Result<()> {
-    if branch != format!("user/{user_id}") {
-        return Err(AppError::Forbidden(
-            "writes are only allowed on your own draft branch".into(),
-        ));
-    }
-    Ok(())
-}
-
 #[derive(Deserialize)]
 pub struct RenamePathRequest {
     pub branch: String,
@@ -575,7 +553,7 @@ pub async fn rename_path_ws(
 ) -> Result<Json<serde_json::Value>> {
     let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
-    require_own_branch(&input.branch, guard.user.id)?;
+    crate::routes::guard::require_own_branch(&input.branch, guard.user.id)?;
     validate_wiki_path(&input.from)?;
     validate_wiki_path(&input.to)?;
 
@@ -609,7 +587,7 @@ pub async fn delete_path_ws(
 ) -> Result<Json<serde_json::Value>> {
     let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
-    require_own_branch(&input.branch, guard.user.id)?;
+    crate::routes::guard::require_own_branch(&input.branch, guard.user.id)?;
     validate_wiki_path(&input.path)?;
 
     let repo = state

--- a/crates/server/src/routes/pages.rs
+++ b/crates/server/src/routes/pages.rs
@@ -191,13 +191,17 @@ pub struct CreateFolder {
 pub async fn list_pages_ws(
     State(state): State<Arc<AppState>>,
     Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
     Query(params): Query<PageQueryParams>,
 ) -> Result<Json<Vec<PageListItem>>> {
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::ViewContent)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     let branch = params.branch.unwrap_or_else(|| "main".into());
+    require_readable_branch(&branch, guard.user.id)?;
     ensure_user_branch_if_needed(&repo, &branch)?;
 
     let dir = params.dir.as_deref().unwrap_or("wiki");
@@ -216,14 +220,18 @@ pub async fn list_pages_ws(
 pub async fn get_page_ws(
     State(state): State<Arc<AppState>>,
     Path((ws_slug, raw_slug)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
     Query(params): Query<PageQueryParams>,
 ) -> Result<Json<PageResponse>> {
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::ViewContent)?;
     let slug = raw_slug.strip_prefix('/').unwrap_or(&raw_slug).to_string();
     let repo = state
         .repo_manager
         .get(&ws_slug)
         .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
     let branch = params.branch.unwrap_or_else(|| "main".into());
+    require_readable_branch(&branch, guard.user.id)?;
     ensure_user_branch_if_needed(&repo, &branch)?;
     let dir = params.dir.as_deref().unwrap_or("wiki");
     if dir == "all" {
@@ -528,6 +536,17 @@ fn validate_wiki_path(p: &str) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+/// Reads may target the shared `main` or the caller's own draft branch — never
+/// another user's branch (their un-reviewed drafts are private until submitted).
+pub(crate) fn require_readable_branch(branch: &str, user_id: uuid::Uuid) -> Result<()> {
+    if branch == "main" || branch == format!("user/{user_id}") {
+        return Ok(());
+    }
+    Err(AppError::Forbidden(
+        "reads are limited to main or your own draft branch".into(),
+    ))
 }
 
 /// Mutating ops only touch the caller's own draft branch — never main, pr/* snapshots,

--- a/crates/server/src/routes/sources.rs
+++ b/crates/server/src/routes/sources.rs
@@ -56,7 +56,7 @@ pub async fn list_sources(
 ) -> Result<Json<Vec<SourceItem>>> {
     let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::ViewContent)?;
-    super::pages::require_readable_branch(&params.branch, guard.user.id)?;
+    super::guard::require_readable_branch(&params.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)
@@ -98,7 +98,7 @@ pub async fn get_source(
 ) -> Result<Json<SourceContent>> {
     let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::ViewContent)?;
-    super::pages::require_readable_branch(&params.branch, guard.user.id)?;
+    super::guard::require_readable_branch(&params.branch, guard.user.id)?;
     super::validate_source_filename(&filename)?;
 
     let repo = state

--- a/crates/server/src/routes/sources.rs
+++ b/crates/server/src/routes/sources.rs
@@ -51,8 +51,12 @@ fn load_compile_state(
 pub async fn list_sources(
     State(state): State<Arc<AppState>>,
     Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
     Query(params): Query<ListSourcesParams>,
 ) -> Result<Json<Vec<SourceItem>>> {
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::ViewContent)?;
+    super::pages::require_readable_branch(&params.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)
@@ -89,8 +93,12 @@ pub async fn list_sources(
 pub async fn get_source(
     State(state): State<Arc<AppState>>,
     Path((ws_slug, filename)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
     Query(params): Query<GetSourceParams>,
 ) -> Result<Json<SourceContent>> {
+    let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
+    crate::routes::guard::require(&guard, crate::routes::guard::Permission::ViewContent)?;
+    super::pages::require_readable_branch(&params.branch, guard.user.id)?;
     super::validate_source_filename(&filename)?;
 
     let repo = state

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -35,7 +35,7 @@ pub async fn submit(
     // let any user rewrite another user's branch or a frozen pr/* snapshot.
     let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
-    super::pages::require_own_branch(&input.branch, guard.user.id)?;
+    super::guard::require_own_branch(&input.branch, guard.user.id)?;
     let user = guard.user.clone();
     let repo = state
         .repo_manager
@@ -235,7 +235,7 @@ pub async fn rebase(
     // branches must be unreachable from here.
     let guard = crate::routes::guard::require_membership(&state, &headers, &ws_slug).await?;
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
-    super::pages::require_own_branch(&input.branch, guard.user.id)?;
+    super::guard::require_own_branch(&input.branch, guard.user.id)?;
     let repo = state
         .repo_manager
         .get(&ws_slug)

--- a/crates/server/tests/read_path_authz_tests.rs
+++ b/crates/server/tests/read_path_authz_tests.rs
@@ -1,0 +1,205 @@
+// ── Read-path authorization tests (#55) ──────────────────────────────
+// Black-box HTTP tests against a running server (same harness style as
+// permission_api_tests.rs). They self-skip unless TEST_API_URL is set, e.g.:
+//   TEST_API_URL=http://localhost:3000/api cargo test -p cowiki-server
+//
+// Cover the gates added in PR #87: read routes require membership, and the
+// `branch` parameter can only be `main` or the caller's OWN draft branch —
+// never another member's `user/{uuid}` draft.
+
+use std::process::Command;
+
+fn api_request(method: &str, path: &str, body: Option<&str>, api_key: &str) -> (String, i32) {
+    let mut args = vec!["-s", "-o", "/dev/stderr", "-w", "%{http_code}"];
+    if let Some(b) = body {
+        args.push("-d");
+        args.push(b);
+    }
+    args.push("-H");
+    let auth_header = format!("Authorization: Bearer {}", api_key);
+    args.push(&auth_header);
+    args.push("-H");
+    args.push("Content-Type: application/json");
+    args.push("-X");
+    args.push(method);
+
+    let base_url =
+        std::env::var("TEST_API_URL").unwrap_or_else(|_| "http://localhost:3000/api".into());
+    let url = format!("{}{}", base_url, path);
+    args.push(&url);
+
+    let output = Command::new("curl")
+        .args(&args)
+        .output()
+        .expect("failed to execute curl");
+    let status = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<i32>()
+        .unwrap_or(-1);
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (stderr, status)
+}
+
+fn register_user(name: &str) -> (String, String) {
+    let unique = format!(
+        "{}-{}",
+        name,
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
+    let body = format!(r#"{{"name":"{}"}}"#, unique);
+    let (resp, status) = api_request("POST", "/auth/register", Some(&body), "");
+    assert_eq!(status, 200, "register failed: {}", resp);
+    let json: serde_json::Value = serde_json::from_str(&resp).unwrap();
+    // Response shape: { "user": { "id": ... }, "api_key": ... }
+    (
+        json["user"]["id"].as_str().unwrap().to_string(),
+        json["api_key"].as_str().unwrap().to_string(),
+    )
+}
+
+fn new_slug(prefix: &str) -> String {
+    format!(
+        "{}-{}",
+        prefix,
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    )
+}
+
+fn create_workspace(api_key: &str, slug: &str) {
+    let body = format!(
+        r#"{{"name":"Read Authz WS","slug":"{}","visibility":"public"}}"#,
+        slug
+    );
+    let (resp, status) = api_request("POST", "/workspaces", Some(&body), api_key);
+    assert_eq!(status, 200, "create workspace failed: {}", resp);
+}
+
+fn join_workspace(api_key: &str, slug: &str) {
+    let (resp, status) = api_request("POST", &format!("/workspaces/{}/join", slug), None, api_key);
+    assert_eq!(status, 200, "join failed: {}", resp);
+}
+
+fn skip() -> bool {
+    if std::env::var("TEST_API_URL").is_err() {
+        eprintln!("Skipping: TEST_API_URL not set");
+        true
+    } else {
+        false
+    }
+}
+
+#[test]
+fn test_read_pages_requires_membership() {
+    if skip() {
+        return;
+    }
+    let (_o, owner) = register_user("rp-owner");
+    let (_x, outsider) = register_user("rp-outsider");
+    let slug = new_slug("rp-priv");
+    // Private workspace so the outsider has no membership at all.
+    let body = format!(
+        r#"{{"name":"Priv","slug":"{}","visibility":"private"}}"#,
+        slug
+    );
+    let (resp, status) = api_request("POST", "/workspaces", Some(&body), &owner);
+    assert_eq!(status, 200, "create private ws: {}", resp);
+
+    // Owner (member) can list.
+    let (_, s) = api_request("GET", &format!("/workspaces/{}/pages", slug), None, &owner);
+    assert_eq!(s, 200, "owner list pages → 200");
+
+    // Outsider is denied (membership gate).
+    let (_, s) = api_request(
+        "GET",
+        &format!("/workspaces/{}/pages", slug),
+        None,
+        &outsider,
+    );
+    assert!(
+        s == 403 || s == 404,
+        "outsider list pages → 403/404, got {s}"
+    );
+}
+
+#[test]
+fn test_read_unauthenticated_rejected() {
+    if skip() {
+        return;
+    }
+    let (_o, owner) = register_user("rp-anon-owner");
+    let slug = new_slug("rp-anon");
+    create_workspace(&owner, &slug);
+    // No bearer token at all.
+    let (_, s) = api_request("GET", &format!("/workspaces/{}/pages", slug), None, "");
+    assert_eq!(s, 401, "unauthenticated list pages → 401");
+    let (_, s) = api_request("GET", &format!("/workspaces/{}/sources", slug), None, "");
+    assert_eq!(s, 401, "unauthenticated list sources → 401");
+}
+
+#[test]
+fn test_cannot_read_other_members_draft_branch() {
+    if skip() {
+        return;
+    }
+    // Two members of the same workspace; one must not read the other's draft.
+    let (_o, owner) = register_user("rp-a");
+    let (victim_id, victim) = register_user("rp-victim");
+    let slug = new_slug("rp-shared");
+    create_workspace(&owner, &slug);
+    join_workspace(&victim, &slug);
+
+    let victim_branch = format!("user/{}", victim_id);
+
+    // Reading your own branch is fine (owner reading owner's branch via default is main;
+    // here we assert the cross-user case is blocked).
+    let (_, s) = api_request(
+        "GET",
+        &format!("/workspaces/{}/pages?branch={}", slug, victim_branch),
+        None,
+        &owner,
+    );
+    assert_eq!(
+        s, 403,
+        "reading another member's draft branch (pages) → 403"
+    );
+
+    let (_, s) = api_request(
+        "GET",
+        &format!("/workspaces/{}/sources?branch={}", slug, victim_branch),
+        None,
+        &owner,
+    );
+    assert_eq!(
+        s, 403,
+        "reading another member's draft branch (sources) → 403"
+    );
+}
+
+#[test]
+fn test_own_and_main_branches_readable() {
+    if skip() {
+        return;
+    }
+    let (owner_id, owner) = register_user("rp-self");
+    let slug = new_slug("rp-self-ws");
+    create_workspace(&owner, &slug);
+
+    // main is always readable.
+    let (_, s) = api_request(
+        "GET",
+        &format!("/workspaces/{}/pages?branch=main", slug),
+        None,
+        &owner,
+    );
+    assert_eq!(s, 200, "main branch readable → 200");
+
+    // Caller's own draft branch is readable.
+    let own = format!("user/{}", owner_id);
+    let (_, s) = api_request(
+        "GET",
+        &format!("/workspaces/{}/pages?branch={}", slug, own),
+        None,
+        &owner,
+    );
+    assert_eq!(s, 200, "own draft branch readable → 200");
+}


### PR DESCRIPTION
## Problem (P0)
The read-side data plane had no authorization at all:
- `list_pages` / `get_page`: no auth + arbitrary `branch` param → anyone could read private wikis, including **other users' draft branches** via `branch=user/{uuid}`
- `sources` list/get: **no authentication whatsoever**
- `compile`: no membership, arbitrary branch
- `ingest`: no membership, and explicitly allowed writing sources straight to `main`

## Fix
- All six routes require workspace **membership** (ViewContent for reads, EditContent for compile/ingest)
- New `require_readable_branch`: reads accept only `main` or the caller's own `user/{id}` — other members' un-reviewed drafts stay private (ADR 0004 view model)
- compile/ingest also enforce `require_own_branch` — content reaches `main` only via `merge_pr`

## Compatibility
Frontend only ever passes `userBranch` or `'main'` (verified all call sites) — zero behavior change for legitimate use. All 10 test suites green.

Together with #79 (write paths) and #80 (search), this **closes #55**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)