### PR TITLE
feat(notifications): dedicated cross-space notifications inbox

### DIFF
--- a/crates/db/src/notifications.rs
+++ b/crates/db/src/notifications.rs
@@ -13,6 +13,12 @@ pub struct Notification {
     pub link: Option<String>,
     pub read: bool,
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Workspace name/slug joined in read queries (None for cross-space
+    /// notifications with no workspace, or on write paths that don't JOIN).
+    #[sqlx(default)]
+    pub workspace_name: Option<String>,
+    #[sqlx(default)]
+    pub workspace_slug: Option<String>,
 }
 
 pub async fn create(
@@ -47,8 +53,14 @@ pub async fn list_for_user(
     user_id: Uuid,
     limit: i64,
 ) -> sqlx::Result<Vec<Notification>> {
+    // LEFT JOIN so cross-space notifications (workspace_id NULL) still come back,
+    // with workspace_name/slug for display and the per-space filter on the page.
     sqlx::query_as::<_, Notification>(
-        "SELECT * FROM notifications WHERE user_id = $1 ORDER BY read ASC, created_at DESC LIMIT $2",
+        "SELECT n.*, w.name AS workspace_name, w.slug AS workspace_slug \
+         FROM notifications n \
+         LEFT JOIN workspaces w ON w.id = n.workspace_id \
+         WHERE n.user_id = $1 \
+         ORDER BY n.read ASC, n.created_at DESC LIMIT $2",
     )
     .bind(user_id)
     .bind(limit)
@@ -81,6 +93,23 @@ pub async fn mark_read(pool: &PgPool, notification_id: Uuid, user_id: Uuid) -> s
         .await
         .map_err(|e| {
             tracing::error!("DB mark read failed: {e}");
+            e
+        })?;
+    Ok(rows.rows_affected() > 0)
+}
+
+pub async fn mark_unread(
+    pool: &PgPool,
+    notification_id: Uuid,
+    user_id: Uuid,
+) -> sqlx::Result<bool> {
+    let rows = sqlx::query("UPDATE notifications SET read = FALSE WHERE id = $1 AND user_id = $2")
+        .bind(notification_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB mark unread failed: {e}");
             e
         })?;
     Ok(rows.rows_affected() > 0)

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -326,6 +326,10 @@ async fn main() {
             "/api/notifications/{id}/read",
             post(routes::notifications::mark_read),
         )
+        .route(
+            "/api/notifications/{id}/unread",
+            post(routes::notifications::mark_unread),
+        )
         .layer(
             TraceLayer::new_for_http()
                 .on_request(DefaultOnRequest::new().level(Level::INFO))

--- a/crates/server/src/routes/notifications.rs
+++ b/crates/server/src/routes/notifications.rs
@@ -15,6 +15,10 @@ pub struct NotificationResponse {
     pub title: String,
     pub body: Option<String>,
     pub workspace_id: Option<String>,
+    /// Workspace name/slug (joined) for display and the per-space filter; null for
+    /// cross-space notifications with no associated workspace.
+    pub workspace_name: Option<String>,
+    pub workspace_slug: Option<String>,
     pub link: Option<String>,
     pub read: bool,
     pub created_at: String,
@@ -27,6 +31,8 @@ fn notif_response(n: &cowiki_db::notifications::Notification) -> NotificationRes
         title: n.title.clone(),
         body: n.body.clone(),
         workspace_id: n.workspace_id.map(|id| id.to_string()),
+        workspace_name: n.workspace_name.clone(),
+        workspace_slug: n.workspace_slug.clone(),
         link: n.link.clone(),
         read: n.read,
         created_at: n.created_at.to_rfc3339(),
@@ -68,6 +74,17 @@ pub async fn mark_read(
 ) -> Result<Json<serde_json::Value>> {
     let user = extract_user(&state.db, &headers).await?;
     cowiki_db::notifications::mark_read(&state.db, notification_id, user.id).await?;
+    Ok(Json(serde_json::json!({"ok": true})))
+}
+
+/// POST /api/notifications/{id}/unread
+pub async fn mark_unread(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(notification_id): Path<Uuid>,
+) -> Result<Json<serde_json::Value>> {
+    let user = extract_user(&state.db, &headers).await?;
+    cowiki_db::notifications::mark_unread(&state.db, notification_id, user.id).await?;
     Ok(Json(serde_json::json!({"ok": true})))
 }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -561,6 +561,9 @@ export interface Notification {
   title: string;
   body: string | null;
   workspace_id: string | null;
+  /** Joined workspace name/slug for display + per-space filtering; null when cross-space. */
+  workspace_name: string | null;
+  workspace_slug: string | null;
   link: string | null;
   read: boolean;
   created_at: string;
@@ -581,6 +584,11 @@ export async function notificationUnreadCount(): Promise<number> {
 
 export async function markNotificationRead(id: string): Promise<void> {
   const res = await fetch(`${BASE}/notifications/${id}/read`, { method: 'POST', headers: h() });
+  if (!res.ok) throw new Error(await res.text());
+}
+
+export async function markNotificationUnread(id: string): Promise<void> {
+  const res = await fetch(`${BASE}/notifications/${id}/unread`, { method: 'POST', headers: h() });
   if (!res.ok) throw new Error(await res.text());
 }
 

--- a/web/src/components/layout/SpaceRail.tsx
+++ b/web/src/components/layout/SpaceRail.tsx
@@ -1,15 +1,5 @@
 import { Plus, Settings, Compass, LogOut, Bell } from 'lucide-react';
-import { useState, useEffect } from 'react';
-import type { Workspace, Notification } from '../../api';
-import {
-  listNotifications, notificationUnreadCount, markAllNotificationsRead,
-  markNotificationRead, acceptInvitation, rejectInvitation,
-  acceptTransfer, rejectTransfer,
-} from '../../api';
-import {
-  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
+import type { Workspace } from '../../api';
 import {
   Tooltip, TooltipContent, TooltipTrigger,
 } from '@/components/ui/tooltip';
@@ -31,6 +21,8 @@ interface SpaceRailProps {
   onSettings: () => void;
   onDiscover: () => void;
   onLogout: () => void;
+  notifUnread: number;
+  onShowNotifications: () => void;
 }
 
 export function SpaceRail({
@@ -42,6 +34,8 @@ export function SpaceRail({
   onSettings,
   onDiscover,
   onLogout,
+  notifUnread,
+  onShowNotifications,
 }: SpaceRailProps) {
   const personalSpaces = workspaces.filter((w) => w.visibility === 'private' && w.role === 'owner');
   const teamSpaces = workspaces.filter((w) => !(w.visibility === 'private' && w.role === 'owner'));
@@ -125,7 +119,7 @@ export function SpaceRail({
       <div style={{ flex: 1 }} />
 
       {/* Notification bell */}
-      <NotificationBell />
+      <NotificationBell unread={notifUnread} onOpen={onShowNotifications} />
 
       {/* User avatar + menu */}
       <DropdownMenu>
@@ -207,327 +201,35 @@ function SpaceTile({
 
 // ── Notification Bell ──
 
-function NotificationBell() {
-  const [unread, setUnread] = useState(0);
-  const [notifs, setNotifs] = useState<Notification[]>([]);
-  const [open, setOpen] = useState(false);
-  const [detail, setDetail] = useState<Notification | null>(null);
-  const [acting, setActing] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    notificationUnreadCount()
-      .then((c) => { if (!cancelled) setUnread(c); })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, []);
-
-  const loadNotifs = async () => {
-    try {
-      const list = await listNotifications(30);
-      setNotifs(list);
-    } catch { /* ignore */ }
-  };
-
-  const handleBellClick = () => {
-    const next = !open;
-    setOpen(next);
-    if (next) loadNotifs();
-  };
-
-  const handleMarkAllRead = async () => {
-    try {
-      await markAllNotificationsRead();
-      setUnread(0);
-      setNotifs((prev) => prev.map((n) => ({ ...n, read: true })));
-    } catch { /* ignore */ }
-  };
-
-  const markRead = async (id: string) => {
-    try {
-      await markNotificationRead(id);
-      setNotifs((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
-      setUnread((prev) => Math.max(0, prev - 1));
-    } catch { /* ignore */ }
-  };
-
-  // Extract resource id from notification link (format: /invitations/{uuid} or /transfers/{uuid})
-  const extractLinkId = (n: Notification): string | null => {
-    if (!n.link) return null;
-    const parts = n.link.split('/');
-    return parts[parts.length - 1] || null;
-  };
-
-  const handleItemClick = (n: Notification) => {
-    setDetail(n);
-    if (!n.read) markRead(n.id);
-  };
-
-  const handleAccept = async () => {
-    if (!detail) return;
-    const invId = extractLinkId(detail);
-    if (!invId) return;
-    setActing(true);
-    try {
-      await acceptInvitation(invId);
-      markRead(detail.id);
-      setDetail(null);
-      window.location.reload();
-    } catch { setActing(false); }
-  };
-
-  const handleReject = async () => {
-    if (!detail) return;
-    const invId = extractLinkId(detail);
-    if (!invId) return;
-    setActing(true);
-    try {
-      await rejectInvitation(invId);
-      markRead(detail.id);
-      setDetail(null);
-    } catch { setActing(false); }
-  };
-
-  const timeAgo = (iso: string): string => {
-    const diff = Date.now() - new Date(iso).getTime();
-    const mins = Math.floor(diff / 60000);
-    if (mins < 1) return 'just now';
-    if (mins < 60) return `${mins}m`;
-    const hours = Math.floor(mins / 60);
-    if (hours < 24) return `${hours}h`;
-    return `${Math.floor(hours / 24)}d`;
-  };
-
-  const formatTime = (iso: string): string => {
-    const d = new Date(iso);
-    return d.toLocaleString();
-  };
-
-  const isInvitation = detail?.kind === 'invitation' && extractLinkId(detail);
-  const isTransfer = detail?.kind === 'ownership_transfer' && extractLinkId(detail);
-
-  const handleTransferAccept = async () => {
-    if (!detail) return;
-    const tId = extractLinkId(detail);
-    if (!tId) return;
-    setActing(true);
-    try {
-      await acceptTransfer(tId);
-      markRead(detail.id);
-      setDetail(null);
-      window.location.reload();
-    } catch { setActing(false); }
-  };
-
-  const handleTransferReject = async () => {
-    if (!detail) return;
-    const tId = extractLinkId(detail);
-    if (!tId) return;
-    setActing(true);
-    try {
-      await rejectTransfer(tId);
-      markRead(detail.id);
-      setDetail(null);
-    } catch { setActing(false); }
-  };
-
+function NotificationBell({ unread, onOpen }: { unread: number; onOpen: () => void }) {
   return (
-    <div style={{ position: 'relative' }}>
-      <button
-        onClick={handleBellClick}
-        style={{
-          width: 34, height: 34, borderRadius: '50%',
-          border: `1px solid ${C.line}`, background: 'transparent', cursor: 'pointer',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          marginBottom: 6, color: C.ink2, position: 'relative',
-        }}
-      >
-        <Bell size={16} />
-        {unread > 0 && (
-          <span style={{
-            position: 'absolute', top: -2, right: -2,
-            minWidth: 16, height: 16, borderRadius: 8,
-            background: C.accent, color: '#fff', fontSize: 10,
-            fontWeight: 600, display: 'flex', alignItems: 'center',
-            justifyContent: 'center', padding: '0 4px',
-          }}>
-            {unread > 99 ? '99+' : unread}
-          </span>
-        )}
-      </button>
-
-      {/* Notification list dropdown */}
-      {open && (
-        <>
-          <div
-            style={{ position: 'fixed', inset: 0, zIndex: 90 }}
-            onClick={() => setOpen(false)}
-          />
-          <div style={{
-            position: 'fixed', left: 72, bottom: 60, zIndex: 100,
-            width: 360, maxHeight: 400,
-            border: `1px solid ${C.line}`, borderRadius: 10,
-            background: C.panel, boxShadow: '0 8px 28px rgba(29,28,26,0.15)',
-            display: 'flex', flexDirection: 'column',
-          }}>
-            <div style={{
-              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-              padding: '12px 16px', borderBottom: `1px solid ${C.line}`,
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={onOpen}
+          style={{
+            width: 34, height: 34, borderRadius: '50%',
+            border: `1px solid ${C.line}`, background: 'transparent', cursor: 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            marginBottom: 6, color: C.ink2, position: 'relative',
+          }}
+        >
+          <Bell size={16} />
+          {unread > 0 && (
+            <span style={{
+              position: 'absolute', top: -2, right: -2,
+              minWidth: 16, height: 16, borderRadius: 8,
+              background: C.accent, color: '#fff', fontSize: 10,
+              fontWeight: 600, display: 'flex', alignItems: 'center',
+              justifyContent: 'center', padding: '0 4px',
             }}>
-              <span style={{ fontSize: 14, fontWeight: 600, color: C.ink }}>Notifications</span>
-              {unread > 0 && (
-                <button onClick={handleMarkAllRead} style={{
-                  background: 'none', border: 'none', cursor: 'pointer',
-                  fontSize: 12, color: C.accent, fontWeight: 500,
-                }}>
-                  Mark all read
-                </button>
-              )}
-            </div>
-            <div style={{ flex: 1, overflow: 'auto' }}>
-              {notifs.length === 0 ? (
-                <div style={{ padding: '32px 16px', textAlign: 'center', color: C.muted, fontSize: 13 }}>
-                  No notifications
-                </div>
-              ) : (
-                notifs.map((n) => (
-                  <button
-                    key={n.id}
-                    onClick={() => { setOpen(false); handleItemClick(n); }}
-                    style={{
-                      display: 'flex', gap: 10, padding: '12px 16px',
-                      width: '100%', border: 'none', cursor: 'pointer',
-                      textAlign: 'left', background: n.read ? C.panel : C.sidebar,
-                      borderBottom: `1px solid ${C.lineSoft}`,
-                    }}
-                  >
-                    <div style={{
-                      width: 8, height: 8, borderRadius: '50%',
-                      background: n.read ? 'transparent' : C.accent,
-                      marginTop: 6, flexShrink: 0,
-                    }} />
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{
-                        fontSize: 13, fontWeight: n.read ? 400 : 600, color: C.ink,
-                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                      }}>
-                        {n.title}
-                      </div>
-                      {n.body && (
-                        <div style={{
-                          fontSize: 12, color: C.muted, marginTop: 2,
-                          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                        }}>
-                          {n.body}
-                        </div>
-                      )}
-                      <div style={{ fontSize: 11, color: C.faint, marginTop: 4 }}>
-                        {timeAgo(n.created_at)}
-                      </div>
-                    </div>
-                  </button>
-                ))
-              )}
-            </div>
-          </div>
-        </>
-      )}
-
-      {/* Detail modal */}
-      <Dialog open={!!detail} onOpenChange={(open) => { if (!open) setDetail(null); }}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle style={{ fontSize: 16 }}>
-              {detail?.kind === 'invitation' ? 'Workspace Invitation'
-                : detail?.kind === 'ownership_transfer' ? 'Ownership Transfer'
-                : 'Notification'}
-            </DialogTitle>
-            <DialogDescription />
-          </DialogHeader>
-
-          {detail && (
-            <div className="space-y-4 mt-2">
-              <div>
-                <div style={{ fontSize: 15, fontWeight: 600, color: C.ink, marginBottom: 4 }}>
-                  {detail.title}
-                </div>
-                {detail.body && (
-                  <div style={{ fontSize: 13, color: C.ink2, lineHeight: 1.5 }}>
-                    {detail.body}
-                  </div>
-                )}
-                <div style={{ fontSize: 12, color: C.faint, marginTop: 8 }}>
-                  {formatTime(detail.created_at)}
-                </div>
-              </div>
-
-              {/* Action buttons for invitation */}
-              {isInvitation && (
-                <div style={{
-                  display: 'flex', gap: 10, paddingTop: 8,
-                  borderTop: `1px solid ${C.line}`,
-                }}>
-                  <Button
-                    onClick={handleAccept}
-                    disabled={acting}
-                    style={{
-                      flex: 1, background: C.green, border: 'none',
-                      color: '#fff', fontWeight: 600,
-                    }}
-                  >
-                    {acting ? 'Accepting...' : 'Accept Invitation'}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={handleReject}
-                    disabled={acting}
-                    style={{ flex: 1 }}
-                  >
-                    Decline
-                  </Button>
-                </div>
-              )}
-
-              {/* Action buttons for ownership transfer */}
-              {isTransfer && (
-                <div style={{
-                  display: 'flex', gap: 10, paddingTop: 8,
-                  borderTop: `1px solid ${C.line}`,
-                }}>
-                  <Button
-                    onClick={handleTransferAccept}
-                    disabled={acting}
-                    style={{
-                      flex: 1, background: C.accent, border: 'none',
-                      color: '#fff', fontWeight: 600,
-                    }}
-                  >
-                    {acting ? 'Accepting...' : 'Accept Transfer'}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={handleTransferReject}
-                    disabled={acting}
-                    style={{ flex: 1 }}
-                  >
-                    Decline
-                  </Button>
-                </div>
-              )}
-
-              {/* Read-only: other notification types */}
-              {!isInvitation && !isTransfer && (
-                <div className="flex justify-end pt-2">
-                  <Button variant="outline" onClick={() => setDetail(null)}>
-                    Close
-                  </Button>
-                </div>
-              )}
-            </div>
+              {unread > 99 ? '99+' : unread}
+            </span>
           )}
-        </DialogContent>
-      </Dialog>
-    </div>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right">Notifications</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/web/src/components/notifications/NotificationsPage.tsx
+++ b/web/src/components/notifications/NotificationsPage.tsx
@@ -1,0 +1,365 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Mail, ArrowRightLeft, GitPullRequest, CheckCircle2, Users, Sparkles, Bell,
+  Check, Circle, CheckCheck, Inbox,
+} from 'lucide-react';
+import {
+  listNotifications, markNotificationRead, markNotificationUnread,
+  markAllNotificationsRead, acceptInvitation, rejectInvitation,
+  acceptTransfer, rejectTransfer, type Notification,
+} from '../../api';
+import { C } from '@/lib/design';
+import { timeAgo } from '../../lib/time';
+
+type Tab = 'unread' | 'all';
+
+/** Per-kind icon + accent colour. Unknown kinds fall back to a neutral bell. */
+function kindMeta(kind: string): { icon: typeof Bell; color: string; label: string } {
+  switch (kind) {
+    case 'invitation':
+      return { icon: Mail, color: C.accent, label: 'Invitation' };
+    case 'ownership_transfer':
+      return { icon: ArrowRightLeft, color: '#8250df', label: 'Ownership transfer' };
+    case 'transfer_accepted':
+      return { icon: CheckCircle2, color: C.green, label: 'Transfer accepted' };
+    case 'review_request':
+      return { icon: GitPullRequest, color: '#3f6c8c', label: 'Review request' };
+    case 'review_decision':
+      return { icon: CheckCircle2, color: C.green, label: 'Review decision' };
+    case 'member_joined':
+      return { icon: Users, color: '#3f6c8c', label: 'Member joined' };
+    case 'compile_done':
+      return { icon: Sparkles, color: C.accent, label: 'Compile done' };
+    default:
+      return { icon: Bell, color: C.muted, label: kind };
+  }
+}
+
+function linkId(n: Notification): string | null {
+  if (!n.link) return null;
+  const parts = n.link.split('/');
+  return parts[parts.length - 1] || null;
+}
+
+/**
+ * Cross-space notifications inbox (GitHub-style). Replaces the bell dropdown as
+ * the place to actually manage notifications: Unread/All tabs, filter by type and
+ * by space, per-row read/unread toggle, inline accept/decline for actionable kinds,
+ * and mark-all-as-read. Filtering is client-side over the fetched list — fine at
+ * current volume; move to query params if it grows.
+ */
+export function NotificationsPage({ onUnreadChange }: { onUnreadChange?: (n: number) => void }) {
+  const [notifs, setNotifs] = useState<Notification[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>('unread');
+  const [kindFilter, setKindFilter] = useState<string>('all');
+  const [spaceFilter, setSpaceFilter] = useState<string>('all');
+  const [acting, setActing] = useState<string | null>(null);
+
+  const reload = () => {
+    listNotifications(100)
+      .then((list) => {
+        setNotifs(list);
+        onUnreadChange?.(list.filter((n) => !n.read).length);
+      })
+      .catch((e) => setError(e.message || 'Failed to load notifications'));
+  };
+
+  useEffect(() => {
+    reload();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Distinct kinds and spaces present, for the filter dropdowns.
+  const kinds = useMemo(
+    () => Array.from(new Set((notifs ?? []).map((n) => n.kind))),
+    [notifs],
+  );
+  const spaces = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const n of notifs ?? []) {
+      if (n.workspace_slug) m.set(n.workspace_slug, n.workspace_name || n.workspace_slug);
+    }
+    return Array.from(m.entries()); // [slug, name][]
+  }, [notifs]);
+
+  const filtered = (notifs ?? []).filter((n) => {
+    if (tab === 'unread' && n.read) return false;
+    if (kindFilter !== 'all' && n.kind !== kindFilter) return false;
+    if (spaceFilter !== 'all') {
+      if (spaceFilter === '__none__' ? n.workspace_slug : n.workspace_slug !== spaceFilter) return false;
+    }
+    return true;
+  });
+
+  const unreadCount = (notifs ?? []).filter((n) => !n.read).length;
+
+  const setRead = async (n: Notification, read: boolean) => {
+    // Optimistic; revert on failure.
+    setNotifs((prev) => {
+      const next = (prev ?? []).map((x) => (x.id === n.id ? { ...x, read } : x));
+      onUnreadChange?.(next.filter((x) => !x.read).length);
+      return next;
+    });
+    try {
+      await (read ? markNotificationRead(n.id) : markNotificationUnread(n.id));
+    } catch {
+      reload();
+    }
+  };
+
+  const markAll = async () => {
+    setNotifs((prev) => (prev ?? []).map((x) => ({ ...x, read: true })));
+    onUnreadChange?.(0);
+    try {
+      await markAllNotificationsRead();
+    } catch {
+      reload();
+    }
+  };
+
+  // Accept/decline for actionable kinds. Membership-changing accepts reload the
+  // app so the rail/space list reflects the new state (matches prior bell flow).
+  const act = async (n: Notification, action: 'accept' | 'decline') => {
+    const id = linkId(n);
+    if (!id) return;
+    setActing(n.id);
+    try {
+      if (n.kind === 'invitation') {
+        await (action === 'accept' ? acceptInvitation(id) : rejectInvitation(id));
+      } else if (n.kind === 'ownership_transfer') {
+        await (action === 'accept' ? acceptTransfer(id) : rejectTransfer(id));
+      }
+      await markNotificationRead(n.id).catch(() => {});
+      if (action === 'accept') {
+        window.location.reload();
+        return;
+      }
+      reload();
+    } catch {
+      /* leave it; user can retry */
+    } finally {
+      setActing(null);
+    }
+  };
+
+  if (error) {
+    return <p style={{ color: C.red, fontSize: 14 }}>Failed to load notifications: {error}</p>;
+  }
+
+  return (
+    <div style={{ maxWidth: 860 }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 18 }}>
+        <h1 className="page-title" style={{ marginBottom: 0 }}>Notifications</h1>
+        <button
+          onClick={markAll}
+          disabled={unreadCount === 0}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 6,
+            padding: '7px 12px', borderRadius: 8, border: `1px solid ${C.line}`,
+            background: C.panel, cursor: unreadCount === 0 ? 'default' : 'pointer',
+            color: unreadCount === 0 ? C.faint : C.ink2, fontSize: 13, fontWeight: 550,
+            opacity: unreadCount === 0 ? 0.6 : 1,
+          }}
+        >
+          <CheckCheck size={14} /> Mark all as read
+        </button>
+      </div>
+
+      {/* Filter bar */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14, flexWrap: 'wrap',
+      }}>
+        {/* Unread / All segmented */}
+        <div style={{ display: 'flex', gap: 6 }}>
+          {([
+            { key: 'unread' as Tab, label: 'Unread', count: unreadCount },
+            { key: 'all' as Tab, label: 'All', count: (notifs ?? []).length },
+          ]).map((t) => (
+            <button
+              key={t.key}
+              onClick={() => setTab(t.key)}
+              style={{
+                padding: '6px 12px', borderRadius: 7, border: 'none', cursor: 'pointer',
+                fontWeight: 550, fontSize: 13.5,
+                background: tab === t.key ? C.ink : 'transparent',
+                color: tab === t.key ? '#fff' : C.muted,
+              }}
+            >
+              {t.label} · {t.count}
+            </button>
+          ))}
+        </div>
+
+        <div style={{ flex: 1 }} />
+
+        {/* Type filter */}
+        <FilterSelect
+          value={kindFilter}
+          onChange={setKindFilter}
+          options={[{ value: 'all', label: 'All types' }, ...kinds.map((k) => ({ value: k, label: kindMeta(k).label }))]}
+        />
+        {/* Space filter */}
+        {spaces.length > 0 && (
+          <FilterSelect
+            value={spaceFilter}
+            onChange={setSpaceFilter}
+            options={[
+              { value: 'all', label: 'All spaces' },
+              ...spaces.map(([slug, name]) => ({ value: slug, label: name })),
+              { value: '__none__', label: 'No space' },
+            ]}
+          />
+        )}
+      </div>
+
+      {/* List */}
+      {notifs == null ? (
+        <p style={{ color: C.muted, fontSize: 14, padding: '16px 0' }}>Loading…</p>
+      ) : filtered.length === 0 ? (
+        <div style={{
+          display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10,
+          padding: '56px 24px', color: C.faint,
+          border: `1px solid ${C.line}`, borderRadius: 12, background: C.panel,
+        }}>
+          <Inbox size={32} strokeWidth={1.5} />
+          <span style={{ fontSize: 14 }}>
+            {tab === 'unread' ? "You're all caught up." : 'No notifications.'}
+          </span>
+        </div>
+      ) : (
+        <div style={{ border: `1px solid ${C.line}`, borderRadius: 12, overflow: 'hidden', background: C.panel }}>
+          {filtered.map((n, i) => {
+            const meta = kindMeta(n.kind);
+            const Icon = meta.icon;
+            const actionable = (n.kind === 'invitation' || n.kind === 'ownership_transfer') && linkId(n);
+            return (
+              <div
+                key={n.id}
+                style={{
+                  display: 'flex', alignItems: 'flex-start', gap: 13,
+                  padding: '14px 16px',
+                  borderTop: i ? `1px solid ${C.lineSoft}` : 'none',
+                  background: n.read ? C.panel : C.accentSoft + '55',
+                }}
+              >
+                {/* unread dot */}
+                <div style={{ width: 8, paddingTop: 7, flexShrink: 0 }}>
+                  {!n.read && (
+                    <span style={{ display: 'block', width: 8, height: 8, borderRadius: 4, background: C.accent }} />
+                  )}
+                </div>
+
+                {/* kind icon */}
+                <div style={{
+                  width: 32, height: 32, borderRadius: 9, flexShrink: 0,
+                  background: meta.color + '1a', color: meta.color,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}>
+                  <Icon size={16} />
+                </div>
+
+                {/* body */}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{
+                    fontSize: 14, color: C.ink, fontWeight: n.read ? 450 : 600, lineHeight: 1.4,
+                  }}>
+                    {n.title}
+                  </div>
+                  {n.body && (
+                    <div style={{ fontSize: 13, color: C.muted, marginTop: 2, lineHeight: 1.45 }}>
+                      {n.body}
+                    </div>
+                  )}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 6, fontSize: 12, color: C.faint }}>
+                    {n.workspace_name && (
+                      <span style={{
+                        padding: '1px 7px', borderRadius: 999, background: C.rail, color: C.muted, fontWeight: 550,
+                      }}>
+                        {n.workspace_name}
+                      </span>
+                    )}
+                    <span>{meta.label}</span>
+                    <span>·</span>
+                    <span>{timeAgo(n.created_at)}</span>
+                  </div>
+
+                  {/* inline actions */}
+                  {actionable && !n.read && (
+                    <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
+                      <button
+                        onClick={() => act(n, 'accept')}
+                        disabled={acting === n.id}
+                        style={{
+                          padding: '5px 14px', borderRadius: 7, border: 'none', cursor: 'pointer',
+                          background: C.accent, color: '#fff', fontSize: 13, fontWeight: 550,
+                          opacity: acting === n.id ? 0.6 : 1,
+                        }}
+                      >
+                        Accept
+                      </button>
+                      <button
+                        onClick={() => act(n, 'decline')}
+                        disabled={acting === n.id}
+                        style={{
+                          padding: '5px 14px', borderRadius: 7, border: `1px solid ${C.line}`, cursor: 'pointer',
+                          background: C.panel, color: C.ink2, fontSize: 13, fontWeight: 550,
+                          opacity: acting === n.id ? 0.6 : 1,
+                        }}
+                      >
+                        Decline
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                {/* read/unread toggle */}
+                <button
+                  onClick={() => setRead(n, !n.read)}
+                  title={n.read ? 'Mark as unread' : 'Mark as read'}
+                  style={{
+                    flexShrink: 0, width: 28, height: 28, borderRadius: 7, border: 'none',
+                    background: 'transparent', cursor: 'pointer', color: C.faint,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = C.rail; e.currentTarget.style.color = C.muted; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = C.faint; }}
+                >
+                  {n.read ? <Circle size={15} /> : <Check size={15} />}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Small unstyled-native select that inherits the design language. */
+function FilterSelect({
+  value, onChange, options,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{
+        padding: '6px 10px', borderRadius: 7, border: `1px solid ${C.line}`,
+        background: C.panel, color: C.ink2, fontSize: 13, cursor: 'pointer',
+        fontFamily: 'inherit',
+      }}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>{o.label}</option>
+      ))}
+    </select>
+  );
+}
+
+export default NotificationsPage;

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -35,6 +35,8 @@ import { MembersView } from '../components/views/MembersView';
 import { InviteDialog } from '../components/InviteDialog';
 import { PageEditor } from '../components/PageEditor';
 import { TransferDialog } from '../components/TransferDialog';
+import { NotificationsPage } from '../components/notifications/NotificationsPage';
+import { notificationUnreadCount } from '../api';
 import { C } from '@/lib/design';
 
 type ActiveView =
@@ -44,6 +46,7 @@ type ActiveView =
   | { kind: 'review-detail'; workspaceSlug: string; submissionId: string }
   | { kind: 'members'; workspaceSlug: string }
   | { kind: 'activity'; workspaceSlug: string }
+  | { kind: 'notifications' }
   | null;
 
 export function MainLayout() {
@@ -65,6 +68,12 @@ export function MainLayout() {
   const [spaceSources, setSpaceSources] = useState<Record<string, SourceItem[]>>({});
   const [activeView, setActiveView] = useState<ActiveView>(null);
   const [activeWorkspace, setActiveWorkspace] = useState<Workspace | null>(null);
+  const [notifUnread, setNotifUnread] = useState(0);
+
+  // Cross-space unread badge for the rail; refreshed when opening the inbox.
+  useEffect(() => {
+    notificationUnreadCount().then(setNotifUnread).catch(() => {});
+  }, []);
   const [reviewRefreshKey, setReviewRefreshKey] = useState(0);
   const [activeTab, setActiveTab] = useState<NavTab>('wiki');
   const [reviewCount, setReviewCount] = useState(0);
@@ -593,6 +602,8 @@ export function MainLayout() {
             onSettings={() => setSettingsOpen(true)}
             onDiscover={() => { setActiveView(null); navigate('/discover'); }}
             onLogout={handleLogout}
+            notifUnread={notifUnread}
+            onShowNotifications={() => setActiveView({ kind: 'notifications' })}
           />
 
           {/* Secondary Panel */}
@@ -673,6 +684,9 @@ export function MainLayout() {
                     <span style={{ color: C.faint }}>/</span>
                     <span style={{ color: C.ink }}>Activity</span>
                   </>
+                )}
+                {activeView?.kind === 'notifications' && (
+                  <span style={{ color: C.ink }}>Notifications</span>
                 )}
               </div>
 
@@ -761,8 +775,12 @@ export function MainLayout() {
 
             {/* Content */}
             <div style={{ flex: 1, padding: '36px 56px 56px' }}>
-              {/* Review detail */}
-              {activeView?.kind === 'review-detail' ? (
+              {/* Notifications (cross-space inbox) */}
+              {activeView?.kind === 'notifications' ? (
+                <NotificationsPage onUnreadChange={setNotifUnread} />
+
+              /* Review detail */
+              ) : activeView?.kind === 'review-detail' ? (
                 <ReviewDetail
                   workspaceSlug={activeView.workspaceSlug}
                   submissionId={activeView.submissionId}


### PR DESCRIPTION
Implements the roadmap item **"Notification 单独搞个页面"** (moved Backlog→Now in the cowiki-team wiki). As notification volume grows, the bell **dropdown** is the wrong surface to manage them — this adds a GitHub-style inbox.

**Cross-space**: the bell and page aggregate notifications across every workspace (and space-less ones) — not per-space.

## Backend
- `list_for_user` LEFT JOINs `workspaces` → each notification carries `workspace_name` / `workspace_slug` (display + per-space filter). Cross-space rows (`workspace_id` NULL) still return.
- New `POST /api/notifications/{id}/unread` (+ `db::notifications::mark_unread`) for the read/unread toggle.

## Frontend
- **`NotificationsPage`** (GitHub inbox flow): **Unread / All** tabs with counts; filter by **type** and by **space**; per-row **read ↔ unread** toggle; **Mark all as read**; inline **Accept / Decline** for invitations & ownership transfers; kind icons, unread highlight, empty state. Filtering is client-side over the fetched list (fine at current volume).
- Rail **bell becomes a navigation button** — keeps the unread badge (lifted to `MainLayout`), opens the inbox instead of a popup. Old dropdown/detail-modal removed from `SpaceRail`.
- New global `ActiveView` `'notifications'` (workspace-independent) + breadcrumb.

## Verified locally (running server)
- enriched list response includes `workspace_name`/`workspace_slug`
- `mark read` → unread-count 0; `mark unread` → unread-count 1
- `cargo fmt` clean, backend suites green, `tsc + vite build` green

> The Netlify deploy preview points at the **test API**, which won't have the JOIN fields / `mark_unread` route until this lands on the server — so the preview's space badge is blank and the unread-toggle 404s until deploy. Complete for code review; full E2E is post-merge-deploy (same pattern as prior backend+frontend PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)