### PR TITLE
fix(test): make permission_api_tests actually runnable (false green)

### DIFF
--- a/crates/server/tests/permission_api_tests.rs
+++ b/crates/server/tests/permission_api_tests.rs
@@ -45,12 +45,21 @@ fn api_request(method: &str, path: &str, body: Option<&str>, api_key: &str) -> (
 
 /// Helper: register a test user and return (user_id, api_key)
 fn register_user(name: &str) -> (String, String) {
-    let body = format!(r#"{{"name":"{}"}}"#, name);
+    // Usernames are globally unique, so suffix with a random fragment — otherwise
+    // re-running the suite (or two tests sharing a base name) collides on the
+    // second register with "name already taken".
+    let unique = format!(
+        "{}-{}",
+        name,
+        uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
+    );
+    let body = format!(r#"{{"name":"{}"}}"#, unique);
     let (resp, status) = api_request("POST", "/auth/register", Some(&body), "");
     assert_eq!(status, 200, "register failed: {}", resp);
 
     let json: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON from register");
-    let user_id = json["id"].as_str().unwrap().to_string();
+    // Response shape: { "user": { "id": ... }, "api_key": ... } — id is nested.
+    let user_id = json["user"]["id"].as_str().unwrap().to_string();
     let api_key = json["api_key"].as_str().unwrap().to_string();
     (user_id, api_key)
 }
@@ -187,15 +196,30 @@ fn test_invite_with_invalid_role_rejected() {
 
     create_workspace(&key_a, "Invite Role WS", &slug, "public");
 
-    // Invalid role
+    // Invalid role. Invite is a batch endpoint: it returns 200 with per-item
+    // results, and an invalid role surfaces as a failed item (not a top-level 400).
     let body = r#"{"invitations":[{"user":"new@test.com","role":"admin"}]}"#;
-    let (_resp, status) = api_request(
+    let (resp, status) = api_request(
         "POST",
         &format!("/workspaces/{}/invite", slug),
         Some(body),
         &key_a,
     );
-    assert_eq!(status, 400, "invalid role should be rejected");
+    assert_eq!(status, 200, "batch invite returns 200: {resp}");
+    let json: serde_json::Value = serde_json::from_str(&resp).unwrap();
+    assert_eq!(
+        json["failed"].as_i64(),
+        Some(1),
+        "invalid role item fails: {resp}"
+    );
+    assert_eq!(json["sent"].as_i64(), Some(0), "nothing sent: {resp}");
+    assert!(
+        json["results"][0]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("invalid role"),
+        "failure reason names invalid role: {resp}"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -268,7 +292,7 @@ fn test_remove_member_owner_only() {
         return;
     }
     let (_uid_a, key_a) = register_user("testuser-rm-a");
-    let (_uid_b, key_b) = register_user("testuser-rm-b");
+    let (user_b_id, key_b) = register_user("testuser-rm-b");
     let slug = format!(
         "perm-rm-{}",
         uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
@@ -277,20 +301,7 @@ fn test_remove_member_owner_only() {
     create_workspace(&key_a, "Remove Test WS", &slug, "public");
     join_workspace(&key_b, &slug);
 
-    // Get user_b's ID from member list
-    let (resp, _) = api_request(
-        "GET",
-        &format!("/workspaces/{}/members", slug),
-        None,
-        &key_a,
-    );
-    let members: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap();
-    let user_b_id = members
-        .iter()
-        .find(|m| m["name"].as_str() == Some("testuser-rm-b"))
-        .map(|m| m["id"].as_str().unwrap())
-        .expect("user_b should be in member list");
-
+    // user_b's id comes straight from register — no brittle lookup by name.
     // Writer tries to remove → 403
     let body = format!(r#"{{"user_id":"{}"}}"#, user_b_id);
     let (_resp, status) = api_request(
@@ -318,7 +329,7 @@ fn test_change_role_owner_only() {
         return;
     }
     let (_uid_a, key_a) = register_user("testuser-cr-a");
-    let (_uid_b, key_b) = register_user("testuser-cr-b");
+    let (user_b_id, key_b) = register_user("testuser-cr-b");
     let slug = format!(
         "perm-cr-{}",
         uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
@@ -327,20 +338,7 @@ fn test_change_role_owner_only() {
     create_workspace(&key_a, "ChangeRole WS", &slug, "public");
     join_workspace(&key_b, &slug);
 
-    // Get user_b's ID
-    let (resp, _) = api_request(
-        "GET",
-        &format!("/workspaces/{}/members", slug),
-        None,
-        &key_a,
-    );
-    let members: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap();
-    let user_b_id = members
-        .iter()
-        .find(|m| m["name"].as_str() == Some("testuser-cr-b"))
-        .map(|m| m["id"].as_str().unwrap())
-        .expect("user_b should be in member list");
-
+    // user_b's id comes straight from register — no brittle lookup by name.
     // Writer tries to change role → 403
     let body = format!(r#"{{"user_id":"{}","role":"viewer"}}"#, user_b_id);
     let (_resp, status) = api_request(


### PR DESCRIPTION
## The problem
`crates/server/tests/permission_api_tests.rs` self-skips when `TEST_API_URL` is unset, so CI has never actually run it — the suite was **green without executing**. Run against a live server, all 11 tests failed for pre-existing reasons (unrelated to any recent change; surfaced while adding the read-path/comment authz tests for #87/#86):

1. **`register_user` parsed `json["id"]`** — the register response nests it as `json["user"]["id"]`, so every test panicked in the helper.
2. **Fixed usernames collided** — `register_user("testuser-perm-1")` etc. hit "name already taken" on any re-run → now suffixed with a uuid fragment.
3. **`test_remove_member` / `test_change_role` looked up the member by literal name** — brittle, and broken by the uuid suffix. They now use the `user_id` that `register_user` already returns instead of scanning the member list.
4. **`test_invite_with_invalid_role` asserted a top-level 400** — invite is now a batch endpoint returning `200` with a per-item `{"failed":1,"reason":"invalid role: admin"}`. Assertion updated to check the failed item.

## Result
All 11 pass against a local server, and the suite is re-runnable (verified twice consecutively).

```
TEST_API_URL=http://localhost:3000/api cargo test -p cowiki-server --test permission_api_tests
test result: ok. 11 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)