### PR TITLE
fix(security): credential hardening — hashed keys, OAuth state, no key-in-URL (#59)

### DIFF
--- a/crates/db/src/api_keys.rs
+++ b/crates/db/src/api_keys.rs
@@ -75,6 +75,21 @@ pub async fn revoke(pool: &PgPool, key_id: Uuid, user_id: Uuid) -> sqlx::Result<
     Ok(result.rows_affected() > 0)
 }
 
+/// Revoke all of a user's active keys with the given name. Returns how many were
+/// revoked. Used to prevent unbounded accumulation of auto-minted keys (e.g. each
+/// GitHub sign-in mints one) — revoke the prior batch before minting the next.
+pub async fn revoke_by_name(pool: &PgPool, user_id: Uuid, name: &str) -> sqlx::Result<u64> {
+    let result = sqlx::query(
+        "UPDATE api_keys SET revoked_at = now() WHERE user_id = $1 AND name = $2 AND revoked_at IS NULL"
+    )
+    .bind(user_id)
+    .bind(name)
+    .execute(pool)
+    .await
+    .map_err(|e| { tracing::error!("DB revoke_by_name failed: {e}"); e })?;
+    Ok(result.rows_affected())
+}
+
 /// Look up an active key by its SHA-256 hash. Returns (ApiKey, user_id) or None.
 /// Used by the auth fallback path — MUST filter revoked_at IS NULL.
 pub async fn find_by_key_hash(

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -81,5 +81,10 @@ pub async fn run_migrations(pool: &PgPool, embedding_dim: u32) -> sqlx::Result<(
         tracing::error!("DB error: {e}");
         e
     })?;
+    let sql14 = include_str!("migrations/012_hash_primary_api_keys.sql");
+    sqlx::raw_sql(sql14).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     Ok(())
 }

--- a/crates/db/src/migrations/012_hash_primary_api_keys.sql
+++ b/crates/db/src/migrations/012_hash_primary_api_keys.sql
@@ -1,0 +1,8 @@
+-- #59: store the primary API key (users.api_key) as a SHA-256 hex digest instead
+-- of plaintext. Idempotent: cw_-prefixed (or any non-64-hex) values are legacy
+-- plaintext and get hashed; already-hashed values match ^[0-9a-f]{64}$ and are
+-- left alone. Existing keys keep working — auth hashes the incoming bearer token.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+UPDATE users
+SET api_key = encode(digest(api_key, 'sha256'), 'hex')
+WHERE api_key !~ '^[0-9a-f]{64}$';

--- a/crates/db/src/pages.rs
+++ b/crates/db/src/pages.rs
@@ -164,6 +164,7 @@ mod tests {
             include_str!("migrations/010_notifications.sql"),
             include_str!("migrations/010_invitation_reject_status.sql"),
             include_str!("migrations/011_pages_workspace_scope.sql"),
+            include_str!("migrations/012_hash_primary_api_keys.sql"),
         ] {
             let _ = sqlx::raw_sql(m).execute(&pool).await;
         }

--- a/crates/db/src/submissions.rs
+++ b/crates/db/src/submissions.rs
@@ -185,6 +185,7 @@ mod tests {
             include_str!("migrations/010_notifications.sql"),
             include_str!("migrations/010_invitation_reject_status.sql"),
             include_str!("migrations/011_pages_workspace_scope.sql"),
+            include_str!("migrations/012_hash_primary_api_keys.sql"),
         ] {
             let _ = sqlx::raw_sql(m).execute(&pool).await;
         }

--- a/crates/db/src/users.rs
+++ b/crates/db/src/users.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -10,9 +11,11 @@ pub struct User {
     pub api_key: String,
 }
 
-pub async fn find_by_api_key(pool: &PgPool, api_key: &str) -> sqlx::Result<Option<User>> {
+/// Look up a user by the **raw** bearer token. The primary key is stored as a
+/// SHA-256 hex digest (#59) — the raw value is hashed here and never persisted.
+pub async fn find_by_api_key(pool: &PgPool, raw_key: &str) -> sqlx::Result<Option<User>> {
     sqlx::query_as::<_, User>("SELECT id, name, email, api_key FROM users WHERE api_key = $1")
-        .bind(api_key)
+        .bind(hash_api_key(raw_key))
         .fetch_optional(pool)
         .await
 }
@@ -38,37 +41,42 @@ pub async fn find_by_id(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<User>> {
         .await
 }
 
+/// Create a user. Returns the user and the **raw** API key — the only moment the
+/// raw value exists; the DB stores its SHA-256 digest.
 pub async fn create(
     pool: &PgPool,
     name: &str,
     email: Option<&str>,
     password_hash: Option<&str>,
-) -> sqlx::Result<User> {
-    let api_key = generate_api_key();
-    sqlx::query_as::<_, User>(
+) -> sqlx::Result<(User, String)> {
+    let raw_key = generate_api_key();
+    let user = sqlx::query_as::<_, User>(
         "INSERT INTO users (name, email, api_key, password_hash) VALUES ($1, $2, $3, $4) RETURNING id, name, email, api_key"
     )
     .bind(name)
     .bind(email)
-    .bind(&api_key)
+    .bind(hash_api_key(&raw_key))
     .bind(password_hash)
     .fetch_one(pool)
-    .await
+    .await?;
+    Ok((user, raw_key))
 }
 
-pub async fn regenerate_api_key(pool: &PgPool, user_id: Uuid) -> sqlx::Result<User> {
-    let api_key = generate_api_key();
-    sqlx::query_as::<_, User>(
+/// Rotate the primary key. Returns the user and the **raw** new key (shown once).
+pub async fn regenerate_api_key(pool: &PgPool, user_id: Uuid) -> sqlx::Result<(User, String)> {
+    let raw_key = generate_api_key();
+    let user = sqlx::query_as::<_, User>(
         "UPDATE users SET api_key = $2 WHERE id = $1 RETURNING id, name, email, api_key",
     )
     .bind(user_id)
-    .bind(&api_key)
+    .bind(hash_api_key(&raw_key))
     .fetch_one(pool)
     .await
     .map_err(|e| {
         tracing::error!("DB regenerate API key failed: {e}");
         e
-    })
+    })?;
+    Ok((user, raw_key))
 }
 
 pub async fn update_email(pool: &PgPool, user_id: Uuid, email: &str) -> sqlx::Result<()> {
@@ -117,4 +125,11 @@ pub async fn search(pool: &PgPool, query: &str, limit: i64) -> sqlx::Result<Vec<
 
 fn generate_api_key() -> String {
     format!("cw_{}", Uuid::new_v4().to_string().replace('-', ""))
+}
+
+/// SHA-256 hex digest used for at-rest storage of the primary API key.
+pub fn hash_api_key(raw_key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(raw_key.as_bytes());
+    format!("{:x}", hasher.finalize())
 }

--- a/crates/db/src/users.rs
+++ b/crates/db/src/users.rs
@@ -128,8 +128,46 @@ fn generate_api_key() -> String {
 }
 
 /// SHA-256 hex digest used for at-rest storage of the primary API key.
+///
+/// No salt: API keys are `cw_<uuid-v4>` — ~122 bits of uniform entropy — so
+/// rainbow tables and brute force are infeasible regardless of salting (the same
+/// rationale as the secondary `api_keys` table). If the key format ever changes
+/// to something lower-entropy, switch to a salted KDF here.
 pub fn hash_api_key(raw_key: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(raw_key.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hash_api_key;
+
+    #[test]
+    fn hash_is_deterministic() {
+        assert_eq!(hash_api_key("cw_abc"), hash_api_key("cw_abc"));
+    }
+
+    #[test]
+    fn hash_differs_for_different_keys() {
+        assert_ne!(hash_api_key("cw_abc"), hash_api_key("cw_xyz"));
+    }
+
+    #[test]
+    fn hash_is_sha256_hex() {
+        let h = hash_api_key("cw_abc");
+        assert_eq!(h.len(), 64, "sha-256 hex digest is 64 chars");
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+        // Known vector: SHA-256("cw_abc")
+        assert_eq!(
+            hash_api_key("cw_abc"),
+            "a9a662a565ab7b0cfdb7609f7ad91d6f569b9d58ab8d7b30f6584c0e3417439a"
+        );
+    }
+
+    #[test]
+    fn hash_does_not_contain_raw_key() {
+        // The stored digest must not leak the plaintext.
+        assert!(!hash_api_key("cw_secret123").contains("cw_secret123"));
+    }
 }

--- a/crates/db/src/workspaces.rs
+++ b/crates/db/src/workspaces.rs
@@ -783,6 +783,9 @@ mod tests {
         let _ = sqlx::raw_sql(include_str!("migrations/011_pages_workspace_scope.sql"))
             .execute(&pool)
             .await;
+        let _ = sqlx::raw_sql(include_str!("migrations/012_hash_primary_api_keys.sql"))
+            .execute(&pool)
+            .await;
         Some(pool)
     }
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -21,7 +21,13 @@ pub struct AppState {
     pub config: config::Config,
     pub repo_manager: cowiki_core::git::WikiRepoManager, // per-workspace repos
     pub compiler: Compiler,
-    /// Pending OAuth CSRF nonces → minted-at, swept on insert (single-instance).
+    /// Pending OAuth CSRF nonces → minted-at, swept on insert.
+    ///
+    /// In-process only: this does NOT survive a restart and is NOT shared across
+    /// instances behind a load balancer — a login started on instance A can't
+    /// complete its callback on instance B. Fine for the current single-instance
+    /// deploy; multi-instance needs a shared store (Redis/DB) or a signed,
+    /// self-validating state token. Tracked with the account-system redesign (#12).
     pub oauth_states: std::sync::Mutex<HashMap<String, std::time::Instant>>,
 }
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -21,6 +21,8 @@ pub struct AppState {
     pub config: config::Config,
     pub repo_manager: cowiki_core::git::WikiRepoManager, // per-workspace repos
     pub compiler: Compiler,
+    /// Pending OAuth CSRF nonces → minted-at, swept on insert (single-instance).
+    pub oauth_states: std::sync::Mutex<HashMap<String, std::time::Instant>>,
 }
 
 // ── Usage endpoint response ──
@@ -91,6 +93,7 @@ async fn main() {
         config,
         repo_manager,
         compiler,
+        oauth_states: std::sync::Mutex::new(HashMap::new()),
     });
 
     // Background task: expire stale invitations every hour

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -222,7 +222,10 @@ pub async fn github_callback(
         }
         // The primary key is stored hashed and can't be recovered — mint a fresh
         // secondary key for this sign-in instead of rotating the primary (which
-        // would log out the user's other sessions/agents).
+        // would log out the user's other sessions/agents). Revoke the previous
+        // "GitHub sign-in" key first so repeated logins don't accumulate keys
+        // unboundedly — each sign-in supersedes the last (one active login key).
+        let _ = cowiki_db::api_keys::revoke_by_name(&state.db, existing.id, "GitHub sign-in").await;
         let minted = cowiki_db::api_keys::create(&state.db, existing.id, "GitHub sign-in").await?;
         (existing, minted.raw_key)
     } else {
@@ -254,8 +257,6 @@ pub async fn extract_user(
     db: &sqlx::PgPool,
     headers: &axum::http::HeaderMap,
 ) -> Result<cowiki_db::users::User> {
-    use sha2::{Digest, Sha256};
-
     let auth_header = headers
         .get("authorization")
         .and_then(|v| v.to_str().ok())
@@ -270,12 +271,9 @@ pub async fn extract_user(
         return Ok(user);
     }
 
-    // Fallback: secondary keys (SHA-256 hashed in api_keys.key_hash)
-    let key_hash: String = {
-        let mut hasher = Sha256::new();
-        hasher.update(api_key.as_bytes());
-        format!("{:x}", hasher.finalize())
-    };
+    // Fallback: secondary keys (SHA-256 hashed in api_keys.key_hash). Use the same
+    // canonical hash function as the primary key so the two paths can't drift.
+    let key_hash = cowiki_db::users::hash_api_key(api_key);
 
     if let Some((_key, user_id)) = cowiki_db::api_keys::find_by_key_hash(db, &key_hash).await? {
         // Touch last_used_at (fire-and-forget)

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -39,12 +39,12 @@ pub async fn register(
         return Err(AppError::BadRequest("name already taken".into()));
     }
 
-    let user =
+    let (user, raw_key) =
         cowiki_db::users::create(&state.db, &input.name, input.email.as_deref(), None).await?;
     init_user_space(&state, &user).await?;
 
     Ok(Json(AuthResponse {
-        api_key: user.api_key.clone(),
+        api_key: raw_key,
         user: UserInfo {
             id: user.id.to_string(),
             name: user.name,
@@ -74,10 +74,10 @@ pub async fn regenerate_key(
     headers: axum::http::HeaderMap,
 ) -> Result<Json<AuthResponse>> {
     let user = extract_user(&state.db, &headers).await?;
-    let updated = cowiki_db::users::regenerate_api_key(&state.db, user.id).await?;
+    let (updated, raw_key) = cowiki_db::users::regenerate_api_key(&state.db, user.id).await?;
 
     Ok(Json(AuthResponse {
-        api_key: updated.api_key.clone(),
+        api_key: raw_key,
         user: UserInfo {
             id: updated.id.to_string(),
             name: updated.name,
@@ -90,17 +90,30 @@ pub async fn regenerate_key(
 // ── GitHub OAuth ──
 
 pub async fn github_login(State(state): State<Arc<AppState>>) -> Redirect {
+    // CSRF protection (#59): a random, single-use `state` nonce that the callback
+    // must echo back. Stored in-memory with a TTL (single-instance server).
+    let nonce = uuid::Uuid::new_v4().simple().to_string();
+    {
+        let mut states = state.oauth_states.lock().unwrap();
+        let now = std::time::Instant::now();
+        states.retain(|_, t| now.duration_since(*t).as_secs() < OAUTH_STATE_TTL_SECS);
+        states.insert(nonce.clone(), now);
+    }
     let url = format!(
-        "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}&scope=read:user%20user:email",
+        "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}&scope=read:user%20user:email&state={}",
         state.config.auth.github_client_id,
         urlencoding::encode(&state.config.auth.github_redirect_uri),
+        nonce,
     );
     Redirect::temporary(&url)
 }
 
+const OAUTH_STATE_TTL_SECS: u64 = 600;
+
 #[derive(Deserialize)]
 pub struct GithubCallbackParams {
     pub code: String,
+    pub state: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -127,6 +140,23 @@ pub async fn github_callback(
     State(state): State<Arc<AppState>>,
     Query(params): Query<GithubCallbackParams>,
 ) -> Result<Redirect> {
+    // Verify the CSRF nonce minted at login: present, known, fresh, single-use.
+    let nonce = params
+        .state
+        .as_deref()
+        .ok_or_else(|| AppError::Unauthorized("missing oauth state".into()))?;
+    {
+        let mut states = state.oauth_states.lock().unwrap();
+        let fresh = states
+            .remove(nonce)
+            .map(|t| t.elapsed().as_secs() < OAUTH_STATE_TTL_SECS)
+            .unwrap_or(false);
+        if !fresh {
+            return Err(AppError::Unauthorized(
+                "invalid or expired oauth state".into(),
+            ));
+        }
+    }
     let client = reqwest::Client::new();
 
     let token_resp = client
@@ -177,7 +207,7 @@ pub async fn github_callback(
         emails.and_then(|list| list.into_iter().find(|e| e.primary).map(|e| e.email))
     };
 
-    let user = if let Some(existing) =
+    let (user, raw_key) = if let Some(existing) =
         cowiki_db::users::find_by_name(&state.db, &gh_user.login).await?
     {
         // Update email if the existing user has none but GitHub provides one
@@ -190,25 +220,28 @@ pub async fn github_callback(
                 }
             }
         }
-        existing
+        // The primary key is stored hashed and can't be recovered — mint a fresh
+        // secondary key for this sign-in instead of rotating the primary (which
+        // would log out the user's other sessions/agents).
+        let minted = cowiki_db::api_keys::create(&state.db, existing.id, "GitHub sign-in").await?;
+        (existing, minted.raw_key)
     } else {
-        let user =
+        let (user, raw_key) =
             cowiki_db::users::create(&state.db, &gh_user.login, email.as_deref(), None).await?;
         if let Err(e) = init_user_space(&state, &user).await {
             tracing::error!("failed to init user space: {:?}", e);
         }
         tracing::info!("created user {} via GitHub OAuth", user.name);
-        user
+        (user, raw_key)
     };
 
-    // TODO: SECURITY — Passing the API key as a query parameter in the redirect URL is a risk:
-    // it may be logged in server access logs, browser history, and HTTP Referer headers.
-    // This should be replaced with a short-lived auth code exchange or secure HttpOnly cookie flow.
-    // Not changing the flow now as it would break the current login integration.
+    // The credential travels in the URL *fragment* (#59): fragments never reach
+    // servers, access logs, or Referer headers — unlike the old ?api_key= query.
+    // (A full HttpOnly-cookie session flow is the account-system redesign, #12.)
     let redirect_url = format!(
-        "{}/?api_key={}&user_name={}&user_id={}",
+        "{}/#api_key={}&user_name={}&user_id={}",
         state.config.frontend_url,
-        user.api_key,
+        raw_key,
         urlencoding::encode(&user.name),
         user.id,
     );
@@ -232,7 +265,7 @@ pub async fn extract_user(
         .strip_prefix("Bearer ")
         .ok_or_else(|| AppError::Unauthorized("invalid Authorization format".into()))?;
 
-    // Fast path: primary key (plaintext in users.api_key)
+    // Primary key: stored as SHA-256 (find_by_api_key hashes the raw token)
     if let Some(user) = cowiki_db::users::find_by_api_key(db, api_key).await? {
         return Ok(user);
     }

--- a/crates/server/tests/oauth_csrf_tests.rs
+++ b/crates/server/tests/oauth_csrf_tests.rs
@@ -1,0 +1,78 @@
+// ── OAuth CSRF state tests (#59) ─────────────────────────────────────
+// Black-box HTTP tests (same harness style as permission_api_tests.rs).
+// Self-skip unless TEST_API_URL is set, e.g.:
+//   TEST_API_URL=http://localhost:3000/api cargo test -p cowiki-server
+//
+// The callback validates the CSRF `state` nonce BEFORE contacting GitHub, so
+// the rejection paths (missing / unknown / already-used state) are observable
+// without any GitHub credentials — they must not reach the token exchange.
+
+use std::process::Command;
+
+/// GET a path WITHOUT following redirects, returning the HTTP status.
+fn get_status(path: &str) -> i32 {
+    let base_url =
+        std::env::var("TEST_API_URL").unwrap_or_else(|_| "http://localhost:3000/api".into());
+    let url = format!("{}{}", base_url, path);
+    let output = Command::new("curl")
+        .args(["-s", "-o", "/dev/null", "-w", "%{http_code}", &url])
+        .output()
+        .expect("failed to execute curl");
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<i32>()
+        .unwrap_or(-1)
+}
+
+fn skip() -> bool {
+    if std::env::var("TEST_API_URL").is_err() {
+        eprintln!("Skipping: TEST_API_URL not set");
+        true
+    } else {
+        false
+    }
+}
+
+#[test]
+fn test_callback_missing_state_rejected() {
+    if skip() {
+        return;
+    }
+    // No `state` param at all → 401 (rejected before any GitHub call).
+    let s = get_status("/auth/github/callback?code=fake-code");
+    assert_eq!(s, 401, "callback without state → 401, got {s}");
+}
+
+#[test]
+fn test_callback_unknown_state_rejected() {
+    if skip() {
+        return;
+    }
+    // A state value the server never minted → 401.
+    let s = get_status("/auth/github/callback?code=fake-code&state=never-issued-nonce");
+    assert_eq!(s, 401, "callback with unknown state → 401, got {s}");
+}
+
+#[test]
+fn test_login_redirects_with_state() {
+    if skip() {
+        return;
+    }
+    // /auth/github should 3xx-redirect to GitHub with a state param attached.
+    let base_url =
+        std::env::var("TEST_API_URL").unwrap_or_else(|_| "http://localhost:3000/api".into());
+    let url = format!("{}/auth/github", base_url);
+    let output = Command::new("curl")
+        .args(["-s", "-D", "-", "-o", "/dev/null", &url])
+        .output()
+        .expect("failed to execute curl");
+    let headers = String::from_utf8_lossy(&output.stdout);
+    let location = headers
+        .lines()
+        .find(|l| l.to_lowercase().starts_with("location:"))
+        .unwrap_or("");
+    assert!(
+        location.contains("github.com") && location.contains("state="),
+        "login should redirect to GitHub with a state nonce; Location: {location}"
+    );
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
-import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
-import { useEffect } from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import { MainLayout } from './pages/MainLayout';
 import { LoginPage } from './pages/LoginPage';
 import { getStoredAuth, storeAuth } from './auth';
@@ -7,50 +7,46 @@ import { getStoredAuth, storeAuth } from './auth';
 /** OAuth hands the credential over in the URL *fragment* (never sent to servers,
  *  logs, or Referer). Parse #api_key=...&user_name=...&user_id=..., store, then
  *  scrub the fragment from the address bar/history. */
-function readOAuthFragment(): { apiKey: string; userName: string; userId: string } | null {
+function consumeOAuthFragment(): boolean {
   const hash = window.location.hash.replace(/^#/, '');
-  if (!hash.includes('api_key=')) return null;
+  if (!hash.includes('api_key=')) return false;
   const params = new URLSearchParams(hash);
   const apiKey = params.get('api_key');
   const userName = params.get('user_name');
   const userId = params.get('user_id');
-  if (!apiKey || !userName || !userId) return null;
-  return { apiKey, userName, userId };
-}
-
-function OAuthInterceptor({ children }: { children: React.ReactNode }) {
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    const creds = readOAuthFragment();
-    if (creds) {
-      storeAuth(creds.apiKey, creds.userName, creds.userId);
-      // Remove the fragment so the key doesn't linger in the URL/history entry.
-      window.history.replaceState(null, '', window.location.pathname);
-      navigate('/', { replace: true });
-    }
-  }, [navigate]);
-
-  return <>{children}</>;
+  if (!apiKey || !userName || !userId) return false;
+  storeAuth(apiKey, userName, userId);
+  // Scrub the fragment so the key doesn't linger in the URL/history entry.
+  window.history.replaceState(null, '', window.location.pathname);
+  return true;
 }
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const auth = getStoredAuth();
-  // Don't redirect while the OAuth fragment is still being processed.
-  if (!auth && !readOAuthFragment()) return <Navigate to="/login" replace />;
+  // No hash read here — the OAuth fragment is consumed once at startup (below),
+  // so a stored session is the single source of truth on every render.
+  if (!getStoredAuth()) return <Navigate to="/login" replace />;
   return <>{children}</>;
 }
 
 export default function App() {
+  // Consume any OAuth fragment exactly once, before routing decisions are made.
+  // `ready` gates the first paint so ProtectedRoute never sees a transient
+  // "no auth yet, fragment still present" state.
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    consumeOAuthFragment();
+    setReady(true);
+  }, []);
+
+  if (!ready) return null;
+
   return (
     <BrowserRouter>
-      <OAuthInterceptor>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          {/* All content in one layout — no page transitions */}
-          <Route path="/*" element={<ProtectedRoute><MainLayout /></ProtectedRoute>} />
-        </Routes>
-      </OAuthInterceptor>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        {/* All content in one layout — no page transitions */}
+        <Route path="/*" element={<ProtectedRoute><MainLayout /></ProtectedRoute>} />
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,33 +1,43 @@
-import { BrowserRouter, Routes, Route, Navigate, useSearchParams, useNavigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
 import { MainLayout } from './pages/MainLayout';
 import { LoginPage } from './pages/LoginPage';
 import { getStoredAuth, storeAuth } from './auth';
 
+/** OAuth hands the credential over in the URL *fragment* (never sent to servers,
+ *  logs, or Referer). Parse #api_key=...&user_name=...&user_id=..., store, then
+ *  scrub the fragment from the address bar/history. */
+function readOAuthFragment(): { apiKey: string; userName: string; userId: string } | null {
+  const hash = window.location.hash.replace(/^#/, '');
+  if (!hash.includes('api_key=')) return null;
+  const params = new URLSearchParams(hash);
+  const apiKey = params.get('api_key');
+  const userName = params.get('user_name');
+  const userId = params.get('user_id');
+  if (!apiKey || !userName || !userId) return null;
+  return { apiKey, userName, userId };
+}
+
 function OAuthInterceptor({ children }: { children: React.ReactNode }) {
-  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
   useEffect(() => {
-    const apiKey = searchParams.get('api_key');
-    const userName = searchParams.get('user_name');
-    const userId = searchParams.get('user_id');
-
-    if (apiKey && userName && userId) {
-      storeAuth(apiKey, userName, userId);
+    const creds = readOAuthFragment();
+    if (creds) {
+      storeAuth(creds.apiKey, creds.userName, creds.userId);
+      // Remove the fragment so the key doesn't linger in the URL/history entry.
+      window.history.replaceState(null, '', window.location.pathname);
       navigate('/', { replace: true });
     }
-  }, [searchParams, navigate]);
+  }, [navigate]);
 
   return <>{children}</>;
 }
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const [searchParams] = useSearchParams();
   const auth = getStoredAuth();
-  // Don't redirect if we're in the middle of OAuth callback (api_key in URL)
-  const hasOAuthParams = searchParams.has('api_key');
-  if (!auth && !hasOAuthParams) return <Navigate to="/login" replace />;
+  // Don't redirect while the OAuth fragment is still being processed.
+  if (!auth && !readOAuthFragment()) return <Navigate to="/login" replace />;
   return <>{children}</>;
 }
 


### PR DESCRIPTION
## Three of #59's four findings, end to end

### 1. Primary API key hashed at rest
`users.api_key` now stores a **SHA-256 digest** (the secondary `api_keys` table was already hashed). Migration 012 hashes legacy plaintext rows **idempotently** (only rows not matching `^[0-9a-f]{64}$`); existing keys keep working because auth hashes the incoming bearer token. Raw keys exist only at creation — register/regenerate return them once.

### 2. OAuth CSRF `state`
`github_login` mints a single-use random nonce (10-min TTL, in-memory, swept on insert); the callback rejects missing/unknown/expired state.

### 3. Credential out of the URL
The callback redirect used `?api_key=...` (server logs / history / Referer). Now it uses the **URL fragment** — never sent to any server; the frontend parses it, stores the key, and scrubs the fragment from the address bar/history. Since the hashed primary can't be recovered, an existing user's OAuth sign-in mints a fresh **secondary key** ("GitHub sign-in") instead of rotating the primary — other sessions/agents stay logged in.

### Deferred (by design)
localStorage as the token store → HttpOnly-cookie sessions are the account-system redesign (#12).

## Notes for review
- Migration 012 needs `pgcrypto` (`CREATE EXTENSION IF NOT EXISTS`)
- `users::create`/`regenerate_api_key` signatures now return `(User, raw_key)`
- All 10 suites green; frontend `tsc + vite build` green

Progress on #59 (3/4 items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)