### PR TITLE
chore(cli): add root dev install scripts

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -7,11 +7,14 @@ Command-line client for [cowiki](https://github.com/wfnuser/cowiki) — a collab
 ### Dev Install (from source)
 
 ```bash
-cd cli
-npm install
-npm run build
-npm link
+npm run cli:dev-install
 cowiki --help
+```
+
+After the first dev install, rebuild the linked CLI after pulling CLI changes:
+
+```bash
+npm run cli:build
 ```
 
 ### npm Install (when published)

--- a/cli/skills/cowiki-cli/SKILL.md
+++ b/cli/skills/cowiki-cli/SKILL.md
@@ -36,7 +36,7 @@ If Node.js is not installed or < 18, tell the user to install Node.js 18+.
 Ask the user:
 
 > "cowiki CLI can be installed in two ways:
-> 1. **Dev install** (`cd cli && npm install && npm run build && npm link`) — from the repo source, for local development
+> 1. **Dev install** (`npm run cli:dev-install`) — from the repo source, for local development
 > 2. **Global** (`npm install -g @cowiki/cli`) — published package, available everywhere
 > 
 > Which do you prefer?"
@@ -45,7 +45,12 @@ Wait for the user's choice before proceeding.
 
 **Dev install (from repo source):**
 ```bash
-cd cli && npm install && npm run build && npm link
+npm run cli:dev-install
+```
+
+After the first dev install, rebuild the linked CLI after pulling CLI changes:
+```bash
+npm run cli:build
 ```
 
 **Global install (published package):**

--- a/cli/skills/cowiki-cli/troubleshooting.md
+++ b/cli/skills/cowiki-cli/troubleshooting.md
@@ -70,9 +70,7 @@ npx @cowiki/cli <command>
 **Fix:**
 ```bash
 # Option 1: Clone the repo and link locally
-cd cli
-npm install
-npm link
+npm run cli:dev-install
 
 # Verify installation
 cowiki --version
@@ -80,8 +78,8 @@ cowiki --version
 # Option 2: If npm install fails within the local directory
 cd cli
 rm -rf node_modules package-lock.json
-npm install
-npm link
+cd ..
+npm run cli:dev-install
 ```
 
 `npm link` creates a global symlink to the local build, so `cowiki` will be available system-wide. This is also the recommended approach for development.
@@ -98,11 +96,11 @@ If you're developing the CLI itself:
 
 ```bash
 # Type check
-npm run typecheck
+npm --prefix cli run typecheck
 
-# Build
-npm run build
+# Build from the repo root
+npm run cli:build
 
 # Clean install
-rm -rf node_modules && npm install
+rm -rf cli/node_modules cli/package-lock.json && npm run cli:dev-install
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "scripts": {
+    "cli:dev-install": "npm --prefix cli install && npm --prefix cli run build && npm --prefix cli link",
+    "cli:build": "npm --prefix cli run build"
+  }
+}


### PR DESCRIPTION
## Summary
- Add root-level `cli:dev-install` and `cli:build` npm scripts for local CLI development.
- Update CLI README and bundled skill docs to use the root scripts.
- Keep npm package install documented as future/published path.

## Verification
- `npm run cli:dev-install`
- `npm run cli:build`

Note: `npm install` reports existing dependency audit findings in the CLI dependency tree; the install/build/link flow still completes successfully.