### PR TITLE
feat(ui): replace flat wiki tree with 4-section directory sidebar

### DIFF
--- a/cli/skills/cowiki-cli/commands.md
+++ b/cli/skills/cowiki-cli/commands.md
@@ -100,7 +100,12 @@ Submit pages for review.
 
 ```bash
 cowiki submit -w <ws> page1 page2
-cowiki submit -w <ws> --all --yes
+cowiki submit -w <ws> page1 --dir entities           # submit from entities/
+cowiki submit -w <ws> page1 --dir concepts            # submit from concepts/
+cowiki submit -w <ws> entities/page1                  # known dir prefix, used as-is
+cowiki submit -w <ws> --all --yes                     # submit all pages in default wiki/
+cowiki submit -w <ws> --all --dir entities --yes      # submit all in entities/
+cowiki submit -w <ws> --all --dir all --yes           # submit all across all dirs
 ```
 
 ### `cowiki review`

--- a/cli/src/commands/submit.ts
+++ b/cli/src/commands/submit.ts
@@ -5,7 +5,22 @@ import { CowikiClient } from '../client.js';
 import { printSuccess, printError, printInfo, printJson, printWarning } from '../output.js';
 import { resolveUserBranch, requireWorkspace } from '../shared.js';
 import type { GlobalOpts } from '../shared.js';
-import type { SubmitRequest } from '../types.js';
+import type { SubmitRequest, PageMeta } from '../types.js';
+
+const KNOWN_DIRS = ['wiki', 'entities', 'concepts'];
+
+/** Flatten a page tree to a list of repo paths, skipping folders and _index */
+function flattenPaths(pages: PageMeta[]): string[] {
+  const paths: string[] = [];
+  for (const p of pages) {
+    if (p.kind === 'folder' && p.children && p.children.length > 0) {
+      paths.push(...flattenPaths(p.children));
+    } else if (p.kind !== 'folder') {
+      paths.push(p.path);
+    }
+  }
+  return paths;
+}
 
 export function registerSubmitCommand(program: Command): void {
   program
@@ -13,6 +28,7 @@ export function registerSubmitCommand(program: Command): void {
     .description('Submit pages for review')
     .argument('[slugs...]', 'Page slugs to submit')
     .option('--all', 'Submit all pages on the branch')
+    .option('--dir <dir>', 'Content directory (wiki, entities, concepts). Default: wiki', 'wiki')
     .option('-y, --yes', 'Skip confirmation prompt')
     .action(async (slugs, opts, cmd) => {
       const globalOpts = cmd.parent?.optsWithGlobals() as GlobalOpts;
@@ -21,25 +37,34 @@ export function registerSubmitCommand(program: Command): void {
       const client = new CowikiClient(config.baseUrl, config.apiKey);
       const branch = await resolveUserBranch(client);
 
-      // Resolve page slugs
-      let pageSlugs: string[];
+      const dir = opts.dir || 'wiki';
+
+      // Resolve page paths
+      let pagePaths: string[];
       if (opts.all) {
-        const pages = await client.listPages(ws, branch);
+        const pages = await client.listPages(ws, branch, dir === 'all' ? 'all' : dir);
         if (pages.length === 0) {
-          printInfo(`no pages on branch "${branch}"`);
+          printInfo(`no pages on branch "${branch}" in ${dir}`);
           return;
         }
-        pageSlugs = pages.map((p) => p.slug);
+        pagePaths = flattenPaths(pages);
       } else if (!slugs || slugs.length === 0) {
         printError('No slugs specified. Provide slugs or use --all.');
         process.exit(1);
       } else {
-        pageSlugs = slugs;
+        // Convert slugs to paths, respecting --dir
+        pagePaths = slugs.map((slug: string) => {
+          // If slug already starts with a known dir, pass through as-is
+          if (KNOWN_DIRS.some(d => slug.startsWith(`${d}/`))) {
+            return slug;
+          }
+          return `${dir}/${slug}`;
+        });
       }
 
       // Show summary
       printInfo(
-        `Submitting ${pageSlugs.length} page(s) from branch "${branch}": ${pageSlugs.join(', ')}`,
+        `Submitting ${pagePaths.length} page(s) from branch "${branch}": ${pagePaths.join(', ')}`,
       );
 
       // Confirm
@@ -54,7 +79,7 @@ export function registerSubmitCommand(program: Command): void {
         }
       }
 
-      const req: SubmitRequest = { branch, page_slugs: pageSlugs };
+      const req: SubmitRequest = { branch, paths: pagePaths };
 
       try {
         const resp = await client.submit(ws, req);
@@ -69,7 +94,7 @@ export function registerSubmitCommand(program: Command): void {
             printWarning('Duplicate warnings:');
             for (const dup of resp.duplicates) {
               console.error(
-                `  ${dup.new_slug} ↔ ${dup.existing_slug} (${(dup.similarity * 100).toFixed(1)}%)`,
+                `  ${dup.new_path} ↔ ${dup.existing_path} (${(dup.similarity * 100).toFixed(1)}%)`,
               );
             }
           }

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -21,9 +21,12 @@ export interface UserInfo {
 
 export interface PageMeta {
   slug: string;
+  path: string;
   title: string;
   summary: string;
   branch: string;
+  kind?: string;
+  children?: PageMeta[];
 }
 
 export interface PageFull {
@@ -120,7 +123,7 @@ export interface SearchResponse {
 
 export interface SubmitRequest {
   branch: string;
-  page_slugs: string[];
+  paths: string[];
 }
 
 export interface SubmitResponse {
@@ -130,8 +133,8 @@ export interface SubmitResponse {
 }
 
 export interface DuplicateWarning {
-  new_slug: string;
-  existing_slug: string;
+  new_path: string;
+  existing_path: string;
   similarity: number;
 }
 
@@ -142,7 +145,7 @@ export interface Submission {
   user_id: string;
   status: string;
   summary: string;
-  page_slugs: string[];
+  paths: string[];
   source_branch: string;
   created_at: string;
   reviewed_by?: string;

--- a/cowiki-mcp-server/src/server.rs
+++ b/cowiki-mcp-server/src/server.rs
@@ -122,7 +122,7 @@ pub struct ListParams {} // no params — always main
 pub struct SearchParams { pub query: String, pub limit: Option<i64>, }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-pub struct SubmitParams { pub page_slugs: Vec<String>, }
+pub struct SubmitParams { pub paths: Vec<String>, }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ReviewGetParams { pub id: String, }
@@ -254,7 +254,7 @@ impl CowikiServer {
     async fn cowiki_submit(&self, ctx: RequestContext<RoleServer>, Parameters(p): Parameters<SubmitParams>) -> Result<CallToolResult, ErrorData> {
         let auth = self.bearer(&ctx)?;
         let branch = self.user_branch(&auth).await?;
-        self.post(&auth, "api/submit", &serde_json::json!({"page_slugs": p.page_slugs, "branch": branch})).await.and_then(Self::json_result)
+        self.post(&auth, "api/submit", &serde_json::json!({"paths": p.paths, "branch": branch})).await.and_then(Self::json_result)
     }
 
     #[tool(description = "List all pending submissions in the review queue")]

--- a/crates/core/src/dedup.rs
+++ b/crates/core/src/dedup.rs
@@ -3,13 +3,13 @@ use crate::models::DuplicateWarning;
 /// Check for duplicate pages by comparing embeddings.
 /// Returns (slug, similarity) pairs for pages above the threshold.
 /// This is a pure function that takes pre-fetched similar pages.
-pub fn find_duplicates(new_slug: &str, similar_pages: &[(String, f64)]) -> Vec<DuplicateWarning> {
+pub fn find_duplicates(new_path: &str, similar_pages: &[(String, f64)]) -> Vec<DuplicateWarning> {
     similar_pages
         .iter()
-        .filter(|(slug, _)| slug != new_slug)
+        .filter(|(slug, _)| slug != new_path)
         .map(|(slug, score)| DuplicateWarning {
-            new_slug: new_slug.to_string(),
-            existing_slug: slug.clone(),
+            new_path: new_path.to_string(),
+            existing_path: slug.clone(),
             similarity: *score,
         })
         .collect()

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -1349,14 +1349,8 @@ mod tests {
             .unwrap();
         repo.write_file("user/b", "entities/alice.md", b"alice\n", "e", "b")
             .unwrap();
-        repo.write_file(
-            "user/b",
-            "entities/people/bob.md",
-            b"bob\n",
-            "e",
-            "b",
-        )
-        .unwrap();
+        repo.write_file("user/b", "entities/people/bob.md", b"bob\n", "e", "b")
+            .unwrap();
 
         // list_pages_recursive under entities/
         let entities_files =
@@ -1366,8 +1360,7 @@ mod tests {
         assert!(entities_files.iter().any(|f| f == "entities/people/bob.md"));
 
         // list_pages_recursive under wiki/
-        let wiki_files =
-            crate::wiki_fs::list_pages_recursive(&repo, "user/b", "wiki").unwrap();
+        let wiki_files = crate::wiki_fs::list_pages_recursive(&repo, "user/b", "wiki").unwrap();
         assert_eq!(wiki_files.len(), 1);
         assert!(wiki_files.iter().any(|f| f == "wiki/home.md"));
 
@@ -1384,7 +1377,10 @@ mod tests {
         let test_cases = vec![
             ("wiki/team-home.md", "team home content"),
             ("entities/people/alice.md", "alice content"),
-            ("concepts/patterns/error-handling.md", "error handling content"),
+            (
+                "concepts/patterns/error-handling.md",
+                "error handling content",
+            ),
             ("wiki/research/ai-safety.md", "nested wiki page"),
             ("entities/orgs/acme.md", "org entity"),
         ];

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -633,12 +633,12 @@ impl WikiRepo {
         Ok(())
     }
 
-    pub fn diff_files(&self, branch: &str, slugs: &[String]) -> Result<Vec<FileDiff>, git2::Error> {
+    pub fn diff_files(&self, branch: &str, paths: &[String]) -> Result<Vec<FileDiff>, git2::Error> {
         let mut diffs = Vec::new();
-        for slug in slugs {
-            let path = format!("wiki/{slug}.md");
-            let main_content = self.read_file("main", &path)?;
-            let branch_content = self.read_file(branch, &path)?;
+        for p in paths {
+            let file_path = format!("{p}.md");
+            let main_content = self.read_file("main", &file_path)?;
+            let branch_content = self.read_file(branch, &file_path)?;
             let old_str = main_content
                 .as_ref()
                 .map(|b| String::from_utf8_lossy(b).into_owned());
@@ -650,7 +650,7 @@ impl WikiRepo {
                 new_str.as_deref().unwrap_or(""),
             );
             diffs.push(FileDiff {
-                path,
+                path: file_path,
                 old_content: old_str,
                 new_content: new_str,
                 hunks,
@@ -1290,6 +1290,122 @@ mod tests {
         assert!(repo
             .rename_path("user/r", "wiki/new.md", "wiki/exists.md", "mv", "r")
             .is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// diff_files accepts full repo paths (no hardcoded wiki/ prefix), so pages
+    /// from entities/ and concepts/ are diffed against the correct files.
+    #[test]
+    fn diff_files_uses_full_repo_paths() {
+        let (repo, dir) = temp_repo("diff-paths");
+        repo.ensure_branch_exists("user/a").unwrap();
+
+        // Write pages in different content directories
+        repo.write_file("user/a", "wiki/home.md", b"wiki page\n", "edit", "a")
+            .unwrap();
+        repo.write_file(
+            "user/a",
+            "entities/people/alice.md",
+            b"alice entity\n",
+            "edit",
+            "a",
+        )
+        .unwrap();
+        repo.write_file(
+            "user/a",
+            "concepts/patterns/error-handling.md",
+            b"error handling concept\n",
+            "edit",
+            "a",
+        )
+        .unwrap();
+
+        // diff_files with full repo paths (no .md extension per design)
+        let paths: Vec<String> = vec![
+            "wiki/home".into(),
+            "entities/people/alice".into(),
+            "concepts/patterns/error-handling".into(),
+        ];
+        let diffs = repo.diff_files("user/a", &paths).unwrap();
+        assert_eq!(diffs.len(), 3);
+
+        // Each path in the diff should carry the full .md file path
+        let diff_paths: Vec<&str> = diffs.iter().map(|d| d.path.as_str()).collect();
+        assert!(diff_paths.contains(&"wiki/home.md"));
+        assert!(diff_paths.contains(&"entities/people/alice.md"));
+        assert!(diff_paths.contains(&"concepts/patterns/error-handling.md"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// list_pages with dir=entities only returns pages under entities/,
+    /// not wiki/ or concepts/.
+    #[test]
+    fn list_pages_scoped_to_directory() {
+        let (repo, dir) = temp_repo("list-scoped");
+        repo.ensure_branch_exists("user/b").unwrap();
+
+        repo.write_file("user/b", "wiki/home.md", b"wiki\n", "e", "b")
+            .unwrap();
+        repo.write_file("user/b", "entities/alice.md", b"alice\n", "e", "b")
+            .unwrap();
+        repo.write_file(
+            "user/b",
+            "entities/people/bob.md",
+            b"bob\n",
+            "e",
+            "b",
+        )
+        .unwrap();
+
+        // list_pages_recursive under entities/
+        let entities_files =
+            crate::wiki_fs::list_pages_recursive(&repo, "user/b", "entities").unwrap();
+        assert_eq!(entities_files.len(), 2);
+        assert!(entities_files.iter().any(|f| f == "entities/alice.md"));
+        assert!(entities_files.iter().any(|f| f == "entities/people/bob.md"));
+
+        // list_pages_recursive under wiki/
+        let wiki_files =
+            crate::wiki_fs::list_pages_recursive(&repo, "user/b", "wiki").unwrap();
+        assert_eq!(wiki_files.len(), 1);
+        assert!(wiki_files.iter().any(|f| f == "wiki/home.md"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// write_file + read_file work with multi-directory paths — no hardcoded
+    /// assumptions about the content root.
+    #[test]
+    fn read_write_multi_directory() {
+        let (repo, dir) = temp_repo("multi-dir-rw");
+        repo.ensure_branch_exists("user/c").unwrap();
+
+        let test_cases = vec![
+            ("wiki/team-home.md", "team home content"),
+            ("entities/people/alice.md", "alice content"),
+            ("concepts/patterns/error-handling.md", "error handling content"),
+            ("wiki/research/ai-safety.md", "nested wiki page"),
+            ("entities/orgs/acme.md", "org entity"),
+        ];
+
+        for (file_path, content) in &test_cases {
+            repo.write_file("user/c", file_path, content.as_bytes(), "add", "c")
+                .unwrap();
+        }
+
+        for (file_path, expected) in &test_cases {
+            let got = repo
+                .read_file("user/c", file_path)
+                .unwrap()
+                .map(|b| String::from_utf8_lossy(&b).into_owned());
+            assert_eq!(
+                got.as_deref(),
+                Some(*expected),
+                "read_file({file_path}) should match written content"
+            );
+        }
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/core/src/models.rs
+++ b/crates/core/src/models.rs
@@ -12,7 +12,7 @@ pub struct Page {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DuplicateWarning {
-    pub new_slug: String,
-    pub existing_slug: String,
+    pub new_path: String,
+    pub existing_path: String,
     pub similarity: f64,
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -81,5 +81,10 @@ pub async fn run_migrations(pool: &PgPool, embedding_dim: u32) -> sqlx::Result<(
         tracing::error!("DB error: {e}");
         e
     })?;
+    let sql14 = include_str!("migrations/012_rename_page_slugs_to_paths.sql");
+    sqlx::raw_sql(sql14).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
     Ok(())
 }

--- a/crates/db/src/migrations/001_init.sql
+++ b/crates/db/src/migrations/001_init.sql
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS submissions (
     status TEXT NOT NULL DEFAULT 'pending'
         CHECK (status IN ('pending', 'approved', 'rejected', 'changes_requested')),
     summary TEXT NOT NULL DEFAULT '',
-    page_slugs TEXT[] NOT NULL DEFAULT '{}',
+    paths TEXT[] NOT NULL DEFAULT '{}',
     source_branch TEXT NOT NULL DEFAULT '',
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     reviewed_by UUID REFERENCES users(id),

--- a/crates/db/src/migrations/012_rename_page_slugs_to_paths.sql
+++ b/crates/db/src/migrations/012_rename_page_slugs_to_paths.sql
@@ -1,0 +1,3 @@
+-- Migration 012: Rename page_slugs → paths in submissions table
+-- Submit Path Awareness: replaces bare slugs with repo paths (dir-prefixed)
+ALTER TABLE submissions RENAME COLUMN page_slugs TO paths;

--- a/crates/db/src/submissions.rs
+++ b/crates/db/src/submissions.rs
@@ -58,7 +58,7 @@ pub struct Submission {
     pub user_id: Uuid,
     pub status: String,
     pub summary: String,
-    pub page_slugs: Vec<String>,
+    pub paths: Vec<String>,
     pub source_branch: String,
     pub workspace_slug: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
@@ -76,17 +76,17 @@ pub async fn create(
     pool: &PgPool,
     user_id: Uuid,
     summary: &str,
-    page_slugs: &[String],
+    paths: &[String],
     source_branch: &str,
     workspace_slug: &str,
 ) -> sqlx::Result<Submission> {
     sqlx::query_as::<_, Submission>(
-        "INSERT INTO submissions (user_id, summary, page_slugs, source_branch, workspace_slug) \
+        "INSERT INTO submissions (user_id, summary, paths, source_branch, workspace_slug) \
          VALUES ($1, $2, $3, $4, $5) RETURNING *",
     )
     .bind(user_id)
     .bind(summary)
-    .bind(page_slugs)
+    .bind(paths)
     .bind(source_branch)
     .bind(workspace_slug)
     .fetch_one(pool)
@@ -185,6 +185,7 @@ mod tests {
             include_str!("migrations/010_notifications.sql"),
             include_str!("migrations/010_invitation_reject_status.sql"),
             include_str!("migrations/011_pages_workspace_scope.sql"),
+            include_str!("migrations/012_rename_page_slugs_to_paths.sql"),
         ] {
             let _ = sqlx::raw_sql(m).execute(&pool).await;
         }

--- a/crates/server/src/routes/pages.rs
+++ b/crates/server/src/routes/pages.rs
@@ -513,18 +513,19 @@ fn list_pages_from_dir(
 
 // ── Path operations: rename / delete (files and folders under wiki/) ──
 
-/// Validate a repo path for destructive ops: must be inside `wiki/` (so `sources/` and
-/// other special trees are untouchable), no traversal, no empty segments, and never the
-/// `wiki` root itself.
+/// Validate a repo path for destructive ops: must be inside a known content directory
+/// (`wiki/`, `entities/`, `concepts/`), no traversal, no empty segments, and never the
+/// root itself.
 fn validate_wiki_path(p: &str) -> Result<()> {
-    let ok = p.starts_with("wiki/")
-        && p.len() > 5
+    let allowed = cowiki_core::wiki_fs::all_dirs();
+    let ok = allowed.iter().any(|d| p.starts_with(&format!("{d}/")))
         && !p.ends_with('/')
         && p.split('/')
             .all(|seg| !seg.is_empty() && seg != "." && seg != "..");
     if !ok {
         return Err(AppError::BadRequest(format!(
-            "invalid path '{p}': only paths inside wiki/ can be modified"
+            "invalid path '{p}': paths must be inside one of {:?}",
+            allowed
         )));
     }
     Ok(())

--- a/crates/server/src/routes/pages.rs
+++ b/crates/server/src/routes/pages.rs
@@ -321,9 +321,7 @@ pub async fn create_folder_ws(
         .collect::<Vec<_>>()
         .join("-");
     let parent = input.parent.as_deref().ok_or_else(|| {
-        AppError::BadRequest(
-            "parent is required (e.g. wiki, entities, entities/people)".into(),
-        )
+        AppError::BadRequest("parent is required (e.g. wiki, entities, entities/people)".into())
     })?;
     let dir = format!("{parent}/{slug}");
     let index_path = format!("{dir}/_index.md");
@@ -450,7 +448,12 @@ fn list_pages_from_dir(
     }
 
     // Build tree recursively
-    fn build_level(items: &[RawItem], parent_dir: &str, branch: &str, dir: &str) -> Vec<PageListItem> {
+    fn build_level(
+        items: &[RawItem],
+        parent_dir: &str,
+        branch: &str,
+        dir: &str,
+    ) -> Vec<PageListItem> {
         let mut result: Vec<PageListItem> = Vec::new();
 
         // Find pages directly in this directory (not _index)

--- a/crates/server/src/routes/pages.rs
+++ b/crates/server/src/routes/pages.rs
@@ -16,6 +16,7 @@ pub struct PageQueryParams {
 #[derive(Serialize, Clone)]
 pub struct PageListItem {
     pub slug: String,
+    pub path: String,
     pub title: String,
     pub summary: String,
     pub branch: String,
@@ -319,10 +320,12 @@ pub async fn create_folder_ws(
         .split_whitespace()
         .collect::<Vec<_>>()
         .join("-");
-    let dir = match &input.parent {
-        Some(p) => format!("{p}/{slug}"),
-        None => format!("wiki/{slug}"),
-    };
+    let parent = input.parent.as_deref().ok_or_else(|| {
+        AppError::BadRequest(
+            "parent is required (e.g. wiki, entities, entities/people)".into(),
+        )
+    })?;
+    let dir = format!("{parent}/{slug}");
     let index_path = format!("{dir}/_index.md");
     let body = format!(
         "---\ntitle: \"{}\"\nsummary: \"\"\nkind: overview\n---\n\n",
@@ -447,7 +450,7 @@ fn list_pages_from_dir(
     }
 
     // Build tree recursively
-    fn build_level(items: &[RawItem], parent_dir: &str, branch: &str) -> Vec<PageListItem> {
+    fn build_level(items: &[RawItem], parent_dir: &str, branch: &str, dir: &str) -> Vec<PageListItem> {
         let mut result: Vec<PageListItem> = Vec::new();
 
         // Find pages directly in this directory (not _index)
@@ -455,6 +458,9 @@ fn list_pages_from_dir(
             if item.dir == parent_dir && !item.is_index {
                 result.push(PageListItem {
                     slug: item.slug.clone(),
+                    // item.slug is the full relative path under dir (e.g. "people/alice"),
+                    // so dir + slug always produces the correct full path.
+                    path: format!("{}/{}", dir, item.slug),
                     title: item.title.clone(),
                     summary: item.summary.clone(),
                     branch: branch.into(),
@@ -487,9 +493,10 @@ fn list_pages_from_dir(
                     (name.to_string(), String::new())
                 });
 
-            let children = build_level(items, &subdir, branch);
+            let children = build_level(items, &subdir, branch, dir);
             result.push(PageListItem {
                 slug: format!("{subdir}/_index"),
+                path: format!("{dir}/{subdir}/_index"),
                 title,
                 summary,
                 branch: branch.into(),
@@ -507,7 +514,7 @@ fn list_pages_from_dir(
         result
     }
 
-    let tree = build_level(&items, "", branch);
+    let tree = build_level(&items, "", branch, dir);
     Ok(Json(tree))
 }
 
@@ -633,6 +640,7 @@ fn list_pages_all_dirs(
 
         let dir_node = PageListItem {
             slug: format!("{dir}/_index"),
+            path: format!("{dir}/_index"),
             title: dir.to_string(),
             summary: String::new(),
             branch: branch.into(),

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -11,7 +11,7 @@ use cowiki_core::models::DuplicateWarning;
 #[derive(Deserialize)]
 pub struct SubmitRequest {
     pub branch: String,
-    pub page_slugs: Vec<String>,
+    pub paths: Vec<String>,
     /// If true, skip review and merge directly to main (for Personal Space)
     #[serde(default)]
     pub skip_review: bool,
@@ -55,13 +55,13 @@ pub async fn submit(
         )));
     }
 
-    let diffs = match repo.diff_files(&input.branch, &input.page_slugs) {
+    let diffs = match repo.diff_files(&input.branch, &input.paths) {
         Ok(d) => d,
         Err(e) => {
             tracing::error!(
-                "failed to diff files for branch={} slugs={:?}: {}",
+                "failed to diff files for branch={} paths={:?}: {}",
                 &input.branch,
-                &input.page_slugs,
+                &input.paths,
                 e
             );
             return Err(AppError::Internal(e.to_string()));
@@ -70,30 +70,35 @@ pub async fn submit(
 
     // Generate embeddings for dedup
     let mut embeddings = Vec::new();
-    for slug in &input.page_slugs {
-        let path = format!("wiki/{slug}.md");
+    for p in &input.paths {
+        // Skip synthetic _index folders
+        if p.ends_with("/_index") {
+            continue;
+        }
+        let file_path = format!("{p}.md");
         let content = repo
-            .read_file(&input.branch, &path)
+            .read_file(&input.branch, &file_path)
             .map_err(|e| AppError::Internal(e.to_string()))?
-            .ok_or_else(|| AppError::BadRequest(format!("page {slug} not found")))?;
+            .ok_or_else(|| AppError::BadRequest(format!("page {p} not found")))?;
         let text = String::from_utf8_lossy(&content);
         super::pages::require_page_title(&text)?;
         if let Ok(emb) = state.compiler.embed(&text).await {
-            embeddings.push((slug.clone(), emb));
+            embeddings.push((p.clone(), emb));
         }
     }
 
     // Check for duplicates
     let mut duplicates = Vec::new();
-    for (slug, emb) in &embeddings {
+    for (path, emb) in &embeddings {
         if let Ok(similar) =
             cowiki_db::pages::find_similar(&state.db, emb, "main", 3, 0.85, Some(&ws_slug)).await
         {
             for (page, score) in similar {
-                if page.slug != *slug {
+                let submitted_slug = path.rsplit('/').next().unwrap_or(path);
+                if page.slug != submitted_slug {
                     duplicates.push(cowiki_core::models::DuplicateWarning {
-                        new_slug: slug.clone(),
-                        existing_slug: page.slug,
+                        new_path: path.clone(),
+                        existing_path: page.slug,
                         similarity: score,
                     });
                 }
@@ -170,7 +175,7 @@ pub async fn submit(
         &state.db,
         user.id,
         &summary,
-        &input.page_slugs,
+        &input.paths,
         &input.branch,
         &ws_slug,
     )

--- a/docs/superpowers/specs/2026-06-16-sidebar-sections-design.md
+++ b/docs/superpowers/specs/2026-06-16-sidebar-sections-design.md
@@ -1,0 +1,100 @@
+# Sidebar: 4-Section Directory Tree
+
+**Date:** 2026-06-16
+**Status:** design approved
+
+## Summary
+
+Replace the flat "Wiki Space" tree in the sidebar with 4 independent collapsible sections — Sources, Wiki, Entities, Concepts — each grouping pages by their slug prefix. Within each section, folders display above files, both sorted alphabetically.
+
+## Motivation
+
+The backend (`wiki_fs.rs`) already organizes pages under content directories: `wiki/`, `entities/`, `concepts/`. The frontend ignores this structure and renders a flat merged list. Surfacing the content directories in the UI gives users a clear mental model of where pages live and makes navigation faster as pages grow.
+
+## Design
+
+### Section Layout
+
+Four sections, displayed top-to-bottom in the sidebar tree area, replacing the current "Wiki Space" header section:
+
+| Order | Section | Content Source | Editable | Sort |
+|---|---|---|---|---|
+| 1 | **Sources** | `SourceItem[]` from API | Yes — add source, compile | Existing behavior |
+| 2 | **Wiki** | Pages with `wiki/` prefix | Yes — CRUD | Folders first, A→Z |
+| 3 | **Entities** | Pages with `entities/` prefix | Yes — CRUD | Folders first, A→Z |
+| 4 | **Concepts** | Pages with `concepts/` prefix | Yes — CRUD | Folders first, A→Z |
+
+All four sections are editable. Conflict resolution between sections is handled later by lint tooling.
+
+### Section Component
+
+Each section:
+- **Header row**: section name, chevron for expand/collapse (default: expanded), + button with dropdown (New Page, New Folder) scoped to that section's directory prefix
+- **Tree area**: folders-first, alphabetical sort. Folders render with the existing `PageTreeItem` recursive component with expand/collapse. Files render as existing leaf items.
+- **Empty state**: "No pages yet" italic placeholder when the section has zero items
+- **Collapse state**: local `useState`, not persisted across sessions
+
+### Data Flow
+
+```
+API: listPages() → PageMeta[] (flat)
+        ↓
+Group by slug prefix:
+  "wiki/" prefix     → Wiki section
+  "entities/" prefix → Entities section
+  "concepts/" prefix → Concepts section
+        ↓
+Per section: build tree from path segments, sort folders-first A→Z
+        ↓
+Render <Section> → <PageTreeItem> (existing, unchanged)
+```
+
+### Sort Rule
+
+At every tree level:
+1. Folders come before files
+2. Within folders: alphabetical by name
+3. Within files: alphabetical by title (fallback to slug)
+
+### Page Creation
+
+When creating a page or folder from a section's + menu, the slug automatically prepends the section's directory prefix:
+
+- Wiki section → `wiki/<slug>.md`
+- Entities section → `entities/<slug>.md`
+- Concepts section → `concepts/<slug>.md`
+
+The existing `handleCreatePage` / `handleCreateFolder` in `MainLayout.tsx` are modified to accept a `dir` parameter.
+
+### Sources Section
+
+Unchanged from current implementation. Controlled by `SourceItem[]` from the API, collapsible, with "Add Source" and "Compile" actions in the context menu.
+
+### What Goes Away
+
+- The "Wiki Space" label above the tree
+- The global + button (now per-section)
+- The flat page rendering loop — replaced by the 4-section grouped render
+
+## Files Touched
+
+| File | Change |
+|---|---|
+| `web/src/components/layout/SpacePanel.tsx` | Replace flat tree with 4 sections; add grouping + sorting logic; remove "Wiki Space" header |
+| `web/src/pages/MainLayout.tsx` | Pass `dir` prefix to page/folder creation handlers |
+| `web/src/api.ts` | No changes (API already supports slug prefixes) |
+
+## Backend
+
+No backend changes required. `wiki_fs.rs` already supports `wiki/`, `entities/`, `concepts/` as content directories. The `listPages` API already returns slugs with full paths.
+
+## Non-Goals
+
+- Pinning/sticky items (deferred)
+- Persisted collapse state (default: all expanded)
+- Custom sort within sections (folders-first-alphabetical only)
+- Lint/conflict resolution between sections (deferred to separate tooling)
+
+## Open Questions
+
+None.

--- a/docs/superpowers/specs/2026-06-17-submit-path-awareness-design.md
+++ b/docs/superpowers/specs/2026-06-17-submit-path-awareness-design.md
@@ -1,0 +1,279 @@
+# Submit Path Awareness — Design Spec
+
+**Date:** 2026-06-17
+**PR:** [#92](https://github.com/wfnuser/cowiki/pull/92)
+**Status:** approved
+
+## Problem
+
+The submit flow uses bare page slugs (`people/alice`) throughout the stack, with `wiki/` hardcoded at three call sites. Now that the sidebar uses a 4-section directory tree (`wiki/`, `entities/`, `concepts/`), a bare slug is ambiguous — the server cannot know which content directory it belongs to.
+
+Three hardcoded `wiki/{slug}.md` sites:
+
+| Site | File |
+|------|------|
+| diff against main | `crates/core/src/git.rs:639` |
+| embedding + dedup loop | `crates/server/src/routes/submit.rs:74` |
+| CLI flatten | `cli/src/commands/submit.ts:32` |
+
+## Design
+
+Replace bare slugs with **repo paths** in the submit contract. A repo path is a directory-prefixed slug without `.md` extension: `entities/people/alice`, `wiki/team-home`, `concepts/patterns/error-handling`.
+
+### Principle
+
+`slug` = short display identifier (unchanged). `path` = full repo location (new). Two fields, two responsibilities.
+
+---
+
+## 1. Data Model
+
+### 1.1 `PageListItem` (server → JSON)
+
+Add `path` field alongside existing `slug`:
+
+```rust
+pub struct PageListItem {
+    pub slug: String,       // "people/alice" — unchanged, for display/routing
+    pub path: String,       // NEW — "entities/people/alice"
+    pub title: String,
+    pub summary: String,
+    pub branch: String,
+    pub kind: String,       // "page" | "folder"
+    pub children: Vec<PageListItem>,
+}
+```
+
+### 1.2 `SubmitRequest`
+
+```rust
+pub struct SubmitRequest {
+    pub branch: String,
+    pub paths: Vec<String>,  // was: page_slugs
+    #[serde(default)]
+    pub skip_review: bool,
+}
+```
+
+```typescript
+// cli/src/types.ts
+interface SubmitRequest {
+  branch: string;
+  paths: string[];  // was: page_slugs
+}
+```
+
+### 1.3 `PageMeta` (CLI)
+
+```typescript
+interface PageMeta {
+  slug: string;
+  path: string;       // NEW
+  title: string;
+  summary: string;
+  branch: string;
+  kind?: string;      // "page" | "folder"
+  children?: PageMeta[];
+}
+```
+
+### 1.4 `submissions` table
+
+Column `page_slugs` → `paths`. Stores JSON string array of repo paths.
+
+### 1.5 Frontend `Submission` type
+
+```typescript
+interface Submission {
+  // page_slugs: string[];  // removed
+  paths: string[];          // added
+}
+```
+
+---
+
+## 2. Server Changes
+
+### 2.1 `list_pages_from_dir` — construct `path`
+
+```rust
+// Leaf pages
+result.push(PageListItem {
+    slug: item.slug.clone(),
+    path: format!("{}/{}", dir, item.slug),  // "entities/people/alice"
+    ...
+});
+
+// Folder nodes
+result.push(PageListItem {
+    slug: format!("{subdir}/_index"),
+    path: format!("{dir}/{subdir}/_index"),   // "entities/people/_index"
+    ...
+});
+```
+
+### 2.2 `list_pages_all_dirs`
+
+No special treatment needed — delegates to `list_pages_from_dir` which now builds correct paths per directory. Top-level `dir_node` path = `format!("{dir}/_index")`.
+
+### 2.3 `diff_files` — accept paths
+
+```rust
+// Before
+pub fn diff_files(&self, branch: &str, slugs: &[String]) -> ... {
+    for slug in slugs {
+        let path = format!("wiki/{slug}.md");
+
+// After
+pub fn diff_files(&self, branch: &str, paths: &[String]) -> ... {
+    for p in paths {
+        let file_path = format!("{p}.md");
+```
+
+### 2.4 Submit embedding loop
+
+```rust
+// Before
+for slug in &input.page_slugs {
+    let path = format!("wiki/{slug}.md");
+
+// After
+for p in &input.paths {
+    let file_path = format!("{p}.md");
+    // Skip synthetic _index folders
+    if p.ends_with("/_index") { continue; }
+```
+
+### 2.5 `submissions` DB
+
+- Rename column: `page_slugs` → `paths`
+- Migration: SQLite `ALTER TABLE RENAME COLUMN` (3.25.0+)
+- Update `create` function signature: `paths: &[String]` instead of `page_slugs: &[String]`
+
+### 2.6 MCP server
+
+```rust
+pub struct SubmitParams { pub paths: Vec<String>, }  // was: page_slugs
+```
+
+---
+
+## 3. CLI Changes
+
+### 3.1 `submit.ts` — flatten paths, not slugs
+
+```typescript
+function flattenPaths(pages: PageMeta[]): string[] {
+  const paths: string[] = [];
+  for (const p of pages) {
+    if (p.kind === 'folder' && p.children && p.children.length > 0) {
+      paths.push(...flattenPaths(p.children));
+    } else if (p.kind !== 'folder') {
+      paths.push(p.path);
+    }
+  }
+  return paths;
+}
+```
+
+### 3.2 `--dir` parameter
+
+```bash
+cowiki submit -w myws people/alice                    # → wiki/people/alice
+cowiki submit -w myws people/alice --dir entities     # → entities/people/alice
+cowiki submit -w myws entities/people/alice           # CLI detects known dir prefix, uses as-is
+cowiki submit -w myws --all --dir entities --yes      # submit all in entities/
+cowiki submit -w myws --all --dir all --yes           # submit all across all dirs
+```
+
+Default `--dir` = `wiki`. When the slug already starts with a known content directory (`wiki/`, `entities/`, `concepts/`), it is passed through as-is without prepending.
+
+### 3.3 SKILL docs
+
+Update `cli/skills/cowiki-cli/commands.md` with `--dir` examples.
+
+---
+
+## 4. Frontend Changes
+
+### 4.1 `ActiveView` — store `path`
+
+`ActiveView` currently tracks `{ kind, slug, content }`. Add `path` so page actions can derive the content directory from the node itself:
+
+```typescript
+type ActiveView = {
+  kind: 'page' | ...;
+  slug: string;
+  path?: string;   // NEW — "entities/people/alice"
+  content: PageFull | null;
+} | null;
+```
+
+### 4.2 Remove `pageDirMap` / `getPageDir`
+
+Currently `pageDirMap` (`Record<string, string>`) maps slug → dir, built by walking the page tree. `getPageDir(slug)` falls back to `'wiki'` when no entry exists.
+
+**Problem:** `pageDirMap` is keyed by slug, which is ambiguous across directories. A draft-only page in `entities/` won't be in the map if it was built from main pages only — it falls back to `wiki/`, causing read/save/delete to target the wrong directory.
+
+**Fix:** With `PageListItem.path` now available, derive the directory directly from the selected node's `path` (first segment before `/`). Remove `pageDirMap` state, `buildPageDirMap()`, and `getPageDir()`.
+
+Three call sites change:
+
+| Site | Before | After |
+|------|--------|-------|
+| `selectPage` (L307) | `const dir = getPageDir(slug)` | `const dir = path.split('/')[0]` |
+| path ops callback (L586) | `const dir = getPageDir(activeView.slug)` | `const dir = activeView.path?.split('/')[0] \|\| 'wiki'` |
+| `handleSavePage` (L604) | `const dir = getPageDir(slug)` | `const dir = activeView.path?.split('/')[0] \|\| 'wiki'` |
+
+`selectPage` signature changes from `(ws, slug)` to `(ws, slug, path)` — the sidebar passes the node's `path` when selecting.
+
+### 4.3 `api.ts`
+
+```typescript
+export async function submit(branch: string, paths: string[], ...) {
+  body: JSON.stringify({ branch, paths, ... }),
+```
+
+### 4.4 `ReviewDetail.tsx` / `ReviewList.tsx`
+
+Replace `submission.page_slugs` with `submission.paths`. Strip leading content-dir prefix for display (e.g., `entities/people/alice` → show as `entities/people/alice`).
+
+### 4.5 `MainLayout.tsx` — tree merge key
+
+Switch merge key from `slug` to `path`:
+
+```typescript
+const mainByPath = new Map(main.map((p) => [p.path, p]));
+// ...
+const existing = mainByPath.get(dp.path);
+```
+
+`mergePageTrees` uses `path` for identity comparison throughout. Sorting still uses `title`.
+
+---
+
+## 5. Files Affected
+
+| File | Change |
+|------|--------|
+| `crates/server/src/routes/submit.rs` | `SubmitRequest.paths`, loop uses paths |
+| `crates/server/src/routes/pages.rs` | `PageListItem.path`, construction in build_level |
+| `crates/core/src/git.rs` | `diff_files` signature: `slugs` → `paths` |
+| `crates/db/src/submissions.rs` | column rename + function signatures |
+| `cowiki-mcp-server/src/server.rs` | `SubmitParams.paths` |
+| `cli/src/types.ts` | `SubmitRequest.paths`, `PageMeta.path` |
+| `cli/src/commands/submit.ts` | `flattenPaths`, `--dir` flag |
+| `cli/src/client.ts` | `SubmitRequest` type import |
+| `cli/skills/cowiki-cli/commands.md` | `--dir` docs |
+| `web/src/api.ts` | `submit()` signature |
+| `web/src/pages/MainLayout.tsx` | merge key → `path`, remove `pageDirMap`/`getPageDir`, `ActiveView` +`path`, `selectPage` +`path` param |
+| `web/src/components/review/ReviewDetail.tsx` | display `paths` |
+| `web/src/components/review/ReviewList.tsx` | display `paths` |
+
+---
+
+## 6. Non-Goals
+
+- Backward compatibility for `page_slugs`. Per wfnuser: "no legacy `page_slugs` compatibility needed."
+- Changing URL routing or slug semantics. `slug` remains the display/routing identifier.
+- Changing `diff_ref_against_main` — it operates on refs, not individual slugs, so it is unaffected.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -297,8 +297,8 @@ export async function listMembers(workspaceSlug: string): Promise<MemberInfo[]> 
 
 // ── Pages ──
 
-export async function listPages(branch = 'main', workspaceSlug: string): Promise<PageMeta[]> {
-  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/pages?branch=${branch}`, { headers: h() });
+export async function listPages(branch = 'main', workspaceSlug: string, dir = 'all'): Promise<PageMeta[]> {
+  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/pages?branch=${encodeURIComponent(branch)}&dir=${encodeURIComponent(dir)}`, { headers: h() });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.error || `Request failed: ${res.status}`);
@@ -306,8 +306,8 @@ export async function listPages(branch = 'main', workspaceSlug: string): Promise
   return res.json();
 }
 
-export async function getPage(slug: string, branch = 'main', workspaceSlug: string): Promise<PageFull> {
-  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/pages/${slug}?branch=${branch}`, { headers: h() });
+export async function getPage(slug: string, branch = 'main', workspaceSlug: string, dir = 'wiki'): Promise<PageFull> {
+  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/pages/${encodeURIComponent(slug)}?branch=${encodeURIComponent(branch)}&dir=${encodeURIComponent(dir)}`, { headers: h() });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.error || `Request failed: ${res.status}`);
@@ -315,11 +315,11 @@ export async function getPage(slug: string, branch = 'main', workspaceSlug: stri
   return res.json();
 }
 
-export async function writePage(slug: string, body: string, branch: string, workspaceSlug: string): Promise<void> {
+export async function writePage(slug: string, body: string, branch: string, workspaceSlug: string, dir = 'wiki'): Promise<void> {
   const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/pages`, {
     method: 'POST',
     headers: h({ 'Content-Type': 'application/json' }),
-    body: JSON.stringify({ slug, body, branch }),
+    body: JSON.stringify({ slug, body, branch, dir }),
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -10,6 +10,7 @@ function h(extra: Record<string, string> = {}): Record<string, string> {
 
 export interface PageMeta {
   slug: string;
+  path: string;
   title: string;
   summary: string;
   branch: string;
@@ -26,7 +27,7 @@ export interface Submission {
   user_id: string;
   status: string;
   summary: string;
-  page_slugs: string[];
+  paths: string[];
   source_branch: string;
   created_at: string;
   reviewed_by: string | null;
@@ -357,11 +358,11 @@ export async function compile(branch: string, workspaceSlug: string) {
 
 // ── Submit & Review ──
 
-export async function submit(branch: string, pageSlugs: string[], skipReview: boolean, workspaceSlug: string) {
+export async function submit(branch: string, paths: string[], skipReview: boolean, workspaceSlug: string) {
   const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/submit`, {
     method: 'POST',
     headers: h({ 'Content-Type': 'application/json' }),
-    body: JSON.stringify({ branch, page_slugs: pageSlugs, skip_review: skipReview }),
+    body: JSON.stringify({ branch, paths, skip_review: skipReview }),
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));

--- a/web/src/components/SearchModal.tsx
+++ b/web/src/components/SearchModal.tsx
@@ -52,7 +52,7 @@ export function SearchModal({
   workspaceName: string;
   open: boolean;
   onClose: () => void;
-  onSelectPage: (slug: string) => void;
+  onSelectPage: (slug: string, path?: string) => void;
 }) {
   const [q, setQ] = useState('');
   const [kw, setKw] = useState<SearchResponse['keyword'] | null>(null);

--- a/web/src/components/layout/SpacePanel.tsx
+++ b/web/src/components/layout/SpacePanel.tsx
@@ -27,7 +27,7 @@ interface SpacePanelProps {
   reviewCount: number;
   isPersonal: boolean;
   isOwner: boolean;
-  onSelectPage: (slug: string) => void;
+  onSelectPage: (slug: string, path?: string) => void;
   onSelectSource: (filename: string) => void;
   onNewPage: (dir?: ContentDir) => void;
   onNewFolder: (dir?: ContentDir) => void;
@@ -438,7 +438,7 @@ function SourceEntry({
   source: SourceItem;
   active: boolean;
   onSelect: () => void;
-  onSelectPage?: (slug: string) => void;
+  onSelectPage?: (slug: string, path?: string) => void;
 }) {
   return (
     <div>
@@ -495,7 +495,7 @@ function PageTreeItem({
   dir: ContentDir;
   activePage: string | null;
   depth: number;
-  onSelectPage: (slug: string) => void;
+  onSelectPage: (slug: string, path?: string) => void;
   onAddPageInFolder: (folderPath: string) => void;
   onAddFolderInFolder: (parentPath: string) => void;
   onRenamePath: (path: string, isFolder: boolean, title: string) => void;
@@ -600,7 +600,7 @@ function PageTreeItem({
         if (btn) btn.style.opacity = '0';
       }}
     >
-      <span onClick={() => onSelectPage(page.slug)} style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+      <span onClick={() => onSelectPage(page.slug, page.path)} style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
         <FileText size={14} style={{ flexShrink: 0 }} />
         <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{title}</span>
       </span>

--- a/web/src/components/layout/SpacePanel.tsx
+++ b/web/src/components/layout/SpacePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import {
   ChevronRight, FileText, Folder, Upload, Wand2,
   MoreHorizontal, Plus, FolderPlus, Settings, BookOpen, GitPullRequest, Users, Activity,
@@ -13,6 +13,9 @@ import { C } from '@/lib/design';
 
 export type NavTab = 'wiki' | 'reviews' | 'members' | 'activity';
 
+/** Supported content directory prefixes */
+type ContentDir = 'wiki' | 'entities' | 'concepts';
+
 interface SpacePanelProps {
   workspace: Workspace | null;
   activeTab: NavTab;
@@ -26,11 +29,11 @@ interface SpacePanelProps {
   isOwner: boolean;
   onSelectPage: (slug: string) => void;
   onSelectSource: (filename: string) => void;
-  onNewPage: () => void;
-  onNewFolder: () => void;
-  onAddPageInFolder: (folderPath: string) => void;
-  onAddFolderInFolder: (parentPath: string) => void;
-  /** path is the repo path: wiki/<slug>.md for pages, wiki/<dir> for folders */
+  onNewPage: (dir?: ContentDir) => void;
+  onNewFolder: (dir?: ContentDir) => void;
+  onAddPageInFolder: (folderPath: string, dir: ContentDir) => void;
+  onAddFolderInFolder: (parentPath: string, dir: ContentDir) => void;
+  /** path is the repo path: <dir>/<slug>.md for pages, <dir>/<dir> for folders */
   onRenamePath: (path: string, isFolder: boolean, title: string) => void;
   onDeletePath: (path: string, isFolder: boolean, title: string) => void;
   onShowIngest: () => void;
@@ -88,6 +91,8 @@ export function SpacePanel({
     { tab: 'members', icon: <Users size={16} />, label: 'Members & roles', hide: isPersonal },
     { tab: 'activity', icon: <Activity size={16} />, label: 'Activity' },
   ];
+
+  const wikiActive = activeTab === 'wiki';
 
   return (
     <aside style={panelStyle}>
@@ -181,59 +186,147 @@ export function SpacePanel({
           </span>
         </button>
 
-        {/* Wiki Space header */}
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 10px', margin: '12px 0 8px' }}>
-          <span style={{ fontSize: 11.5, fontWeight: 600, color: C.faint, textTransform: 'uppercase', letterSpacing: '0.07em' }}>
-            Wiki Space
-          </span>
+        {/* Section 1: Sources */}
+        <ContentSection
+          title="Sources"
+          items={sources}
+          emptyText="No sources yet"
+          renderItem={(s) => (
+            <SourceEntry
+              key={s.filename}
+              source={s}
+              active={activeSource === s.filename}
+              onSelect={() => onSelectSource(s.filename)}
+              onSelectPage={wikiActive ? onSelectPage : undefined}
+            />
+          )}
+          menuItems={
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: C.faint, display: 'flex' }}
+                  onClick={(e) => e.stopPropagation()}>
+                  <MoreHorizontal size={13} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-36">
+                <DropdownMenuItem onClick={onShowIngest}><Upload size={14} className="mr-2" /> Add Source</DropdownMenuItem>
+                <DropdownMenuItem onClick={onCompile}><Wand2 size={14} className="mr-2" /> Compile</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          }
+        />
+
+        {/* Section 2: Wiki */}
+        <ContentSection
+          title="Wiki"
+          defaultExpanded
+          items={filterAndSortPages(pages, 'wiki')}
+          emptyText="No pages yet"
+          renderItem={(p) => (
+            <PageTreeItem
+              key={p.slug}
+              page={p}
+              dir="wiki"
+              activePage={wikiActive ? activePage : null}
+              depth={0}
+              onSelectPage={onSelectPage}
+              onAddPageInFolder={(fp) => onAddPageInFolder(fp, 'wiki')}
+              onAddFolderInFolder={(pp) => onAddFolderInFolder(pp, 'wiki')}
+              onRenamePath={onRenamePath}
+              onDeletePath={onDeletePath}
+            />
+          )}
+          menuItems={
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button style={{
                   background: 'none', border: 'none', cursor: 'pointer', padding: 2, borderRadius: 4,
                   color: C.faint, display: 'flex',
-                }}>
+                }} onClick={(e) => e.stopPropagation()}>
                   <Plus size={14} />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-40">
-                <DropdownMenuItem onClick={onNewPage}><FileText size={14} className="mr-2" /> New Page</DropdownMenuItem>
-                <DropdownMenuItem onClick={onNewFolder}><FolderPlus size={14} className="mr-2" /> New Folder</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onNewPage('wiki')}><FileText size={14} className="mr-2" /> New Page</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onNewFolder('wiki')}><FolderPlus size={14} className="mr-2" /> New Folder</DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-          </div>
+          }
+        />
 
-          <>
-              {/* Sources section */}
-              <SourcesSection
-                sources={sources}
-                activeSource={activeTab === 'wiki' ? activeSource : null}
-                onSelectSource={onSelectSource}
-                onSelectPage={onSelectPage}
-                onShowIngest={onShowIngest}
-                onCompile={onCompile}
-              />
+        {/* Section 3: Entities */}
+        <ContentSection
+          title="Entities"
+          items={filterAndSortPages(pages, 'entities')}
+          emptyText="No pages yet"
+          renderItem={(p) => (
+            <PageTreeItem
+              key={p.slug}
+              page={p}
+              dir="entities"
+              activePage={wikiActive ? activePage : null}
+              depth={0}
+              onSelectPage={onSelectPage}
+              onAddPageInFolder={(fp) => onAddPageInFolder(fp, 'entities')}
+              onAddFolderInFolder={(pp) => onAddFolderInFolder(pp, 'entities')}
+              onRenamePath={onRenamePath}
+              onDeletePath={onDeletePath}
+            />
+          )}
+          menuItems={
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button style={{
+                  background: 'none', border: 'none', cursor: 'pointer', padding: 2, borderRadius: 4,
+                  color: C.faint, display: 'flex',
+                }} onClick={(e) => e.stopPropagation()}>
+                  <Plus size={14} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-40">
+                <DropdownMenuItem onClick={() => onNewPage('entities')}><FileText size={14} className="mr-2" /> New Page</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onNewFolder('entities')}><FolderPlus size={14} className="mr-2" /> New Folder</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          }
+        />
 
-              {/* Page tree */}
-              {pages.length === 0 ? (
-                <div style={{ padding: '8px 8px', fontSize: 12, color: C.faint, fontStyle: 'italic' }}>
-                  No pages yet
-                </div>
-              ) : (
-                pages.map((p) => (
-                  <PageTreeItem
-                    key={p.slug}
-                    page={p}
-                    activePage={activeTab === 'wiki' ? activePage : null}
-                    depth={0}
-                    onSelectPage={onSelectPage}
-                    onAddPageInFolder={onAddPageInFolder}
-                    onAddFolderInFolder={onAddFolderInFolder}
-                    onRenamePath={onRenamePath}
-                    onDeletePath={onDeletePath}
-                  />
-                ))
-              )}
-            </>
+        {/* Section 4: Concepts */}
+        <ContentSection
+          title="Concepts"
+          items={filterAndSortPages(pages, 'concepts')}
+          emptyText="No pages yet"
+          renderItem={(p) => (
+            <PageTreeItem
+              key={p.slug}
+              page={p}
+              dir="concepts"
+              activePage={wikiActive ? activePage : null}
+              depth={0}
+              onSelectPage={onSelectPage}
+              onAddPageInFolder={(fp) => onAddPageInFolder(fp, 'concepts')}
+              onAddFolderInFolder={(pp) => onAddFolderInFolder(pp, 'concepts')}
+              onRenamePath={onRenamePath}
+              onDeletePath={onDeletePath}
+            />
+          )}
+          menuItems={
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button style={{
+                  background: 'none', border: 'none', cursor: 'pointer', padding: 2, borderRadius: 4,
+                  color: C.faint, display: 'flex',
+                }} onClick={(e) => e.stopPropagation()}>
+                  <Plus size={14} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-40">
+                <DropdownMenuItem onClick={() => onNewPage('concepts')}><FileText size={14} className="mr-2" /> New Page</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onNewFolder('concepts')}><FolderPlus size={14} className="mr-2" /> New Folder</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          }
+        />
       </div>
 
       <SearchModal
@@ -249,95 +342,87 @@ export function SpacePanel({
   );
 }
 
-/* ── Sources section ── */
-function SourcesSection({
-  sources,
-  activeSource,
-  onSelectSource,
-  onSelectPage,
-  onShowIngest,
-  onCompile,
-}: {
-  sources: SourceItem[];
-  activeSource: string | null;
-  onSelectSource: (filename: string) => void;
-  onSelectPage: (slug: string) => void;
-  onShowIngest: () => void;
-  onCompile: () => void;
-}) {
-  const [expanded, setExpanded] = useState(false);
+/* ── Helpers ── */
+
+/** Filter pages by slug prefix and sort folders-first, then A→Z */
+function filterAndSortPages(pages: PageMeta[], prefix: ContentDir): PageMeta[] {
+  const dirNode = pages.find((p) => p.slug === `${prefix}/_index` && p.kind === 'folder');
+  if (!dirNode || !dirNode.children) return [];
+  return sortPages(dirNode.children);
+}
+
+/** Sort pages: folders first, then A→Z within each group */
+function sortPages(pages: PageMeta[]): PageMeta[] {
+  return [...pages].sort((a, b) => {
+    const aFolder = a.kind === 'folder' ? 0 : 1;
+    const bFolder = b.kind === 'folder' ? 0 : 1;
+    if (aFolder !== bFolder) return aFolder - bFolder;
+    const aName = (a.title || a.slug).toLowerCase();
+    const bName = (b.title || b.slug).toLowerCase();
+    return aName.localeCompare(bName);
+  });
+}
+
+/* ── Section header component ── */
+
+interface SectionHeaderProps {
+  title: string;
+  expanded: boolean;
+  onToggle: () => void;
+  menuItems?: React.ReactNode;
+}
+
+function SectionHeader({ title, expanded, onToggle, menuItems }: SectionHeaderProps) {
+  return (
+    <div
+      style={{
+        display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px',
+        borderRadius: 6, cursor: 'pointer', userSelect: 'none',
+        fontSize: 14, color: C.ink2,
+      }}
+      onMouseEnter={(e) => { e.currentTarget.style.background = C.rail; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+    >
+      <span onClick={onToggle} style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1 }}>
+        <ChevronRight size={12} style={{ transform: expanded ? 'rotate(90deg)' : 'none', transition: 'transform 0.15s' }} />
+        <Folder size={14} />
+        <span>{title}</span>
+      </span>
+      {menuItems}
+    </div>
+  );
+}
+
+/* ── Unified collapsible section ── */
+
+interface ContentSectionProps<T> {
+  title: string;
+  defaultExpanded?: boolean;
+  items: T[];
+  emptyText: string;
+  renderItem: (item: T) => React.ReactNode;
+  menuItems?: React.ReactNode;
+}
+
+function ContentSection<T>({
+  title, defaultExpanded = false, items, emptyText, renderItem, menuItems,
+}: ContentSectionProps<T>) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
 
   return (
     <>
-      <div
-        style={{
-          display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px',
-          borderRadius: 6, cursor: 'pointer', userSelect: 'none',
-          fontSize: 14, color: C.ink2,
-        }}
-        onMouseEnter={(e) => { e.currentTarget.style.background = C.rail; }}
-        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
-      >
-        <span onClick={() => setExpanded(!expanded)} style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1 }}>
-          <ChevronRight size={12} style={{ transform: expanded ? 'rotate(90deg)' : 'none', transition: 'transform 0.15s' }} />
-          <Folder size={14} />
-          <span>Sources</span>
-        </span>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: C.faint, display: 'flex' }}
-              onClick={(e) => e.stopPropagation()}>
-              <MoreHorizontal size={13} />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-36">
-            <DropdownMenuItem onClick={onShowIngest}><Upload size={14} className="mr-2" /> Add Source</DropdownMenuItem>
-            <DropdownMenuItem onClick={onCompile}><Wand2 size={14} className="mr-2" /> Compile</DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      <SectionHeader
+        title={title}
+        expanded={expanded}
+        onToggle={() => setExpanded(!expanded)}
+        menuItems={menuItems}
+      />
       {expanded && (
         <div style={{ paddingLeft: 16 }}>
-          {sources.length === 0 ? (
-            <div style={{ padding: '4px 8px', fontSize: 12, color: C.faint, fontStyle: 'italic' }}>No sources yet</div>
+          {items.length === 0 ? (
+            <div style={{ padding: '4px 8px', fontSize: 12, color: C.faint, fontStyle: 'italic' }}>{emptyText}</div>
           ) : (
-            sources.map((s) => (
-              <div key={s.filename}>
-                <button
-                  onClick={() => onSelectSource(s.filename)}
-                  style={{
-                    display: 'flex', alignItems: 'center', gap: 8, width: '100%',
-                    padding: '6px 10px', borderRadius: 6, border: 'none', cursor: 'pointer',
-                    background: activeSource === s.filename ? 'rgba(0,0,0,0.05)' : 'transparent',
-                    color: activeSource === s.filename ? C.ink : C.ink2,
-                    fontSize: 14, fontWeight: activeSource === s.filename ? 550 : 400,
-                    textAlign: 'left',
-                  }}
-                  onMouseEnter={(e) => { if (activeSource !== s.filename) e.currentTarget.style.background = C.rail; }}
-                  onMouseLeave={(e) => { if (activeSource !== s.filename) e.currentTarget.style.background = 'transparent'; }}
-                >
-                  {s.compiled ? <CheckCircle2 size={14} color={C.green} /> : <Clock size={14} color={C.amber} />}
-                  <FileCode size={14} />
-                  <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.filename}</span>
-                </button>
-                {s.compiled && s.compiled_pages.length > 0 && (
-                  <div style={{ paddingLeft: 24, display: 'flex', flexWrap: 'wrap', gap: 2, paddingBottom: 2 }}>
-                    {s.compiled_pages.map((slug) => (
-                      <button
-                        key={slug}
-                        onClick={(e) => { e.stopPropagation(); onSelectPage(slug); }}
-                        style={{
-                          background: 'none', border: 'none', cursor: 'pointer',
-                          fontSize: 10, color: C.faint, padding: 0,
-                        }}
-                      >
-                        {slug}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            ))
+            items.map(renderItem)
           )}
         </div>
       )}
@@ -345,9 +430,59 @@ function SourcesSection({
   );
 }
 
+/* ── Source entry (custom view showing compilation status) ── */
+
+function SourceEntry({
+  source, active, onSelect, onSelectPage,
+}: {
+  source: SourceItem;
+  active: boolean;
+  onSelect: () => void;
+  onSelectPage?: (slug: string) => void;
+}) {
+  return (
+    <div>
+      <button
+        onClick={onSelect}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 8, width: '100%',
+          padding: '6px 10px', borderRadius: 6, border: 'none', cursor: 'pointer',
+          background: active ? 'rgba(0,0,0,0.05)' : 'transparent',
+          color: active ? C.ink : C.ink2,
+          fontSize: 14, fontWeight: active ? 550 : 400,
+          textAlign: 'left',
+        }}
+        onMouseEnter={(e) => { if (!active) e.currentTarget.style.background = C.rail; }}
+        onMouseLeave={(e) => { if (!active) e.currentTarget.style.background = 'transparent'; }}
+      >
+        {source.compiled ? <CheckCircle2 size={14} color={C.green} /> : <Clock size={14} color={C.amber} />}
+        <FileCode size={14} />
+        <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{source.filename}</span>
+      </button>
+      {source.compiled && source.compiled_pages.length > 0 && onSelectPage && (
+        <div style={{ paddingLeft: 24, display: 'flex', flexWrap: 'wrap', gap: 2, paddingBottom: 2 }}>
+          {source.compiled_pages.map((slug) => (
+            <button
+              key={slug}
+              onClick={(e) => { e.stopPropagation(); onSelectPage(slug); }}
+              style={{
+                background: 'none', border: 'none', cursor: 'pointer',
+                fontSize: 10, color: C.faint, padding: 0,
+              }}
+            >
+              {slug}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /* ── Page tree item ── */
 function PageTreeItem({
   page,
+  dir,
   activePage,
   depth,
   onSelectPage,
@@ -357,6 +492,7 @@ function PageTreeItem({
   onDeletePath,
 }: {
   page: PageMeta;
+  dir: ContentDir;
   activePage: string | null;
   depth: number;
   onSelectPage: (slug: string) => void;
@@ -370,8 +506,16 @@ function PageTreeItem({
   const isActive = activePage === page.slug;
   const title = page.title || page.slug;
 
+  // Hook must be at top level — not inside a conditional
+  const sortedChildren = useMemo(() => {
+    if (page.kind !== 'folder' || !page.children || page.children.length === 0) return [];
+    return sortPages(page.children);
+  }, [page.kind, page.children]);
+
   if (page.kind === 'folder') {
-    const folderPath = 'wiki/' + page.slug.replace('/_index', '');
+    // folderPath strips the _index suffix and prepends the dir prefix
+    const folderPath = dir + '/' + page.slug.replace('/_index', '');
+
     return (
       <>
         <div
@@ -415,10 +559,11 @@ function PageTreeItem({
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
-        {open && page.children?.map((child) => (
+        {open && sortedChildren.map((child) => (
           <PageTreeItem
             key={child.slug}
             page={child}
+            dir={dir}
             activePage={activePage}
             depth={depth + 1}
             onSelectPage={onSelectPage}
@@ -432,7 +577,7 @@ function PageTreeItem({
     );
   }
 
-  const pagePath = `wiki/${page.slug}.md`;
+  const pagePath = `${dir}/${page.slug}.md`;
   return (
     <div
       style={{

--- a/web/src/components/review/ReviewDetail.tsx
+++ b/web/src/components/review/ReviewDetail.tsx
@@ -360,12 +360,12 @@ export function ReviewDetail({
               Labels
             </div>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
-              {submission.page_slugs.map((slug) => (
-                <span key={slug} style={{
+              {submission.paths.map((p) => (
+                <span key={p} style={{
                   fontSize: 11.5, padding: '2px 8px', borderRadius: 999,
                   background: C.rail, color: C.ink2,
                 }}>
-                  {slug}
+                  {p}
                 </span>
               ))}
             </div>

--- a/web/src/components/review/ReviewList.tsx
+++ b/web/src/components/review/ReviewList.tsx
@@ -112,12 +112,12 @@ export function ReviewList({
                 {/* Main content */}
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ fontSize: 15, fontWeight: 550, color: C.ink, marginBottom: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    {s.summary || s.page_slugs.join(', ') || 'Submission'}
+                    {s.summary || s.paths.join(', ') || 'Submission'}
                   </div>
                   <div style={{ fontSize: 12.5, color: C.muted, display: 'flex', alignItems: 'center', gap: 8 }}>
                     <span>{author}</span>
                     <span>·</span>
-                    <span>{s.page_slugs.length} file{s.page_slugs.length === 1 ? '' : 's'}</span>
+                    <span>{s.paths.length} file{s.paths.length === 1 ? '' : 's'}</span>
                     <span>·</span>
                     <span>{timeAgo(s.created_at)}</span>
                   </div>

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -39,7 +39,7 @@ import { TransferDialog } from '../components/TransferDialog';
 import { C } from '@/lib/design';
 
 type ActiveView =
-  | { kind: 'page'; slug: string; content: PageFull | null }
+  | { kind: 'page'; slug: string; path?: string; content: PageFull | null }
   | { kind: 'source'; filename: string; content: SourceContent | null }
   | { kind: 'review-list'; workspaceSlug: string }
   | { kind: 'review-detail'; workspaceSlug: string; submissionId: string }
@@ -64,7 +64,6 @@ export function MainLayout() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [spacePages, setSpacePages] = useState<Record<string, PageMeta[]>>({});
   const [spaceSources, setSpaceSources] = useState<Record<string, SourceItem[]>>({});
-  const [pageDirMap, setPageDirMap] = useState<Record<string, string>>({}); // slug → content dir
   const [activeView, setActiveView] = useState<ActiveView>(null);
   const [activeWorkspace, setActiveWorkspace] = useState<Workspace | null>(null);
   const [reviewRefreshKey, setReviewRefreshKey] = useState(0);
@@ -139,11 +138,22 @@ export function MainLayout() {
           await loadSpaceSources(targetWs);
         }
         const branch = targetWs.visibility === 'private' ? userBranch : 'main';
-        const currentMap = buildPageDirMap(spacePages[targetWs.id] || []);
-        const dir = currentMap[pageSlug] || 'wiki';
+        // Find the page in the tree to get its path
+        const findPath = (items: PageMeta[], targetSlug: string): string | undefined => {
+          for (const p of items) {
+            if (p.kind !== 'folder' && p.slug === targetSlug) return p.path;
+            if (p.children) {
+              const found = findPath(p.children, targetSlug);
+              if (found) return found;
+            }
+          }
+          return undefined;
+        };
+        const pagePath = findPath(spacePages[targetWs.id] || [], pageSlug);
+        const dir = pagePath?.split('/')[0] || 'wiki';
         try {
           const page = await getPage(pageSlug, branch, targetWs.slug, dir);
-          setActiveView({ kind: 'page', slug: pageSlug, content: page });
+          setActiveView({ kind: 'page', slug: pageSlug, path: pagePath, content: page });
         } catch {
           // Page not found, just show home
         }
@@ -152,9 +162,9 @@ export function MainLayout() {
       const personalPages = await listPages(userBranch, personal.slug, 'all');
       const firstPage = personalPages.find((p) => p.kind === 'page');
       if (firstPage) {
-        setActiveView({ kind: 'page', slug: firstPage.slug, content: null });
+        setActiveView({ kind: 'page', slug: firstPage.slug, path: firstPage.path, content: null });
         navigate(`/${personal.slug}/${firstPage.slug}`, { replace: true });
-        const firstDir = buildPageDirMap(personalPages)[firstPage.slug] || 'wiki';
+        const firstDir = firstPage.path?.split('/')[0] || 'wiki';
         try {
           const page = await getPage(firstPage.slug, userBranch, personal.slug, firstDir);
           setActiveView(prev => prev?.kind === 'page' ? { ...prev, content: page } : prev);
@@ -186,48 +196,43 @@ export function MainLayout() {
     return ws.visibility === 'private' && ws.role === 'owner';
   }
 
-  /** Walk the page tree and map each slug to its content directory */
-  function buildPageDirMap(pages: PageMeta[]): Record<string, string> {
-    const map: Record<string, string> = {};
-    for (const p of pages) {
-      if (p.kind === 'folder' && p.slug.endsWith('/_index')) {
-        const dir = p.slug.replace('/_index', '');
-        const walk = (children: PageMeta[]) => {
-          for (const c of children) {
-            map[c.slug] = dir;
-            if (c.children) walk(c.children);
-          }
+  /** Walk the page tree and recursively merge draft pages into main pages by path.
+   *  When both trees have a folder at the same path, their children are merged
+   *  recursively so that draft-only pages under existing section nodes (wiki/_index,
+   *  entities/_index, concepts/_index) are not silently dropped. */
+  function mergePageTrees(main: PageMeta[], draft: PageMeta[]): PageMeta[] {
+    const merged: PageMeta[] = [...main];
+    const pathToIndex = new Map(merged.map((p, i) => [p.path, i] as const));
+    for (const dp of draft) {
+      const idx = pathToIndex.get(dp.path);
+      if (idx === undefined) {
+        // Draft-only node — add to merged
+        pathToIndex.set(dp.path, merged.length);
+        merged.push(dp);
+      } else if (merged[idx].kind === 'folder' && dp.kind === 'folder') {
+        // Both are folders — recursively merge their children
+        merged[idx] = {
+          ...merged[idx],
+          children: mergePageTrees(merged[idx].children || [], dp.children || []),
         };
-        if (p.children) walk(p.children);
       }
+      // else: main has a page at this path — main wins, skip draft
     }
-    return map;
+    return merged;
   }
-
-  /** Resolve the content dir for a slug, falling back to 'wiki' */
-  const getPageDir = useCallback((slug: string): string => {
-    return pageDirMap[slug] || 'wiki';
-  }, [pageDirMap]);
 
   // Load pages for a space
   const loadSpacePages = async (ws: Workspace) => {
     if (ws.visibility === 'private') {
       const pages = await listPages(userBranch, ws.slug, 'all');
       setSpacePages((prev) => ({ ...prev, [ws.id]: pages }));
-      setPageDirMap(buildPageDirMap(pages));
     } else {
       const [mainPages, draftPages] = await Promise.all([
         listPages('main', ws.slug, 'all'),
         listPages(userBranch, ws.slug, 'all').catch(() => [] as PageMeta[]),
       ]);
-      const mainSlugs = new Set(mainPages.map((p) => p.slug));
-      const merged = [
-        ...mainPages,
-        ...draftPages.filter((p) => !mainSlugs.has(p.slug)),
-      ];
+      const merged = mergePageTrees(mainPages, draftPages);
       setSpacePages((prev) => ({ ...prev, [ws.id]: merged }));
-      // Use main pages for dir map since they're the canonical source
-      setPageDirMap(buildPageDirMap(mainPages));
     }
   };
 
@@ -290,21 +295,21 @@ export function MainLayout() {
     const pages = spacePages[ws.id] || [];
     const first = pages.find((p) => p.kind === 'page');
     if (first) {
-      selectPage(ws, first.slug);
+      selectPage(ws, first.slug, first.path);
     } else {
       setActiveView(null);
     }
   };
 
   // Select a page
-  const selectPage = async (ws: Workspace, slug: string) => {
+  const selectPage = async (ws: Workspace, slug: string, path?: string) => {
     setActiveWorkspace(ws);
     setActiveTab('wiki');
     setEditingPage(false);
-    setActiveView({ kind: 'page', slug, content: null });
+    setActiveView({ kind: 'page', slug, path, content: null });
     navigate(`/${ws.slug}/${slug}`, { replace: true });
 
-    const dir = getPageDir(slug);
+    const dir = path?.split('/')[0] || 'wiki';
     const setContent = (content: PageFull | null) =>
       setActiveView(prev => prev?.kind === 'page' ? { ...prev, content } : prev);
 
@@ -368,7 +373,8 @@ export function MainLayout() {
       setNewPageFolder(null);
       setNewPageDir('wiki');
       await loadSpacePages(ws);
-      setActiveView({ kind: 'page', slug, content: { slug, title, summary: '', body, branch: userBranch, kind: 'page', children: [] } });
+      const newPath = `${newPageDir}/${slug}`;
+      setActiveView({ kind: 'page', slug, path: newPath, content: { slug, path: newPath, title, summary: '', body, branch: userBranch, kind: 'page', children: [] } });
       navigate(`/${ws.slug}/${slug}`, { replace: true });
     } catch {
       setMessage({ text: 'Failed to create page', type: 'error' });
@@ -424,9 +430,21 @@ export function MainLayout() {
         setMessage({ text: 'No pages to submit', type: 'error' });
         return;
       }
-      const slugs = pages.map((p) => p.slug);
+      // Flatten page tree to paths, skipping folders
+      const flatten = (items: PageMeta[]): string[] => {
+        const result: string[] = [];
+        for (const p of items) {
+          if (p.kind === 'folder' && p.children && p.children.length > 0) {
+            result.push(...flatten(p.children));
+          } else if (p.kind !== 'folder') {
+            result.push(p.path);
+          }
+        }
+        return result;
+      };
+      const paths = flatten(pages);
       const personal = isPersonalSpace(ws);
-      await submit(userBranch, slugs, personal, ws.slug);
+      await submit(userBranch, paths, personal, ws.slug);
       setMessage({ text: personal ? 'Committed.' : 'Submitted for review.', type: 'success' });
     } catch {
       setMessage({ text: 'Submit failed', type: 'error' });
@@ -469,7 +487,7 @@ export function MainLayout() {
         const pages = spacePages[activeWorkspace.id] || [];
         const first = pages.find((p) => p.kind === 'page');
         if (first) {
-          selectPage(activeWorkspace, first.slug);
+          selectPage(activeWorkspace, first.slug, first.path);
         } else {
           setActiveView(null);
         }
@@ -583,7 +601,7 @@ export function MainLayout() {
       setPathOp(null);
       // If the open page lived under the changed path, drop the stale view.
       if (activeView?.kind === 'page') {
-        const dir = getPageDir(activeView.slug);
+        const dir = activeView.path?.split('/')[0] || 'wiki';
         const viewPath = `${dir}/${activeView.slug}.md`;
         if (viewPath === pathOp.path || viewPath.startsWith(pathOp.path + '/')) {
           setActiveView(null);
@@ -601,7 +619,7 @@ export function MainLayout() {
     if (!activeWorkspace || activeView?.kind !== 'page') return;
     const ws = activeWorkspace;
     const slug = activeView.slug;
-    const dir = getPageDir(slug);
+    const dir = activeView.path?.split('/')[0] || 'wiki';
     await writePage(slug, body, userBranch, ws.slug, dir);
     setEditingPage(false);
     setMessage({ text: 'Saved to your draft.', type: 'success' });
@@ -647,7 +665,7 @@ export function MainLayout() {
             reviewCount={reviewCount}
             isPersonal={personal}
             isOwner={isOwner}
-            onSelectPage={(slug) => activeWorkspace && selectPage(activeWorkspace, slug)}
+            onSelectPage={(slug, path) => activeWorkspace && selectPage(activeWorkspace, slug, path)}
             onSelectSource={(filename) => activeWorkspace && selectSource(activeWorkspace, filename)}
             onNewPage={(dir?: ContentDir) => { if (activeWorkspace) { setShowNewPage(activeWorkspace); setNewName(''); setNewPageFolder(null); setNewPageDir(dir || 'wiki'); } }}
             onNewFolder={(dir?: ContentDir) => { if (activeWorkspace) { setShowNewFolder(activeWorkspace); setNewName(''); setNewFolderParent(null); setNewFolderDir(dir || 'wiki'); } }}

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -29,6 +29,7 @@ import { SettingsDialog } from '../components/SettingsDialog';
 import { getStoredAuth, clearAuth } from '../auth';
 import { SpaceRail } from '../components/layout/SpaceRail';
 import { SpacePanel, type NavTab } from '../components/layout/SpacePanel';
+type ContentDir = 'wiki' | 'entities' | 'concepts';
 import { ReviewList } from '../components/review/ReviewList';
 import { ReviewDetail } from '../components/review/ReviewDetail';
 import { MembersView } from '../components/views/MembersView';
@@ -63,6 +64,7 @@ export function MainLayout() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [spacePages, setSpacePages] = useState<Record<string, PageMeta[]>>({});
   const [spaceSources, setSpaceSources] = useState<Record<string, SourceItem[]>>({});
+  const [pageDirMap, setPageDirMap] = useState<Record<string, string>>({}); // slug → content dir
   const [activeView, setActiveView] = useState<ActiveView>(null);
   const [activeWorkspace, setActiveWorkspace] = useState<Workspace | null>(null);
   const [reviewRefreshKey, setReviewRefreshKey] = useState(0);
@@ -75,6 +77,8 @@ export function MainLayout() {
   const [showNewFolder, setShowNewFolder] = useState<Workspace | null>(null);
   const [newPageFolder, setNewPageFolder] = useState<string | null>(null);
   const [newFolderParent, setNewFolderParent] = useState<string | null>(null);
+  const [newPageDir, setNewPageDir] = useState<ContentDir>('wiki');
+  const [newFolderDir, setNewFolderDir] = useState<ContentDir>('wiki');
   const [newName, setNewName] = useState('');
   const [newSlug, setNewSlug] = useState('');
   const [creating, setCreating] = useState(false);
@@ -135,21 +139,24 @@ export function MainLayout() {
           await loadSpaceSources(targetWs);
         }
         const branch = targetWs.visibility === 'private' ? userBranch : 'main';
+        const currentMap = buildPageDirMap(spacePages[targetWs.id] || []);
+        const dir = currentMap[pageSlug] || 'wiki';
         try {
-          const page = await getPage(pageSlug, branch, targetWs.slug);
+          const page = await getPage(pageSlug, branch, targetWs.slug, dir);
           setActiveView({ kind: 'page', slug: pageSlug, content: page });
         } catch {
           // Page not found, just show home
         }
       }
     } else if (personal) {
-      const personalPages = await listPages(userBranch, personal.slug);
+      const personalPages = await listPages(userBranch, personal.slug, 'all');
       const firstPage = personalPages.find((p) => p.kind === 'page');
       if (firstPage) {
         setActiveView({ kind: 'page', slug: firstPage.slug, content: null });
         navigate(`/${personal.slug}/${firstPage.slug}`, { replace: true });
+        const firstDir = buildPageDirMap(personalPages)[firstPage.slug] || 'wiki';
         try {
-          const page = await getPage(firstPage.slug, userBranch, personal.slug);
+          const page = await getPage(firstPage.slug, userBranch, personal.slug, firstDir);
           setActiveView(prev => prev?.kind === 'page' ? { ...prev, content: page } : prev);
         } catch {
           // Page not found
@@ -179,15 +186,39 @@ export function MainLayout() {
     return ws.visibility === 'private' && ws.role === 'owner';
   }
 
+  /** Walk the page tree and map each slug to its content directory */
+  function buildPageDirMap(pages: PageMeta[]): Record<string, string> {
+    const map: Record<string, string> = {};
+    for (const p of pages) {
+      if (p.kind === 'folder' && p.slug.endsWith('/_index')) {
+        const dir = p.slug.replace('/_index', '');
+        const walk = (children: PageMeta[]) => {
+          for (const c of children) {
+            map[c.slug] = dir;
+            if (c.children) walk(c.children);
+          }
+        };
+        if (p.children) walk(p.children);
+      }
+    }
+    return map;
+  }
+
+  /** Resolve the content dir for a slug, falling back to 'wiki' */
+  const getPageDir = useCallback((slug: string): string => {
+    return pageDirMap[slug] || 'wiki';
+  }, [pageDirMap]);
+
   // Load pages for a space
   const loadSpacePages = async (ws: Workspace) => {
     if (ws.visibility === 'private') {
-      const pages = await listPages(userBranch, ws.slug);
+      const pages = await listPages(userBranch, ws.slug, 'all');
       setSpacePages((prev) => ({ ...prev, [ws.id]: pages }));
+      setPageDirMap(buildPageDirMap(pages));
     } else {
       const [mainPages, draftPages] = await Promise.all([
-        listPages('main', ws.slug),
-        listPages(userBranch, ws.slug).catch(() => [] as PageMeta[]),
+        listPages('main', ws.slug, 'all'),
+        listPages(userBranch, ws.slug, 'all').catch(() => [] as PageMeta[]),
       ]);
       const mainSlugs = new Set(mainPages.map((p) => p.slug));
       const merged = [
@@ -195,6 +226,8 @@ export function MainLayout() {
         ...draftPages.filter((p) => !mainSlugs.has(p.slug)),
       ];
       setSpacePages((prev) => ({ ...prev, [ws.id]: merged }));
+      // Use main pages for dir map since they're the canonical source
+      setPageDirMap(buildPageDirMap(mainPages));
     }
   };
 
@@ -271,12 +304,13 @@ export function MainLayout() {
     setActiveView({ kind: 'page', slug, content: null });
     navigate(`/${ws.slug}/${slug}`, { replace: true });
 
+    const dir = getPageDir(slug);
     const setContent = (content: PageFull | null) =>
       setActiveView(prev => prev?.kind === 'page' ? { ...prev, content } : prev);
 
     if (ws.visibility === 'private') {
       try {
-        const page = await getPage(slug, userBranch, ws.slug);
+        const page = await getPage(slug, userBranch, ws.slug, dir);
         setContent(page);
       } catch {
         setContent(null);
@@ -284,11 +318,11 @@ export function MainLayout() {
       }
     } else {
       try {
-        const page = await getPage(slug, userBranch, ws.slug);
+        const page = await getPage(slug, userBranch, ws.slug, dir);
         setContent(page);
       } catch {
         try {
-          const page = await getPage(slug, 'main', ws.slug);
+          const page = await getPage(slug, 'main', ws.slug, dir);
           setContent(page);
         } catch {
           setContent(null);
@@ -320,16 +354,19 @@ export function MainLayout() {
     if (!newName.trim() || !showNewPage) return;
     const ws = showNewPage;
     const baseSlug = newName.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').trim();
-    const slug = newPageFolder
-      ? `${newPageFolder.replace('wiki/', '')}/${baseSlug}`
-      : baseSlug;
+    // Strip dir prefix from folder path if creating inside a folder
+    const folderRelative = newPageFolder
+      ? newPageFolder.slice(newPageDir.length + 1) // e.g. "wiki/some/path" → "some/path"
+      : null;
+    const slug = folderRelative ? `${folderRelative}/${baseSlug}` : baseSlug;
     const body = `---\ntitle: "${newName.trim()}"\nsummary: ""\nkind: concept\n---\n\n`;
     try {
-      await writePage(slug, body, userBranch, ws.slug);
+      await writePage(slug, body, userBranch, ws.slug, newPageDir);
       const title = newName.trim();
       setShowNewPage(null);
       setNewName('');
       setNewPageFolder(null);
+      setNewPageDir('wiki');
       await loadSpacePages(ws);
       setActiveView({ kind: 'page', slug, content: { slug, title, summary: '', body, branch: userBranch, kind: 'page', children: [] } });
       navigate(`/${ws.slug}/${slug}`, { replace: true });
@@ -344,10 +381,11 @@ export function MainLayout() {
     if (!newName.trim() || !showNewFolder) return;
     const ws = showNewFolder;
     try {
-      await createFolder(newName.trim(), userBranch, newFolderParent || undefined, ws.slug);
+      await createFolder(newName.trim(), userBranch, newFolderParent || newFolderDir, ws.slug);
       setShowNewFolder(null);
       setNewName('');
       setNewFolderParent(null);
+      setNewFolderDir('wiki');
       await loadSpacePages(ws);
     } catch {
       setMessage({ text: 'Failed to create folder', type: 'error' });
@@ -545,7 +583,8 @@ export function MainLayout() {
       setPathOp(null);
       // If the open page lived under the changed path, drop the stale view.
       if (activeView?.kind === 'page') {
-        const viewPath = `wiki/${activeView.slug}.md`;
+        const dir = getPageDir(activeView.slug);
+        const viewPath = `${dir}/${activeView.slug}.md`;
         if (viewPath === pathOp.path || viewPath.startsWith(pathOp.path + '/')) {
           setActiveView(null);
           navigate(`/`, { replace: true });
@@ -562,11 +601,12 @@ export function MainLayout() {
     if (!activeWorkspace || activeView?.kind !== 'page') return;
     const ws = activeWorkspace;
     const slug = activeView.slug;
-    await writePage(slug, body, userBranch, ws.slug);
+    const dir = getPageDir(slug);
+    await writePage(slug, body, userBranch, ws.slug, dir);
     setEditingPage(false);
     setMessage({ text: 'Saved to your draft.', type: 'success' });
     try {
-      const page = await getPage(slug, userBranch, ws.slug);
+      const page = await getPage(slug, userBranch, ws.slug, dir);
       setActiveView((prev) => (prev?.kind === 'page' ? { ...prev, content: page } : prev));
     } catch { /* keep the stale view; tree reload below still runs */ }
     loadSpacePages(ws);
@@ -609,10 +649,10 @@ export function MainLayout() {
             isOwner={isOwner}
             onSelectPage={(slug) => activeWorkspace && selectPage(activeWorkspace, slug)}
             onSelectSource={(filename) => activeWorkspace && selectSource(activeWorkspace, filename)}
-            onNewPage={() => { if (activeWorkspace) { setShowNewPage(activeWorkspace); setNewName(''); setNewPageFolder(null); } }}
-            onNewFolder={() => { if (activeWorkspace) { setShowNewFolder(activeWorkspace); setNewName(''); setNewFolderParent(null); } }}
-            onAddPageInFolder={(folderPath) => { if (activeWorkspace) { setShowNewPage(activeWorkspace); setNewName(''); setNewPageFolder(folderPath); } }}
-            onAddFolderInFolder={(parentPath) => { if (activeWorkspace) { setShowNewFolder(activeWorkspace); setNewName(''); setNewFolderParent(parentPath); } }}
+            onNewPage={(dir?: ContentDir) => { if (activeWorkspace) { setShowNewPage(activeWorkspace); setNewName(''); setNewPageFolder(null); setNewPageDir(dir || 'wiki'); } }}
+            onNewFolder={(dir?: ContentDir) => { if (activeWorkspace) { setShowNewFolder(activeWorkspace); setNewName(''); setNewFolderParent(null); setNewFolderDir(dir || 'wiki'); } }}
+            onAddPageInFolder={(folderPath, dir) => { if (activeWorkspace) { setShowNewPage(activeWorkspace); setNewName(''); setNewPageFolder(folderPath); setNewPageDir(dir); } }}
+            onAddFolderInFolder={(parentPath, dir) => { if (activeWorkspace) { setShowNewFolder(activeWorkspace); setNewName(''); setNewFolderParent(parentPath); setNewFolderDir(dir); } }}
             onRenamePath={(path, isFolder, title) => setPathOp({ kind: 'rename', path, isFolder, title, value: title })}
             onDeletePath={(path, isFolder, title) => setPathOp({ kind: 'delete', path, isFolder, title })}
             onShowIngest={() => setShowIngest(true)}


### PR DESCRIPTION
Closes #91

## Summary

Implements the 4-section directory sidebar AND the path-aware submit architecture per review feedback on #92.

### Sidebar: 4-section directory tree
- Replace flat wiki tree with wiki/ | entities/ | concepts/ sections
- Each section is a top-level folder node built from dir=all listing
- Recursive merge of main + draft page trees

### Path-aware submit (per #92 review)
See design spec: docs/superpowers/specs/2026-06-17-submit-path-awareness-design.md

- SubmitRequest: page_slugs → paths (Vec\<String\>)
- diff_files: accepts paths directly, no hardcoded wiki/{slug}.md
- Embedding loop: reads {path}.md, skips synthetic _index nodes
- DB: submissions.page_slugs → paths (migration 012)
- CLI: flattenPaths() + --dir flag (wiki/entities/concepts/all)

### Remove pageDirMap (per #93 review)
- PageListItem gains path field alongside slug
- ActiveView stores path from selected tree node
- selectPage(ws, slug, path) derives dir from path.split('/')[0]
- All page actions (read/save/delete) use activeView.path
- pageDirMap state, buildPageDirMap(), and getPageDir() removed
- mergePageTrees keys on path instead of slug

### Bug fixes
- Fix nested page path: dir/slug instead of dir/parent_dir/slug
- Register migration 012 in run_migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)