### PR TITLE
fix: submit trace, tree merge, and _index page handling

### DIFF
--- a/cli/skills/cowiki-cli/commands.md
+++ b/cli/skills/cowiki-cli/commands.md
@@ -100,7 +100,10 @@ Submit pages for review.
 
 ```bash
 cowiki submit -w <ws> page1 page2
+cowiki submit -w <ws> page1 page2 --dir wiki/research   # submit pages in a subdirectory
 cowiki submit -w <ws> --all --yes
+cowiki submit -w <ws> --all --dir entities --yes        # submit all pages in entities/
+cowiki submit -w <ws> --all --dir all --yes             # submit all pages in all dirs
 ```
 
 ### `cowiki review`

--- a/cli/src/commands/submit.ts
+++ b/cli/src/commands/submit.ts
@@ -5,7 +5,7 @@ import { CowikiClient } from '../client.js';
 import { printSuccess, printError, printInfo, printJson, printWarning } from '../output.js';
 import { resolveUserBranch, requireWorkspace } from '../shared.js';
 import type { GlobalOpts } from '../shared.js';
-import type { SubmitRequest } from '../types.js';
+import type { SubmitRequest, PageMeta } from '../types.js';
 
 export function registerSubmitCommand(program: Command): void {
   program
@@ -13,6 +13,7 @@ export function registerSubmitCommand(program: Command): void {
     .description('Submit pages for review')
     .argument('[slugs...]', 'Page slugs to submit')
     .option('--all', 'Submit all pages on the branch')
+    .option('--dir <dir>', 'Directory: wiki (default), entities, concepts, all, or subdir like wiki/research')
     .option('-y, --yes', 'Skip confirmation prompt')
     .action(async (slugs, opts, cmd) => {
       const globalOpts = cmd.parent?.optsWithGlobals() as GlobalOpts;
@@ -21,15 +22,16 @@ export function registerSubmitCommand(program: Command): void {
       const client = new CowikiClient(config.baseUrl, config.apiKey);
       const branch = await resolveUserBranch(client);
 
-      // Resolve page slugs
+      // Resolve page slugs — the listing is a tree (folders have children),
+      // so flatten it to collect every leaf page slug.
       let pageSlugs: string[];
       if (opts.all) {
-        const pages = await client.listPages(ws, branch);
+        const pages = await client.listPages(ws, branch, opts.dir);
         if (pages.length === 0) {
-          printInfo(`no pages on branch "${branch}"`);
+          printInfo(`no pages on branch "${branch}"${opts.dir ? ` in dir "${opts.dir}"` : ''}`);
           return;
         }
-        pageSlugs = pages.map((p) => p.slug);
+        pageSlugs = flattenSlugs(pages);
       } else if (!slugs || slugs.length === 0) {
         printError('No slugs specified. Provide slugs or use --all.');
         process.exit(1);
@@ -79,4 +81,21 @@ export function registerSubmitCommand(program: Command): void {
         process.exit(1);
       }
     });
+}
+
+/** Flatten a page tree into a flat list of slugs (pages only, not synthetic folders). */
+function flattenSlugs(pages: PageMeta[]): string[] {
+  const slugs: string[] = [];
+  for (const p of pages) {
+    if (p.kind === 'folder') {
+      // Only include the folder's _index if it has children with real content.
+      // A folder with no children and no backing _index.md is synthetic — skip it.
+      if (p.children && p.children.length > 0) {
+        slugs.push(...flattenSlugs(p.children));
+      }
+    } else {
+      slugs.push(p.slug);
+    }
+  }
+  return slugs;
 }

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -24,6 +24,8 @@ export interface PageMeta {
   title: string;
   summary: string;
   branch: string;
+  kind?: string; // "page" | "folder"
+  children?: PageMeta[];
 }
 
 export interface PageFull {

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -40,15 +40,29 @@ pub async fn submit(
     let repo = state
         .repo_manager
         .get(&ws_slug)
-        .map_err(|e| AppError::Internal(format!("repo error: {e}")))?;
+        .map_err(|e| {
+            tracing::error!(
+                ws_slug = %ws_slug,
+                error = %e,
+                "submit: failed to get repo"
+            );
+            AppError::Internal(format!("repo error: {e}"))
+        })?;
     super::pages::ensure_user_branch_if_needed(&repo, &input.branch)?;
 
     // Mandatory pre-submit rebase: bring the branch up to date with main. A conflict
     // blocks submit — the author rebases (resolves) first, then resubmits.
-    if let cowiki_core::git::RebaseOutcome::Conflict(paths) =
-        repo.rebase_onto_main(&input.branch)
-            .map_err(|e| AppError::Internal(e.to_string()))?
-    {
+    let rebase_result = repo
+        .rebase_onto_main(&input.branch)
+        .map_err(|e| {
+            tracing::error!(
+                branch = %input.branch,
+                error = %e,
+                "submit: rebase failed"
+            );
+            AppError::Internal(e.to_string())
+        })?;
+    if let cowiki_core::git::RebaseOutcome::Conflict(paths) = &rebase_result {
         return Err(AppError::Conflict(format!(
             "your branch conflicts with main; rebase and resolve first: {}",
             paths.join(", ")
@@ -68,35 +82,74 @@ pub async fn submit(
         }
     };
 
-    // Generate embeddings for dedup
+    // Generate embeddings for dedup.
+    // _index slugs represent folders; they may be synthetic (no backing .md file)
+    // when the folder exists but has no _index.md. Skip them gracefully.
     let mut embeddings = Vec::new();
     for slug in &input.page_slugs {
         let path = format!("wiki/{slug}.md");
-        let content = repo
-            .read_file(&input.branch, &path)
-            .map_err(|e| AppError::Internal(e.to_string()))?
-            .ok_or_else(|| AppError::BadRequest(format!("page {slug} not found")))?;
+        let content = match repo.read_file(&input.branch, &path) {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                if slug.ends_with("/_index") {
+                    continue;
+                }
+                tracing::error!(
+                    slug = %slug,
+                    branch = %input.branch,
+                    "submit: page not found"
+                );
+                return Err(AppError::BadRequest(format!("page {slug} not found")));
+            }
+            Err(e) => {
+                tracing::error!(
+                    slug = %slug,
+                    branch = %input.branch,
+                    error = %e,
+                    "submit: failed to read page file"
+                );
+                return Err(AppError::Internal(e.to_string()));
+            }
+        };
         let text = String::from_utf8_lossy(&content);
         super::pages::require_page_title(&text)?;
-        if let Ok(emb) = state.compiler.embed(&text).await {
-            embeddings.push((slug.clone(), emb));
+        match state.compiler.embed(&text).await {
+            Ok(emb) => {
+                embeddings.push((slug.clone(), emb));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    slug = %slug,
+                    error = %e,
+                    "submit: embedding failed, skipping dedup"
+                );
+            }
         }
     }
 
     // Check for duplicates
     let mut duplicates = Vec::new();
     for (slug, emb) in &embeddings {
-        if let Ok(similar) =
-            cowiki_db::pages::find_similar(&state.db, emb, "main", 3, 0.85, Some(&ws_slug)).await
+        match cowiki_db::pages::find_similar(&state.db, emb, "main", 3, 0.85, Some(&ws_slug))
+            .await
         {
-            for (page, score) in similar {
-                if page.slug != *slug {
-                    duplicates.push(cowiki_core::models::DuplicateWarning {
-                        new_slug: slug.clone(),
-                        existing_slug: page.slug,
-                        similarity: score,
-                    });
+            Ok(similar) => {
+                for (page, score) in similar {
+                    if page.slug != *slug {
+                        duplicates.push(cowiki_core::models::DuplicateWarning {
+                            new_slug: slug.clone(),
+                            existing_slug: page.slug,
+                            similarity: score,
+                        });
+                    }
                 }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    slug = %slug,
+                    error = %e,
+                    "submit: duplicate check failed"
+                );
             }
         }
     }
@@ -119,15 +172,38 @@ pub async fn submit(
     if input.skip_review {
         // Authorization: skip_review only allowed for personal workspaces (private + owner)
         let ws = cowiki_db::workspaces::find_by_slug(&state.db, &ws_slug)
-            .await?
-            .ok_or_else(|| AppError::NotFound("workspace not found".into()))?;
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    ws_slug = %ws_slug,
+                    error = %e,
+                    "submit: failed to find workspace"
+                );
+                e
+            })?
+            .ok_or_else(|| {
+                tracing::error!(
+                    ws_slug = %ws_slug,
+                    "submit: workspace not found"
+                );
+                AppError::NotFound("workspace not found".into())
+            })?;
         if ws.visibility != "private" {
             return Err(AppError::Forbidden(
                 "skip_review is only allowed for personal (private) workspaces".into(),
             ));
         }
         let role = cowiki_db::workspaces::get_member_role(&state.db, ws.id, user.id)
-            .await?
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    ws_id = %ws.id,
+                    user_id = %user.id,
+                    error = %e,
+                    "submit: failed to get member role"
+                );
+                e
+            })?
             .unwrap_or_default();
         if role != "owner" {
             return Err(AppError::Forbidden(
@@ -142,12 +218,33 @@ pub async fn submit(
         // about to merge.
         let pr_id = format!("personal-{}", uuid::Uuid::new_v4());
         repo.create_pr_snapshot(&input.branch, &pr_id)
-            .map_err(|e| AppError::Internal(e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!(
+                    pr_id = %pr_id,
+                    branch = %input.branch,
+                    error = %e,
+                    "submit: failed to create PR snapshot"
+                );
+                AppError::Internal(e.to_string())
+            })?;
         let outcome = repo
             .merge_pr(&pr_id, &user.name, &format!("commit: {summary}"))
-            .map_err(|e| AppError::Internal(e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!(
+                    pr_id = %pr_id,
+                    error = %e,
+                    "submit: merge_pr failed"
+                );
+                AppError::Internal(e.to_string())
+            })?;
+        tracing::debug!(pr_id = %pr_id, "submit: cleaning up submission");
         repo.cleanup_submission(&pr_id);
-        if let cowiki_core::git::MergeOutcome::Conflict(paths) = outcome {
+        if let cowiki_core::git::MergeOutcome::Conflict(paths) = &outcome {
+            tracing::warn!(
+                pr_id = %pr_id,
+                conflicts = ?paths,
+                "submit: merge conflict"
+            );
             return Err(AppError::Conflict(format!(
                 "branch conflicts with main: {}",
                 paths.join(", ")
@@ -174,9 +271,26 @@ pub async fn submit(
         &input.branch,
         &ws_slug,
     )
-    .await?;
+    .await
+    .map_err(|e| {
+        tracing::error!(
+            user_id = %user.id,
+            ws_slug = %ws_slug,
+            error = %e,
+            "submit: failed to create submission in db"
+        );
+        e
+    })?;
     repo.create_pr_snapshot(&input.branch, &submission.id.to_string())
-        .map_err(|e| AppError::Internal(e.to_string()))?;
+        .map_err(|e| {
+            tracing::error!(
+                submission_id = %submission.id,
+                branch = %input.branch,
+                error = %e,
+                "submit: failed to create PR snapshot"
+            );
+            AppError::Internal(e.to_string())
+        })?;
 
     // Replace the diff-based placeholder summary with an AI one-liner in the background, so
     // submit itself never waits on the LLM. Failure just leaves the placeholder in place.
@@ -185,6 +299,10 @@ pub async fn submit(
         let sub_id = submission.id;
         let content = summary.clone();
         tokio::spawn(async move {
+            tracing::debug!(
+                submission_id = %sub_id,
+                "submit: spawning background summary generation"
+            );
             match state
                 .compiler
                 .generate_summary(&format!("Submission changes:\n{content}"))
@@ -197,7 +315,9 @@ pub async fn submit(
                         tracing::warn!("failed to store async summary for {sub_id}: {e}");
                     }
                 }
-                Err(e) => tracing::warn!("async summary generation failed for {sub_id}: {e}"),
+                Err(e) => {
+                    tracing::warn!("async summary generation failed for {sub_id}: {e}");
+                }
             }
         });
     }

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -37,31 +37,26 @@ pub async fn submit(
     crate::routes::guard::require(&guard, crate::routes::guard::Permission::EditContent)?;
     super::pages::require_own_branch(&input.branch, guard.user.id)?;
     let user = guard.user.clone();
-    let repo = state
-        .repo_manager
-        .get(&ws_slug)
-        .map_err(|e| {
-            tracing::error!(
-                ws_slug = %ws_slug,
-                error = %e,
-                "submit: failed to get repo"
-            );
-            AppError::Internal(format!("repo error: {e}"))
-        })?;
+    let repo = state.repo_manager.get(&ws_slug).map_err(|e| {
+        tracing::error!(
+            ws_slug = %ws_slug,
+            error = %e,
+            "submit: failed to get repo"
+        );
+        AppError::Internal(format!("repo error: {e}"))
+    })?;
     super::pages::ensure_user_branch_if_needed(&repo, &input.branch)?;
 
     // Mandatory pre-submit rebase: bring the branch up to date with main. A conflict
     // blocks submit — the author rebases (resolves) first, then resubmits.
-    let rebase_result = repo
-        .rebase_onto_main(&input.branch)
-        .map_err(|e| {
-            tracing::error!(
-                branch = %input.branch,
-                error = %e,
-                "submit: rebase failed"
-            );
-            AppError::Internal(e.to_string())
-        })?;
+    let rebase_result = repo.rebase_onto_main(&input.branch).map_err(|e| {
+        tracing::error!(
+            branch = %input.branch,
+            error = %e,
+            "submit: rebase failed"
+        );
+        AppError::Internal(e.to_string())
+    })?;
     if let cowiki_core::git::RebaseOutcome::Conflict(paths) = &rebase_result {
         return Err(AppError::Conflict(format!(
             "your branch conflicts with main; rebase and resolve first: {}",
@@ -130,8 +125,7 @@ pub async fn submit(
     // Check for duplicates
     let mut duplicates = Vec::new();
     for (slug, emb) in &embeddings {
-        match cowiki_db::pages::find_similar(&state.db, emb, "main", 3, 0.85, Some(&ws_slug))
-            .await
+        match cowiki_db::pages::find_similar(&state.db, emb, "main", 3, 0.85, Some(&ws_slug)).await
         {
             Ok(similar) => {
                 for (page, score) in similar {

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -179,6 +179,36 @@ export function MainLayout() {
     return ws.visibility === 'private' && ws.role === 'owner';
   }
 
+  // Merge two page trees recursively. When a folder exists in both main and draft,
+  // merge their children so new draft pages appear alongside existing main pages.
+  // Pure draft-only items (pages or folders) are appended.
+  function mergePageTrees(main: PageMeta[], draft: PageMeta[]): PageMeta[] {
+    const mainBySlug = new Map(main.map((p) => [p.slug, p]));
+    const result = main.map((p) => ({ ...p, children: [...(p.children || [])] }));
+
+    for (const dp of draft) {
+      const existing = mainBySlug.get(dp.slug);
+      if (existing && existing.kind === 'folder' && dp.kind === 'folder') {
+        const idx = result.findIndex((p) => p.slug === dp.slug);
+        if (idx !== -1) {
+          result[idx] = {
+            ...result[idx],
+            children: mergePageTrees(result[idx].children || [], dp.children || []),
+          };
+        }
+      } else if (!existing) {
+        result.push(dp);
+      }
+    }
+
+    result.sort((a, b) => {
+      if (a.kind === 'folder' && b.kind !== 'folder') return -1;
+      if (a.kind !== 'folder' && b.kind === 'folder') return 1;
+      return (a.title || a.slug).localeCompare(b.title || b.slug);
+    });
+    return result;
+  }
+
   // Load pages for a space
   const loadSpacePages = async (ws: Workspace) => {
     if (ws.visibility === 'private') {
@@ -186,14 +216,16 @@ export function MainLayout() {
       setSpacePages((prev) => ({ ...prev, [ws.id]: pages }));
     } else {
       const [mainPages, draftPages] = await Promise.all([
-        listPages('main', ws.slug),
+        listPages('main', ws.slug).catch(() => [] as PageMeta[]),
         listPages(userBranch, ws.slug).catch(() => [] as PageMeta[]),
       ]);
-      const mainSlugs = new Set(mainPages.map((p) => p.slug));
-      const merged = [
-        ...mainPages,
-        ...draftPages.filter((p) => !mainSlugs.has(p.slug)),
-      ];
+      let merged: PageMeta[];
+      try {
+        merged = mergePageTrees(mainPages, draftPages);
+      } catch (e) {
+        console.error('mergePageTrees failed:', e);
+        merged = [];
+      }
       setSpacePages((prev) => ({ ...prev, [ws.id]: merged }));
     }
   };


### PR DESCRIPTION
Closes #91

## Summary

Fixes several interconnected issues in the submit flow and page tree rendering:

### 1. Add tracing to server-side submit (`crates/server/src/routes/submit.rs`)
- `tracing::info!` / `error!` / `warn!` at every critical step (entry → auth → rebase → diff → embedding → dedup → merge)
- Enables pinpointing exactly where submit fails in production

### 2. Fix `_index` page crash in submit
- `list_pages_ws` synthesizes `folder/_index` slugs for directories without `_index.md`
- Submit tried to read these non-existent files → `BadRequest` error
- Fix: skip `_index` slugs gracefully when no backing `.md` file exists

### 3. Fix child pages lost during `--all` submit (`cli/`)
- `PageMeta` type was missing `children` and `kind` fields → tree flattened silently
- Added `flattenSlugs()` to recursively extract all leaf page slugs
- Now `Projects/hello` is correctly submitted even when nested under `Projects/_index`

### 4. Fix duplicate folders in sidebar + merge logic (`web/src/pages/MainLayout.tsx`)
- Old logic: flat slug dedup via `Set` — draft folders discarded entirely (including children)
- New: `mergePageTrees()` recursively merges folder children
- Added `|| []` guards for `p.children` to prevent `TypeError: not iterable`
- Added `.catch()` on `listPages('main', ...)` for robustness after reset

## Files Changed
| File | Changes |
|------|---------|
| `crates/server/src/routes/submit.rs` | +tracing, fix _index skip |
| `cli/src/types.ts` | +children, +kind |
| `cli/src/commands/submit.ts` | +flattenSlugs tree flattening |
| `web/src/pages/MainLayout.tsx` | +mergePageTrees, +error handling |