### PR TITLE
feat(comments): document comments with line-anchored re-anchoring + @mention notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ mcp-server
 .claude/settings.local.json
 
 .omc
+# local comment-system test stack
+data-comments-test/
+cowiki.conf

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -3,6 +3,7 @@ use sqlx::PgPool;
 pub mod api_keys;
 pub mod audit;
 pub mod notifications;
+pub mod page_comments;
 pub mod pages;
 pub mod review_comments;
 pub mod submissions;
@@ -83,6 +84,11 @@ pub async fn run_migrations(pool: &PgPool, embedding_dim: u32) -> sqlx::Result<(
     })?;
     let sql14 = include_str!("migrations/012_hash_primary_api_keys.sql");
     sqlx::raw_sql(sql14).execute(pool).await.map_err(|e| {
+        tracing::error!("DB error: {e}");
+        e
+    })?;
+    let sql15 = include_str!("migrations/013_page_comments.sql");
+    sqlx::raw_sql(sql15).execute(pool).await.map_err(|e| {
         tracing::error!("DB error: {e}");
         e
     })?;

--- a/crates/db/src/migrations/013_page_comments.sql
+++ b/crates/db/src/migrations/013_page_comments.sql
@@ -1,0 +1,45 @@
+-- Document comments: Feishu-style inline comments on a wiki page, anchored to a
+-- source *line range* of the page markdown. Comments live entirely outside the
+-- markdown blob (so page diffs stay clean); a content snapshot is kept per
+-- (page, content_hash) so the anchor can be re-mapped onto whatever branch
+-- version a viewer is currently looking at (git-diff line mapping on the client).
+
+-- Snapshot of the page markdown as the author saw it when anchoring a comment.
+-- Deduplicated by content_hash so many comments on the same version share one row.
+CREATE TABLE IF NOT EXISTS page_comment_snapshots (
+    workspace_slug TEXT NOT NULL,
+    page_slug      TEXT NOT NULL,
+    content_hash   TEXT NOT NULL,
+    source         TEXT NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (workspace_slug, page_slug, content_hash)
+);
+
+CREATE TABLE IF NOT EXISTS page_comments (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_slug TEXT NOT NULL,
+    page_slug      TEXT NOT NULL,
+    user_id        UUID NOT NULL REFERENCES users(id),
+    -- Anchor; NULL for replies, which inherit their thread root's anchor.
+    content_hash   TEXT,
+    start_line     INTEGER,
+    end_line       INTEGER,
+    body           TEXT NOT NULL,
+    parent_id      UUID REFERENCES page_comments(id) ON DELETE CASCADE,
+    resolved       BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- A top-level comment carries a full line-range anchor; a reply carries none.
+    CONSTRAINT page_comments_anchor_shape CHECK (
+        (parent_id IS NULL
+            AND content_hash IS NOT NULL AND start_line IS NOT NULL AND end_line IS NOT NULL)
+        OR (parent_id IS NOT NULL
+            AND content_hash IS NULL AND start_line IS NULL AND end_line IS NULL)
+    ),
+    CONSTRAINT page_comments_line_range CHECK (
+        start_line IS NULL OR (start_line >= 1 AND start_line <= end_line)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_page_comments_page ON page_comments(workspace_slug, page_slug);
+CREATE INDEX IF NOT EXISTS idx_page_comments_parent ON page_comments(parent_id);

--- a/crates/db/src/page_comments.rs
+++ b/crates/db/src/page_comments.rs
@@ -1,0 +1,142 @@
+//! Document comments anchored to source line ranges of a wiki page.
+//!
+//! The page markdown itself is never touched (clean diffs); each top-level
+//! comment stores a line-range anchor plus a `content_hash` pointing at a
+//! snapshot of the page as the author saw it. The client re-maps the anchor
+//! onto whatever branch version it is rendering via a git-style line diff.
+
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct PageComment {
+    pub id: Uuid,
+    pub workspace_slug: String,
+    pub page_slug: String,
+    pub user_id: Uuid,
+    /// Anchor snapshot hash; `None` for replies.
+    pub content_hash: Option<String>,
+    /// 1-based inclusive source line range; `None` for replies.
+    pub start_line: Option<i32>,
+    pub end_line: Option<i32>,
+    pub body: String,
+    pub parent_id: Option<Uuid>,
+    pub resolved: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// A deduplicated snapshot of the page markdown an anchor was created against.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct CommentSnapshot {
+    pub content_hash: String,
+    pub source: String,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn create(
+    pool: &PgPool,
+    workspace_slug: &str,
+    page_slug: &str,
+    user_id: Uuid,
+    content_hash: Option<&str>,
+    start_line: Option<i32>,
+    end_line: Option<i32>,
+    body: &str,
+    parent_id: Option<Uuid>,
+) -> sqlx::Result<PageComment> {
+    sqlx::query_as::<_, PageComment>(
+        "INSERT INTO page_comments \
+         (workspace_slug, page_slug, user_id, content_hash, start_line, end_line, body, parent_id) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *",
+    )
+    .bind(workspace_slug)
+    .bind(page_slug)
+    .bind(user_id)
+    .bind(content_hash)
+    .bind(start_line)
+    .bind(end_line)
+    .bind(body)
+    .bind(parent_id)
+    .fetch_one(pool)
+    .await
+}
+
+pub async fn list_for_page(
+    pool: &PgPool,
+    workspace_slug: &str,
+    page_slug: &str,
+) -> sqlx::Result<Vec<PageComment>> {
+    sqlx::query_as::<_, PageComment>(
+        "SELECT * FROM page_comments WHERE workspace_slug = $1 AND page_slug = $2 \
+         ORDER BY created_at ASC",
+    )
+    .bind(workspace_slug)
+    .bind(page_slug)
+    .fetch_all(pool)
+    .await
+}
+
+/// Fetch a single comment (used to authorize/locate before mutation).
+pub async fn find(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<PageComment>> {
+    sqlx::query_as::<_, PageComment>("SELECT * FROM page_comments WHERE id = $1")
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+}
+
+pub async fn set_resolved(pool: &PgPool, id: Uuid, resolved: bool) -> sqlx::Result<PageComment> {
+    sqlx::query_as::<_, PageComment>(
+        "UPDATE page_comments SET resolved = $2, updated_at = now() WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .bind(resolved)
+    .fetch_one(pool)
+    .await
+}
+
+pub async fn delete(pool: &PgPool, id: Uuid) -> sqlx::Result<()> {
+    sqlx::query("DELETE FROM page_comments WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Store the page snapshot an anchor was created against (idempotent by hash).
+pub async fn upsert_snapshot(
+    pool: &PgPool,
+    workspace_slug: &str,
+    page_slug: &str,
+    content_hash: &str,
+    source: &str,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO page_comment_snapshots (workspace_slug, page_slug, content_hash, source) \
+         VALUES ($1, $2, $3, $4) ON CONFLICT (workspace_slug, page_slug, content_hash) DO NOTHING",
+    )
+    .bind(workspace_slug)
+    .bind(page_slug)
+    .bind(content_hash)
+    .bind(source)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// All snapshots referenced by comments on a page, so the client can re-anchor.
+pub async fn snapshots_for_page(
+    pool: &PgPool,
+    workspace_slug: &str,
+    page_slug: &str,
+) -> sqlx::Result<Vec<CommentSnapshot>> {
+    sqlx::query_as::<_, CommentSnapshot>(
+        "SELECT content_hash, source FROM page_comment_snapshots \
+         WHERE workspace_slug = $1 AND page_slug = $2",
+    )
+    .bind(workspace_slug)
+    .bind(page_slug)
+    .fetch_all(pool)
+    .await
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -307,6 +307,27 @@ async fn main() {
             "/api/workspaces/{ws_slug}/reviews/{submission_id}/comments/{comment_id}",
             delete(routes::comments::delete_comment),
         )
+        // Document comments (inline page comments)
+        .route(
+            "/api/workspaces/{ws_slug}/page-comments",
+            get(routes::page_comments::list_comments),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/page-comments",
+            post(routes::page_comments::create_comment),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/page-comments/{comment_id}/resolve",
+            post(routes::page_comments::resolve_comment),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/page-comments/{comment_id}/unresolve",
+            post(routes::page_comments::unresolve_comment),
+        )
+        .route(
+            "/api/workspaces/{ws_slug}/page-comments/{comment_id}",
+            delete(routes::page_comments::delete_comment),
+        )
         // Search
         .route(
             "/api/workspaces/{ws_slug}/search",

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -5,6 +5,7 @@ pub mod guard;
 pub mod ingest;
 pub mod keys;
 pub mod notifications;
+pub mod page_comments;
 pub mod pages;
 pub mod review;
 pub mod search;

--- a/crates/server/src/routes/page_comments.rs
+++ b/crates/server/src/routes/page_comments.rs
@@ -113,6 +113,12 @@ pub async fn create_comment(
     let guard = require_membership(&state, &headers, &ws_slug).await?;
     let user = &guard.user;
 
+    // Validate the body before any write, so a rejected comment never leaves a
+    // snapshot row behind (the snapshot upsert below happens for top-level ones).
+    if input.body.trim().is_empty() {
+        return Err(AppError::BadRequest("comment body is empty".into()));
+    }
+
     let (content_hash, start_line, end_line) = match input.parent_id {
         // Reply: must target a top-level comment on the same page; no anchor.
         Some(parent_id) => {
@@ -152,10 +158,6 @@ pub async fn create_comment(
             (Some(hash), Some(s), Some(e))
         }
     };
-
-    if input.body.trim().is_empty() {
-        return Err(AppError::BadRequest("comment body is empty".into()));
-    }
 
     let comment = cowiki_db::page_comments::create(
         &state.db,

--- a/crates/server/src/routes/page_comments.rs
+++ b/crates/server/src/routes/page_comments.rs
@@ -1,0 +1,290 @@
+//! Document comment endpoints: Feishu-style inline comments on a wiki page,
+//! anchored to source line ranges.
+//!
+//! All endpoints require workspace membership (Viewer+) — a logged-in non-member
+//! must not read comments or the page snapshots they carry (those snapshots are
+//! the full page markdown). Any member may comment; `@name` mentions notify only
+//! users who are members of the same workspace.
+
+use axum::extract::{Path, Query, State};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+use std::sync::Arc;
+
+use crate::error::{AppError, Result};
+use crate::routes::guard::require_membership;
+use crate::AppState;
+use cowiki_db::page_comments::{CommentSnapshot, PageComment};
+
+#[derive(Deserialize)]
+pub struct PageQuery {
+    /// Page slug, e.g. `roadmap/index`. Passed as a query param so slugs with
+    /// slashes don't collide with the `/{comment_id}` mutation routes.
+    pub slug: String,
+}
+
+#[derive(Serialize)]
+pub struct ListResponse {
+    pub comments: Vec<PageComment>,
+    /// Snapshots referenced by the comments' `content_hash`, for client re-anchoring.
+    pub snapshots: Vec<CommentSnapshot>,
+}
+
+#[derive(Deserialize)]
+pub struct CreateCommentRequest {
+    pub slug: String,
+    /// Markdown the anchor was created against (top-level comments only).
+    pub source: Option<String>,
+    /// 1-based inclusive line range (top-level comments only).
+    pub start_line: Option<i32>,
+    pub end_line: Option<i32>,
+    pub body: String,
+    pub parent_id: Option<uuid::Uuid>,
+}
+
+fn sha256_hex(s: &str) -> String {
+    let digest = Sha256::digest(s.as_bytes());
+    let mut out = String::with_capacity(64);
+    for b in digest {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// Extract distinct `@handle` mentions from a comment body.
+fn parse_mentions(body: &str) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+    let bytes = body.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'@' {
+            let start = i + 1;
+            let mut j = start;
+            while j < bytes.len()
+                && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_' || bytes[j] == b'-')
+            {
+                j += 1;
+            }
+            if j > start {
+                let name = &body[start..j];
+                if !names.iter().any(|n| n == name) {
+                    names.push(name.to_string());
+                }
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    names
+}
+
+/// List all comments on a page plus the snapshots needed to re-anchor them.
+/// Requires membership — snapshots contain the full page markdown.
+pub async fn list_comments(
+    State(state): State<Arc<AppState>>,
+    Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
+    Query(q): Query<PageQuery>,
+) -> Result<Json<ListResponse>> {
+    require_membership(&state, &headers, &ws_slug).await?;
+    let comments = cowiki_db::page_comments::list_for_page(&state.db, &ws_slug, &q.slug).await?;
+    let snapshots =
+        cowiki_db::page_comments::snapshots_for_page(&state.db, &ws_slug, &q.slug).await?;
+    Ok(Json(ListResponse {
+        comments,
+        snapshots,
+    }))
+}
+
+/// Create a comment (or reply) and notify any `@`-mentioned **members**.
+///
+/// Any workspace member (Viewer+) may comment. Shape is validated strictly:
+/// a top-level comment must carry `source` + a valid line range; a reply must
+/// reference a top-level comment on the same page and carries no anchor.
+pub async fn create_comment(
+    State(state): State<Arc<AppState>>,
+    Path(ws_slug): Path<String>,
+    headers: axum::http::HeaderMap,
+    Json(input): Json<CreateCommentRequest>,
+) -> Result<Json<PageComment>> {
+    let guard = require_membership(&state, &headers, &ws_slug).await?;
+    let user = &guard.user;
+
+    let (content_hash, start_line, end_line) = match input.parent_id {
+        // Reply: must target a top-level comment on the same page; no anchor.
+        Some(parent_id) => {
+            let parent = cowiki_db::page_comments::find(&state.db, parent_id)
+                .await?
+                .ok_or_else(|| AppError::NotFound("parent comment not found".into()))?;
+            if parent.parent_id.is_some() {
+                return Err(AppError::BadRequest("cannot reply to a reply".into()));
+            }
+            if parent.workspace_slug != ws_slug || parent.page_slug != input.slug {
+                return Err(AppError::BadRequest(
+                    "parent comment belongs to a different page".into(),
+                ));
+            }
+            (None, None, None)
+        }
+        // Top-level: requires a page snapshot + a valid 1-based line range.
+        None => {
+            let source = input
+                .source
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| AppError::BadRequest("a comment requires source".into()))?;
+            let (s, e) = match (input.start_line, input.end_line) {
+                (Some(s), Some(e)) if s >= 1 && s <= e => (s, e),
+                _ => return Err(AppError::BadRequest("invalid line range".into())),
+            };
+            let hash = sha256_hex(source);
+            cowiki_db::page_comments::upsert_snapshot(
+                &state.db,
+                &ws_slug,
+                &input.slug,
+                &hash,
+                source,
+            )
+            .await?;
+            (Some(hash), Some(s), Some(e))
+        }
+    };
+
+    if input.body.trim().is_empty() {
+        return Err(AppError::BadRequest("comment body is empty".into()));
+    }
+
+    let comment = cowiki_db::page_comments::create(
+        &state.db,
+        &ws_slug,
+        &input.slug,
+        user.id,
+        content_hash.as_deref(),
+        start_line,
+        end_line,
+        &input.body,
+        input.parent_id,
+    )
+    .await?;
+
+    // Fan out @mention notifications — only to members of this workspace.
+    let link = format!("/{}/{}", ws_slug, input.slug);
+    for name in parse_mentions(&input.body) {
+        if name == user.name {
+            continue;
+        }
+        let Ok(Some(target)) = cowiki_db::users::find_by_name(&state.db, &name).await else {
+            continue;
+        };
+        if target.id == user.id {
+            continue;
+        }
+        let is_member = cowiki_db::workspaces::is_member(&state.db, guard.workspace.id, target.id)
+            .await
+            .unwrap_or(false);
+        if !is_member {
+            continue;
+        }
+        let _ = cowiki_db::notifications::create(
+            &state.db,
+            target.id,
+            "mention",
+            &format!("{} mentioned you in a comment", user.name),
+            Some(&input.body),
+            Some(guard.workspace.id),
+            Some(&link),
+        )
+        .await;
+    }
+
+    Ok(Json(comment))
+}
+
+/// Load a comment, 404ing unless it belongs to `ws_slug` (prevents cross-workspace
+/// mutation by guessable comment id).
+async fn load_in_workspace(
+    state: &Arc<AppState>,
+    ws_slug: &str,
+    comment_id: uuid::Uuid,
+) -> Result<PageComment> {
+    let c = cowiki_db::page_comments::find(&state.db, comment_id)
+        .await?
+        .filter(|c| c.workspace_slug == ws_slug)
+        .ok_or_else(|| AppError::NotFound("comment not found".into()))?;
+    Ok(c)
+}
+
+pub async fn resolve_comment(
+    State(state): State<Arc<AppState>>,
+    Path((ws_slug, comment_id)): Path<(String, uuid::Uuid)>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<PageComment>> {
+    require_membership(&state, &headers, &ws_slug).await?;
+    load_in_workspace(&state, &ws_slug, comment_id).await?;
+    let comment = cowiki_db::page_comments::set_resolved(&state.db, comment_id, true).await?;
+    Ok(Json(comment))
+}
+
+pub async fn unresolve_comment(
+    State(state): State<Arc<AppState>>,
+    Path((ws_slug, comment_id)): Path<(String, uuid::Uuid)>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<PageComment>> {
+    require_membership(&state, &headers, &ws_slug).await?;
+    load_in_workspace(&state, &ws_slug, comment_id).await?;
+    let comment = cowiki_db::page_comments::set_resolved(&state.db, comment_id, false).await?;
+    Ok(Json(comment))
+}
+
+/// Delete a comment. Member of the workspace + author of the comment only.
+pub async fn delete_comment(
+    State(state): State<Arc<AppState>>,
+    Path((ws_slug, comment_id)): Path<(String, uuid::Uuid)>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<serde_json::Value>> {
+    let guard = require_membership(&state, &headers, &ws_slug).await?;
+    let comment = load_in_workspace(&state, &ws_slug, comment_id).await?;
+    if comment.user_id != guard.user.id {
+        return Err(AppError::Forbidden(
+            "you can only delete your own comment".into(),
+        ));
+    }
+    cowiki_db::page_comments::delete(&state.db, comment_id).await?;
+    Ok(Json(serde_json::json!({"ok": true})))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_mentions, sha256_hex};
+
+    #[test]
+    fn parses_distinct_handles() {
+        let got = parse_mentions("hey @wfnuser and @Deadpoolmine, also @wfnuser again");
+        assert_eq!(got, vec!["wfnuser".to_string(), "Deadpoolmine".to_string()]);
+    }
+
+    #[test]
+    fn handles_punctuation_and_emails() {
+        // Trailing punctuation is excluded; an email's local part still parses
+        // its `@domain` as a handle candidate (resolution later just finds nobody).
+        let got = parse_mentions("ping @alice! see foo@example, end");
+        assert_eq!(got, vec!["alice".to_string(), "example".to_string()]);
+    }
+
+    #[test]
+    fn lone_at_yields_nothing() {
+        assert!(parse_mentions("an @ sign alone").is_empty());
+    }
+
+    #[test]
+    fn sha256_is_stable_and_hex() {
+        let h = sha256_hex("hello");
+        assert_eq!(
+            h,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -678,3 +678,94 @@ export async function editReview(workspaceSlug: string, submissionId: string, pa
   });
   if (!res.ok) throw new Error(await res.text().catch(() => `Request failed: ${res.status}`));
 }
+
+// ── Document Comments ──
+
+export interface PageComment {
+  id: string;
+  workspace_slug: string;
+  page_slug: string;
+  user_id: string;
+  content_hash: string | null;
+  start_line: number | null;
+  end_line: number | null;
+  body: string;
+  parent_id: string | null;
+  resolved: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CommentSnapshot {
+  content_hash: string;
+  source: string;
+}
+
+export interface PageCommentsResponse {
+  comments: PageComment[];
+  snapshots: CommentSnapshot[];
+}
+
+/** All comments on a page plus the snapshots needed to re-anchor them. */
+export async function listPageComments(workspaceSlug: string, slug: string): Promise<PageCommentsResponse> {
+  const res = await fetch(
+    `${BASE}/workspaces/${workspaceSlug}/page-comments?slug=${encodeURIComponent(slug)}`,
+    { headers: h() },
+  );
+  if (!res.ok) throw new Error(await res.text().catch(() => `Request failed: ${res.status}`));
+  return res.json();
+}
+
+/**
+ * Create a comment or reply. Top-level comments pass `source` (the rendered,
+ * frontmatter-stripped markdown the anchor was made against) plus a 1-based
+ * `startLine`/`endLine`; replies pass only `parentId` + `body`.
+ */
+export async function createPageComment(
+  workspaceSlug: string,
+  input: {
+    slug: string;
+    body: string;
+    source?: string;
+    startLine?: number;
+    endLine?: number;
+    parentId?: string;
+  },
+): Promise<PageComment> {
+  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/page-comments`, {
+    method: 'POST',
+    headers: h({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({
+      slug: input.slug,
+      body: input.body,
+      source: input.source,
+      start_line: input.startLine,
+      end_line: input.endLine,
+      parent_id: input.parentId,
+    }),
+  });
+  if (!res.ok) throw new Error(await res.text().catch(() => `Request failed: ${res.status}`));
+  return res.json();
+}
+
+export async function setPageCommentResolved(
+  workspaceSlug: string,
+  commentId: string,
+  resolved: boolean,
+): Promise<PageComment> {
+  const action = resolved ? 'resolve' : 'unresolve';
+  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/page-comments/${commentId}/${action}`, {
+    method: 'POST',
+    headers: h(),
+  });
+  if (!res.ok) throw new Error(await res.text().catch(() => `Request failed: ${res.status}`));
+  return res.json();
+}
+
+export async function deletePageComment(workspaceSlug: string, commentId: string): Promise<void> {
+  const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/page-comments/${commentId}`, {
+    method: 'DELETE',
+    headers: h(),
+  });
+  if (!res.ok) throw new Error(await res.text().catch(() => `Request failed: ${res.status}`));
+}

--- a/web/src/components/PageCommentsLayer.tsx
+++ b/web/src/components/PageCommentsLayer.tsx
@@ -148,6 +148,10 @@ export function CommentsProvider({
   const [panelOpen, setPanelOpen] = useState(true);
   const [pending, setPending] = useState<{ start: number; end: number; x: number; y: number } | null>(null);
   const [composing, setComposing] = useState<{ start: number; end: number; quote: string } | null>(null);
+  // Mirror `composing` into a ref so the once-registered mouseup handler can read
+  // it without a stale closure (and without re-subscribing on every change).
+  const composingRef = useRef(false);
+  composingRef.current = composing != null;
 
   const enabled = !!workspaceSlug && !!pageSlug;
 
@@ -217,6 +221,9 @@ export function CommentsProvider({
   // selection → floating "Comment" toolbar
   useEffect(() => {
     const onUp = () => {
+      // A composer is open — don't let the still-present selection re-arm the
+      // floating "Comment" bubble (it would resurface after cancel/submit).
+      if (composingRef.current) return;
       const root = articleRef.current;
       if (!root) return;
       const lr = selectionLineRange(root);
@@ -232,6 +239,7 @@ export function CommentsProvider({
     if (!composing || !body.trim()) return;
     await createPageComment(workspaceSlug, { slug: pageSlug, body: body.trim(), source, startLine: composing.start, endLine: composing.end });
     setComposing(null);
+    setPending(null);
     await reload();
   };
   const submitReply = async (parentId: string, body: string) => {
@@ -245,7 +253,7 @@ export function CommentsProvider({
     anchored, outdated, resolved, openCount,
     activeId, setActive: setActiveId,
     panelOpen, setPanelOpen,
-    composing, cancelCompose: () => setComposing(null), submitNew,
+    composing, cancelCompose: () => { setComposing(null); setPending(null); }, submitNew,
     members, nameOf, currentUserId, myId: currentUserId ?? 'me', myName: currentUserId ? nameOf(currentUserId) : 'You',
     onResolve: async (id, r) => { await setPageCommentResolved(workspaceSlug, id, r); await reload(); },
     onDelete: async (id) => { await deletePageComment(workspaceSlug, id); await reload(); },

--- a/web/src/components/PageCommentsLayer.tsx
+++ b/web/src/components/PageCommentsLayer.tsx
@@ -1,0 +1,574 @@
+import {
+  createContext, createElement, useCallback, useContext, useEffect, useMemo, useRef, useState,
+} from 'react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  MessageSquare, Reply, Check, RotateCcw, AtSign, ChevronsRight,
+  ChevronRight, ChevronDown, CheckCircle2, Trash2, MoreHorizontal,
+} from 'lucide-react';
+import {
+  listPageComments, createPageComment, setPageCommentResolved, deletePageComment,
+  listMembers, type PageComment, type MemberInfo,
+} from '@/api';
+import { buildSnapshotMaps, mapWithSurviving, type MappedAnchor } from '@/lib/comment-anchor';
+import { C, fonts } from '@/lib/design';
+
+// ── identity helpers ───────────────────────────────────────────────────────
+const AVATAR_COLORS = ['#2f6bb0', '#2f8a5b', '#8b5cf6', '#c2410c', '#3f6c8c', '#9a6f93', '#5d8a6c', '#b5790f'];
+function colorFor(id: string): string {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  return AVATAR_COLORS[h % AVATAR_COLORS.length];
+}
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+}
+function relTime(iso: string): string {
+  const s = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+  if (s < 60) return 'now';
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h`;
+  return `${Math.floor(s / 86400)}d`;
+}
+function quoteOf(source: string, start: number, end: number): string {
+  const text = source
+    .split('\n')
+    .slice(start - 1, end)
+    .map((l) => l.replace(/^\s*(#{1,6}\s+|[-*+]\s+|>\s?|\d+\.\s+)/, '').trim())
+    .filter(Boolean)
+    .join(' ');
+  return text.length > 140 ? text.slice(0, 140) + '…' : text;
+}
+
+function Avatar({ id, name, size = 24 }: { id: string; name: string; size?: number }) {
+  return (
+    <div style={{
+      width: size, height: size, flexShrink: 0, borderRadius: '50%', background: colorFor(id),
+      color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontSize: size * 0.42, fontWeight: 600, letterSpacing: '-0.02em',
+    }}>
+      {initials(name)}
+    </div>
+  );
+}
+
+const ghostBtn: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center', gap: 5, padding: '5px 8px', borderRadius: 7,
+  border: 'none', background: 'transparent', color: C.muted, fontSize: 12.5, fontWeight: 550, cursor: 'pointer',
+};
+
+// Render a quoted snippet as *inline* markdown (bold/italic/links/code), so it
+// reads like the doc — but flatten all block wrappers, and show an image's alt
+// text instead of the image itself.
+const QUOTE_COMPONENTS: Components = {
+  p: ({ children }) => <>{children}</>,
+  a: ({ children }) => <>{children}</>,
+  img: ({ alt }) => <>{alt || '🖼'}</>,
+  h1: ({ children }) => <>{children}</>, h2: ({ children }) => <>{children}</>,
+  h3: ({ children }) => <>{children}</>, h4: ({ children }) => <>{children}</>,
+  h5: ({ children }) => <>{children}</>, h6: ({ children }) => <>{children}</>,
+  ul: ({ children }) => <>{children}</>, ol: ({ children }) => <>{children}</>,
+  li: ({ children }) => <>{children} </>,
+  blockquote: ({ children }) => <>{children}</>,
+  pre: ({ children }) => <>{children}</>,
+  br: () => <> </>,
+} as Components;
+function Quote({ text }: { text: string }) {
+  return <ReactMarkdown remarkPlugins={[remarkGfm]} components={QUOTE_COMPONENTS}>{text}</ReactMarkdown>;
+}
+
+interface Thread {
+  root: PageComment;
+  replies: PageComment[];
+  anchor: MappedAnchor;
+  quote: string;
+}
+
+function selectionLineRange(root: HTMLElement): { start: number; end: number } | null {
+  const sel = window.getSelection();
+  if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null;
+  const range = sel.getRangeAt(0);
+  if (!root.contains(range.commonAncestorContainer)) return null;
+  const blockOf = (n: Node): HTMLElement | null => {
+    let el: Node | null = n.nodeType === Node.TEXT_NODE ? n.parentElement : n;
+    while (el && el !== root) {
+      if (el instanceof HTMLElement && el.dataset.sourceLine) return el;
+      el = el.parentElement;
+    }
+    return null;
+  };
+  const a = blockOf(range.startContainer);
+  const b = blockOf(range.endContainer);
+  if (!a || !b) return null;
+  const start = Math.min(Number(a.dataset.sourceLine), Number(b.dataset.sourceLine));
+  const end = Math.max(
+    Number(a.dataset.endLine ?? a.dataset.sourceLine),
+    Number(b.dataset.endLine ?? b.dataset.sourceLine),
+  );
+  return { start, end };
+}
+
+// ── shared controller (doc highlights + panel read the same state) ──────────
+interface CommentsCtx {
+  /** True only on a page view with a workspace — drives the header toggle. */
+  enabled: boolean;
+  anchored: Thread[]; outdated: Thread[]; resolved: Thread[]; openCount: number;
+  activeId: string | null; setActive: (id: string) => void;
+  panelOpen: boolean; setPanelOpen: (b: boolean) => void;
+  composing: { start: number; end: number; quote: string } | null;
+  cancelCompose: () => void; submitNew: (body: string) => Promise<void>;
+  members: MemberInfo[]; nameOf: (id: string) => string;
+  currentUserId?: string; myId: string; myName: string;
+  onResolve: (id: string, r: boolean) => Promise<void>; onDelete: (id: string) => Promise<void>;
+  submitReply: (parentId: string, body: string) => Promise<void>;
+  /** Highlight info for a doc source line, or null if not commented. */
+  lineHighlight: (line: number) => { active: boolean } | null;
+  focusLine: (line: number) => void;
+}
+const Ctx = createContext<CommentsCtx | null>(null);
+
+export function CommentsProvider({
+  workspaceSlug, pageSlug, source, articleRef, currentUserId, children,
+}: {
+  workspaceSlug: string;
+  pageSlug: string;
+  source: string;
+  articleRef: React.RefObject<HTMLElement | null>;
+  currentUserId: string | undefined;
+  children: React.ReactNode;
+}) {
+  const [comments, setComments] = useState<PageComment[]>([]);
+  const [snapshots, setSnapshots] = useState<{ content_hash: string; source: string }[]>([]);
+  const [members, setMembers] = useState<MemberInfo[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [panelOpen, setPanelOpen] = useState(true);
+  const [pending, setPending] = useState<{ start: number; end: number; x: number; y: number } | null>(null);
+  const [composing, setComposing] = useState<{ start: number; end: number; quote: string } | null>(null);
+
+  const enabled = !!workspaceSlug && !!pageSlug;
+
+  const reload = useCallback(async () => {
+    if (!workspaceSlug || !pageSlug) { setComments([]); setSnapshots([]); return; }
+    const res = await listPageComments(workspaceSlug, pageSlug);
+    setComments(res.comments);
+    setSnapshots(res.snapshots);
+  }, [workspaceSlug, pageSlug]);
+
+  useEffect(() => { void reload(); }, [reload]);
+  useEffect(() => {
+    if (!workspaceSlug) return;
+    listMembers(workspaceSlug).then(setMembers).catch(() => setMembers([]));
+  }, [workspaceSlug]);
+  // Reset the focused thread when navigating to a different page.
+  useEffect(() => { setActiveId(null); }, [pageSlug]);
+
+  const nameOf = useCallback(
+    (uid: string) => members.find((m) => m.id === uid)?.name ?? uid.slice(0, 8),
+    [members],
+  );
+
+  const threads = useMemo<Thread[]>(() => {
+    const maps = buildSnapshotMaps(snapshots, source);
+    const snapById = new Map(snapshots.map((s) => [s.content_hash, s.source]));
+    const repliesByParent = new Map<string, PageComment[]>();
+    for (const c of comments) {
+      if (c.parent_id) {
+        const arr = repliesByParent.get(c.parent_id) ?? [];
+        arr.push(c);
+        repliesByParent.set(c.parent_id, arr);
+      }
+    }
+    return comments.filter((c) => !c.parent_id).map((root) => {
+      let anchor: MappedAnchor = { kind: 'outdated' };
+      let quote = '';
+      if (root.content_hash && root.start_line != null && root.end_line != null) {
+        const m = maps.get(root.content_hash);
+        anchor = m ? mapWithSurviving(m, root.start_line, root.end_line) : { kind: 'outdated' };
+        if (anchor.kind === 'anchored') quote = quoteOf(source, anchor.startLine, anchor.endLine);
+        else { const snap = snapById.get(root.content_hash); if (snap) quote = quoteOf(snap, root.start_line, root.end_line); }
+      }
+      return { root, replies: repliesByParent.get(root.id) ?? [], anchor, quote };
+    });
+  }, [comments, snapshots, source]);
+
+  const anchored = threads.filter((t) => t.anchor.kind === 'anchored' && !t.root.resolved);
+  const outdated = threads.filter((t) => t.anchor.kind === 'outdated' && !t.root.resolved);
+  const resolved = threads.filter((t) => t.root.resolved);
+  const openCount = anchored.length + outdated.length;
+
+  useEffect(() => {
+    if (activeId == null && anchored.length) setActiveId(anchored[0].root.id);
+  }, [anchored, activeId]);
+
+  // map every commented source line → its thread (first wins)
+  const lineToThread = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const t of anchored) {
+      if (t.anchor.kind !== 'anchored') continue;
+      for (let l = t.anchor.startLine; l <= t.anchor.endLine; l++) if (!m.has(l)) m.set(l, t.root.id);
+    }
+    return m;
+  }, [anchored]);
+
+  // selection → floating "Comment" toolbar
+  useEffect(() => {
+    const onUp = () => {
+      const root = articleRef.current;
+      if (!root) return;
+      const lr = selectionLineRange(root);
+      if (!lr) { setPending(null); return; }
+      const rect = window.getSelection()!.getRangeAt(0).getBoundingClientRect();
+      setPending({ ...lr, x: rect.left + rect.width / 2, y: rect.top });
+    };
+    document.addEventListener('mouseup', onUp);
+    return () => document.removeEventListener('mouseup', onUp);
+  }, [articleRef]);
+
+  const submitNew = async (body: string) => {
+    if (!composing || !body.trim()) return;
+    await createPageComment(workspaceSlug, { slug: pageSlug, body: body.trim(), source, startLine: composing.start, endLine: composing.end });
+    setComposing(null);
+    await reload();
+  };
+  const submitReply = async (parentId: string, body: string) => {
+    if (!body.trim()) return;
+    await createPageComment(workspaceSlug, { slug: pageSlug, body: body.trim(), parentId });
+    await reload();
+  };
+
+  const value: CommentsCtx = {
+    enabled,
+    anchored, outdated, resolved, openCount,
+    activeId, setActive: setActiveId,
+    panelOpen, setPanelOpen,
+    composing, cancelCompose: () => setComposing(null), submitNew,
+    members, nameOf, currentUserId, myId: currentUserId ?? 'me', myName: currentUserId ? nameOf(currentUserId) : 'You',
+    onResolve: async (id, r) => { await setPageCommentResolved(workspaceSlug, id, r); await reload(); },
+    onDelete: async (id) => { await deletePageComment(workspaceSlug, id); await reload(); },
+    submitReply,
+    lineHighlight: (line) => (lineToThread.has(line) ? { active: lineToThread.get(line) === activeId } : null),
+    focusLine: (line) => { const id = lineToThread.get(line); if (id) { setActiveId(id); setPanelOpen(true); } },
+  };
+
+  const startComment = () => {
+    if (!pending) return;
+    setComposing({ start: pending.start, end: pending.end, quote: quoteOf(source, pending.start, pending.end) });
+    setPanelOpen(true);
+    setPending(null);
+  };
+
+  return (
+    <Ctx.Provider value={value}>
+      {children}
+      {pending && !composing && (
+        <div style={{
+          position: 'fixed', zIndex: 60, top: pending.y - 46, left: pending.x - 52,
+          display: 'flex', alignItems: 'center', background: C.ink, borderRadius: 9, padding: 4,
+          boxShadow: '0 10px 28px -8px rgba(0,0,0,0.4)',
+        }}>
+          <button onMouseDown={(e) => { e.preventDefault(); startComment(); }} style={{
+            display: 'flex', alignItems: 'center', gap: 6, height: 28, padding: '0 11px', color: '#fff',
+            fontSize: 13, fontWeight: 600, borderRadius: 6, border: 'none', background: C.accent, cursor: 'pointer',
+          }}>
+            <MessageSquare size={14} /> Comment
+          </button>
+          <div style={{ position: 'absolute', left: 46, bottom: -5, width: 10, height: 10, background: C.ink, transform: 'rotate(45deg)' }} />
+        </div>
+      )}
+    </Ctx.Provider>
+  );
+}
+
+/** Top-bar comments toggle (count + open/close), à la Feishu/Notion. Renders
+ *  nothing off a page. Place it in the page header. */
+export function CommentsHeaderToggle({ style }: { style?: React.CSSProperties }) {
+  const ctx = useContext(Ctx);
+  if (!ctx || !ctx.enabled) return null;
+  return (
+    <button
+      onClick={() => ctx.setPanelOpen(!ctx.panelOpen)}
+      title={ctx.panelOpen ? 'Hide comments' : 'Show comments'}
+      style={{
+        ...style, fontWeight: 600,
+        background: ctx.panelOpen ? C.accentSoft : (style?.background ?? 'transparent'),
+        color: ctx.panelOpen ? C.accent : (style?.color ?? C.ink2),
+      }}
+    >
+      <MessageSquare size={14} /> {ctx.openCount}
+    </button>
+  );
+}
+
+// ── markdown block renderers: tag every block with its source line, and wrap
+//    commented blocks' inline content in a soft Highlight span (hugs the text) ─
+type BlockProps = {
+  node?: { position?: { start?: { line?: number }; end?: { line?: number } } };
+  children?: React.ReactNode;
+} & React.HTMLAttributes<HTMLElement>;
+
+function makeBlock(tag: string) {
+  return function Block({ node, children, ...rest }: BlockProps) {
+    const ctx = useContext(Ctx);
+    const line = node?.position?.start?.line;
+    const endLine = node?.position?.end?.line ?? line;
+    const hl = ctx && line ? ctx.lineHighlight(line) : null;
+    const inner = hl ? (
+      <span
+        onClick={(e) => { e.stopPropagation(); ctx!.focusLine(line!); }}
+        style={{
+          cursor: 'pointer', borderRadius: 3, padding: '1px 1px',
+          background: hl.active ? 'rgba(226,89,11,0.16)' : 'rgba(226,89,11,0.07)',
+          boxShadow: hl.active ? `inset 0 -2px 0 ${C.accent}` : 'inset 0 -1.5px 0 rgba(226,89,11,0.32)',
+          transition: 'background .15s, box-shadow .15s',
+          WebkitBoxDecorationBreak: 'clone', boxDecorationBreak: 'clone',
+        }}
+      >
+        {children}
+      </span>
+    ) : children;
+    return createElement(tag, { 'data-source-line': line, 'data-end-line': endLine, ...rest }, inner);
+  };
+}
+
+export const commentMarkdownComponents: Components = {
+  p: makeBlock('p'), li: makeBlock('li'), h1: makeBlock('h1'), h2: makeBlock('h2'),
+  h3: makeBlock('h3'), h4: makeBlock('h4'), blockquote: makeBlock('blockquote'), pre: makeBlock('pre'),
+} as Components;
+
+// ── the right-hand comment panel ───────────────────────────────────────────
+export function CommentsPanel() {
+  const ctx = useContext(Ctx);
+  const [showResolved, setShowResolved] = useState(false);
+  const [showOutdated, setShowOutdated] = useState(false);
+  if (!ctx) return null;
+  const { anchored, outdated, resolved, openCount, activeId, setActive, panelOpen, setPanelOpen,
+    composing, cancelCompose, submitNew, members, nameOf, currentUserId, myId, myName,
+    onResolve, onDelete, submitReply } = ctx;
+
+  // Collapsed: nothing here — the header toggle reopens the panel.
+  if (!panelOpen || (openCount === 0 && resolved.length === 0 && !composing)) return null;
+
+  return (
+    <aside style={{
+      width: 360, flexShrink: 0, alignSelf: 'stretch', borderLeft: `1px solid ${C.line}`,
+      background: C.panel, display: 'flex', flexDirection: 'column', minHeight: 0,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px 12px 20px', flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+          <span style={{ fontSize: 13.5, fontWeight: 600, color: C.ink }}>Comments</span>
+          <span style={{ fontSize: 12.5, color: C.faint }}>({openCount})</span>
+        </div>
+        <button onClick={() => setPanelOpen(false)} title="Collapse" style={{ ...ghostBtn, padding: 5 }}>
+          <ChevronsRight size={16} />
+        </button>
+      </div>
+
+      <div style={{ flex: 1, overflow: 'auto', padding: '4px 16px 24px' }}>
+        {composing && (
+          <Composer quote={composing.quote} meId={myId} meName={myName} members={members}
+            placeholder="Add a comment…  use @ to mention" autoFocus
+            onCancel={cancelCompose} onSubmit={submitNew} primaryLabel="Comment" />
+        )}
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {[...anchored, ...outdated].map((t) => (
+            <CommentCard key={t.root.id} t={t} active={t.root.id === activeId} members={members}
+              meId={myId} meName={myName} currentUserId={currentUserId} nameOf={nameOf}
+              onActivate={() => setActive(t.root.id)}
+              onResolve={() => onResolve(t.root.id, true)}
+              onReply={(body) => submitReply(t.root.id, body)} onDelete={onDelete} />
+          ))}
+        </div>
+
+        {outdated.length > 0 && (
+          <button onClick={() => setShowOutdated((s) => !s)} style={{ ...ghostBtn, width: '100%', justifyContent: 'flex-start', padding: '8px 4px', fontSize: 13, marginTop: 14 }}>
+            <span style={{ width: 8, height: 8, borderRadius: '50%', background: C.amber }} />
+            {outdated.length} not in your version
+            {showOutdated ? <ChevronDown size={14} color={C.faint} style={{ marginLeft: 'auto' }} /> : <ChevronRight size={14} color={C.faint} style={{ marginLeft: 'auto' }} />}
+          </button>
+        )}
+
+        {resolved.length > 0 && (
+          <div style={{ marginTop: 18 }}>
+            <button onClick={() => setShowResolved((s) => !s)} style={{ ...ghostBtn, width: '100%', justifyContent: 'flex-start', padding: '8px 4px', fontSize: 13 }}>
+              <CheckCircle2 size={15} color={C.green} />
+              {resolved.length} resolved
+              {showResolved ? <ChevronDown size={14} color={C.faint} style={{ marginLeft: 'auto' }} /> : <ChevronRight size={14} color={C.faint} style={{ marginLeft: 'auto' }} />}
+            </button>
+            {showResolved && resolved.map((t) => (
+              <div key={t.root.id} style={{ opacity: 0.72, padding: '10px 4px', marginTop: 2, borderTop: `1px solid ${C.lineSoft}` }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+                  <Avatar id={t.root.user_id} name={nameOf(t.root.user_id)} size={22} />
+                  <span style={{ fontSize: 13, fontWeight: 600, color: C.ink, flex: 1 }}>{nameOf(t.root.user_id)}</span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11.5, fontWeight: 600, color: C.green }}><Check size={13} />Resolved</span>
+                </div>
+                <div style={{ fontSize: 13, color: C.muted, marginBottom: 8, lineHeight: 1.5 }}>{t.root.body}</div>
+                <button onClick={() => onResolve(t.root.id, false)} style={{ ...ghostBtn, padding: '3px 6px', fontSize: 12 }}><RotateCcw size={12} /> Reopen</button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+// ── one thread card ─────────────────────────────────────────────────────────
+function CommentCard({
+  t, active, members, meId, meName, currentUserId, nameOf, onActivate, onResolve, onReply, onDelete,
+}: {
+  t: Thread; active: boolean; members: MemberInfo[]; meId: string; meName: string;
+  currentUserId: string | undefined; nameOf: (id: string) => string;
+  onActivate: () => void; onResolve: () => void;
+  onReply: (body: string) => void | Promise<void>; onDelete: (id: string) => void;
+}) {
+  const [replying, setReplying] = useState(false);
+  const authorName = nameOf(t.root.user_id);
+  const isOutdated = t.anchor.kind === 'outdated';
+
+  if (!active) {
+    return (
+      <div onClick={onActivate} style={{ background: C.panel, border: `1px solid ${C.line}`, borderRadius: 12, padding: '11px 13px', cursor: 'pointer', boxShadow: '0 1px 2px rgba(29,28,26,0.03)' }}>
+        <div style={{ marginBottom: 9, paddingLeft: 8, borderLeft: `2.5px solid ${isOutdated ? C.amberSoft : '#f0d8c5'}` }}>
+          <span style={{ fontSize: 12, lineHeight: 1.4, color: C.faint, fontStyle: 'italic', display: '-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+            {isOutdated && <span style={{ color: C.amber, fontStyle: 'normal', fontWeight: 600 }}>outdated · </span>}<Quote text={t.quote} />
+          </span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+          <Avatar id={t.root.user_id} name={authorName} size={22} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: C.ink, flex: 1, minWidth: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{authorName}</span>
+          <span style={{ fontSize: 11.5, color: C.faint }}>{relTime(t.root.created_at)}</span>
+        </div>
+        <div style={{ fontSize: 13.5, lineHeight: 1.5, color: C.ink2, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>{t.root.body}</div>
+        {t.replies.length > 0 && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginTop: 7, fontSize: 12, color: C.faint }}>
+            <MessageSquare size={13} />{t.replies.length} {t.replies.length === 1 ? 'reply' : 'replies'}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div onClick={onActivate} style={{ background: C.panel, border: '1px solid transparent', borderRadius: 12, padding: '13px 14px 12px', cursor: 'pointer', position: 'relative', boxShadow: `0 4px 16px -10px rgba(29,28,26,0.25), 0 0 0 1.5px ${isOutdated ? C.amber : C.accent}` }}>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 11, paddingLeft: 9, borderLeft: `2.5px solid ${isOutdated ? C.amber : C.accent}` }}>
+        <span style={{ fontSize: 12.5, lineHeight: 1.45, color: C.muted, fontStyle: 'italic', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+          {isOutdated && <span style={{ color: C.amber, fontStyle: 'normal', fontWeight: 600 }}>outdated · </span>}<Quote text={t.quote} />
+        </span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 9, marginBottom: 7 }}>
+        <Avatar id={t.root.user_id} name={authorName} size={26} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13.5, fontWeight: 600, color: C.ink, lineHeight: 1.2 }}>{authorName}</div>
+          <div style={{ fontSize: 11.5, color: C.faint }}>{relTime(t.root.created_at)} ago</div>
+        </div>
+        {t.root.user_id === currentUserId ? (
+          <button onClick={(e) => { e.stopPropagation(); onDelete(t.root.id); }} title="Delete" style={{ ...ghostBtn, padding: 4 }}><Trash2 size={14} /></button>
+        ) : (
+          <MoreHorizontal size={15} color={C.faint} />
+        )}
+      </div>
+      <div style={{ fontSize: 14, lineHeight: 1.55, color: C.ink2, marginBottom: t.replies.length ? 12 : 10 }}>{t.root.body}</div>
+
+      {t.replies.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 11, marginBottom: 10 }}>
+          {t.replies.map((r) => (
+            <div key={r.id} style={{ display: 'flex', gap: 8 }}>
+              <Avatar id={r.user_id} name={nameOf(r.user_id)} size={22} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 7, marginBottom: 1 }}>
+                  <span style={{ fontSize: 12.5, fontWeight: 600, color: C.ink }}>{nameOf(r.user_id)}</span>
+                  <span style={{ fontSize: 11, color: C.faint }}>{relTime(r.created_at)}</span>
+                </div>
+                <div style={{ fontSize: 13.5, lineHeight: 1.5, color: C.ink2 }}>{r.body}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!replying ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}>
+          <button onClick={(e) => { e.stopPropagation(); setReplying(true); }} style={ghostBtn}><Reply size={14} />Reply</button>
+          <div style={{ flex: 1 }} />
+          <button onClick={(e) => { e.stopPropagation(); onResolve(); }} style={{ ...ghostBtn, color: C.green }}><Check size={15} />Resolve</button>
+        </div>
+      ) : (
+        <div onClick={(e) => e.stopPropagation()}>
+          <Composer meId={meId} meName={meName} members={members} placeholder="Reply…" autoFocus compact
+            onCancel={() => setReplying(false)}
+            onSubmit={async (body) => { await onReply(body); setReplying(false); }} primaryLabel="Send" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── composer with @ mention autocomplete ───────────────────────────────────
+function Composer({
+  quote, meId, meName, members, placeholder, autoFocus, compact, onCancel, onSubmit, primaryLabel,
+}: {
+  quote?: string; meId: string; meName: string; members: MemberInfo[];
+  placeholder?: string; autoFocus?: boolean; compact?: boolean;
+  onCancel: () => void; onSubmit: (body: string) => void | Promise<void>; primaryLabel: string;
+}) {
+  const [value, setValue] = useState('');
+  const ref = useRef<HTMLTextAreaElement>(null);
+  const [menu, setMenu] = useState<{ query: string; at: number } | null>(null);
+
+  const sync = (next: string, caret: number) => {
+    setValue(next);
+    const m = /@([A-Za-z0-9_-]*)$/.exec(next.slice(0, caret));
+    setMenu(m ? { query: m[1], at: caret - m[1].length - 1 } : null);
+  };
+  const pick = (name: string) => {
+    if (!menu) return;
+    setValue(value.slice(0, menu.at) + '@' + name + ' ' + value.slice(menu.at + 1 + menu.query.length));
+    setMenu(null);
+    ref.current?.focus();
+  };
+  const matches = menu ? members.filter((m) => m.name.toLowerCase().startsWith(menu.query.toLowerCase())).slice(0, 5) : [];
+
+  return (
+    <div style={{ marginBottom: compact ? 0 : 14, marginTop: compact ? 4 : 0 }}>
+      {quote && (
+        <div style={{ marginBottom: 9, paddingLeft: 9, borderLeft: `2.5px solid ${C.accent}` }}>
+          <span style={{ fontSize: 12.5, lineHeight: 1.45, color: C.muted, fontStyle: 'italic', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}><Quote text={quote} /></span>
+        </div>
+      )}
+      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+        <Avatar id={meId} name={meName} size={22} />
+        <div style={{ flex: 1, position: 'relative', border: `1.5px solid ${C.accent}`, borderRadius: 9, background: '#fff', overflow: 'hidden' }}>
+          <textarea ref={ref} value={value} placeholder={placeholder} rows={2} autoFocus={autoFocus}
+            onChange={(e) => sync(e.target.value, e.target.selectionStart)}
+            style={{ width: '100%', border: 'none', outline: 'none', resize: 'none', padding: '8px 10px', fontSize: 13.5, lineHeight: 1.5, color: C.ink, fontFamily: fonts.sans, boxSizing: 'border-box', background: 'transparent' }} />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '5px 8px', borderTop: `1px solid ${C.lineSoft}` }}>
+            <AtSign size={15} color={C.faint} />
+            <div style={{ flex: 1 }} />
+            <button onClick={onCancel} style={{ ...ghostBtn, padding: '5px 9px' }}>Cancel</button>
+            <button onClick={() => onSubmit(value)} disabled={!value.trim()}
+              style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '5px 12px', borderRadius: 7, border: 'none', background: value.trim() ? C.accent : C.line, color: value.trim() ? '#fff' : C.faint, fontSize: 12.5, fontWeight: 600, cursor: value.trim() ? 'pointer' : 'default' }}>
+              {primaryLabel}
+            </button>
+          </div>
+          {matches.length > 0 && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, zIndex: 70, marginTop: 2, minWidth: 170, background: '#fff', border: `1px solid ${C.line}`, borderRadius: 8, boxShadow: '0 6px 18px rgba(0,0,0,.12)', overflow: 'hidden' }}>
+              {matches.map((m) => (
+                <button key={m.id} onMouseDown={(e) => { e.preventDefault(); pick(m.name); }}
+                  style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%', textAlign: 'left', padding: '7px 10px', border: 'none', background: 'transparent', fontSize: 12.5, color: C.ink, cursor: 'pointer' }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = C.tag; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}>
+                  <Avatar id={m.id} name={m.name} size={18} /> {m.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -59,11 +59,11 @@ body {
 /* Notion-style prose */
 .prose h1 { font-family: var(--font-serif); font-size: 2.25rem; font-weight: 700; margin: 1.5rem 0 0.5rem; line-height: 1.2; }
 .prose > h1:first-child, .prose h1:first-child { margin: 0 0 0.5rem; }
-.prose h2 { font-family: var(--font-serif); font-size: 1.5rem; font-weight: 600; margin: 1.25rem 0 0.375rem; line-height: 1.3; }
-.prose h3 { font-weight: 600; font-size: 1.125rem; margin: 1rem 0 0.25rem; }
-.prose p { margin: 0.375rem 0; }
-.prose ul, .prose ol { margin: 0.375rem 0; padding-left: 1.5rem; }
-.prose li { margin: 0.125rem 0; }
+.prose h2 { font-family: var(--font-serif); font-size: 1.5rem; font-weight: 600; margin: 1.6rem 0 0.6rem; line-height: 1.3; }
+.prose h3 { font-weight: 600; font-size: 1.125rem; margin: 1.25rem 0 0.35rem; }
+.prose p { margin: 0.75rem 0; line-height: 1.72; }
+.prose ul, .prose ol { margin: 0.75rem 0; padding-left: 1.5rem; }
+.prose li { margin: 0.4rem 0; line-height: 1.62; }
 .prose code { background: var(--color-bg-hover); padding: 0.125rem 0.375rem; border-radius: 3px; font-size: 0.85em; color: var(--color-accent); }
 .prose pre { background: #282c34; color: #abb2bf; padding: 1rem; border-radius: 6px; overflow-x: auto; margin: 0.75rem 0; font-size: 0.85em; }
 .prose pre code { background: none; color: inherit; padding: 0; }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -56,6 +56,11 @@ body {
   line-height: 1.5;
 }
 
+/* Selecting prose text reads in the brand accent, not the browser default blue
+   (the doc selection is how you start a comment). */
+.prose ::selection, .prose::selection { background: rgba(226, 89, 11, 0.18); }
+.prose ::-moz-selection, .prose::-moz-selection { background: rgba(226, 89, 11, 0.18); }
+
 /* Notion-style prose */
 .prose h1 { font-family: var(--font-serif); font-size: 2.25rem; font-weight: 700; margin: 1.5rem 0 0.5rem; line-height: 1.2; }
 .prose > h1:first-child, .prose h1:first-child { margin: 0 0 0.5rem; }

--- a/web/src/lib/comment-anchor.ts
+++ b/web/src/lib/comment-anchor.ts
@@ -1,0 +1,91 @@
+import { diffLines } from 'diff';
+
+/**
+ * Re-anchoring for document comments.
+ *
+ * A comment stores a 1-based source line range against the markdown snapshot the
+ * author saw (`anchored`). To show it on whatever version a viewer is currently
+ * rendering (`current` — their own branch), we line-diff snapshot→current and map
+ * the range forward. If any line in the range was edited or removed, the comment
+ * is reported `outdated` (GitHub-style) rather than dragged onto changed text.
+ *
+ * Line numbers here must match `node.position.start.line` from the same markdown
+ * string that react-markdown renders (i.e. the frontmatter-stripped body).
+ */
+export type MappedAnchor =
+  | { kind: 'anchored'; startLine: number; endLine: number }
+  | { kind: 'outdated' };
+
+/** Build a map old-line → new-line for every line that survived unchanged. */
+function survivingLines(anchored: string, current: string): Map<number, number> {
+  const map = new Map<number, number>();
+  let oldLine = 1;
+  let newLine = 1;
+  for (const part of diffLines(anchored, current)) {
+    const count = part.count ?? part.value.split('\n').length - 1;
+    if (part.added) {
+      newLine += count;
+    } else if (part.removed) {
+      oldLine += count;
+    } else {
+      for (let k = 0; k < count; k++) map.set(oldLine + k, newLine + k);
+      oldLine += count;
+      newLine += count;
+    }
+  }
+  return map;
+}
+
+/** Map a range using a prebuilt surviving-line map (see `buildSnapshotMaps`). */
+export function mapWithSurviving(
+  surviving: Map<number, number>,
+  startLine: number,
+  endLine: number,
+): MappedAnchor {
+  for (let l = startLine; l <= endLine; l++) {
+    if (!surviving.has(l)) return { kind: 'outdated' };
+  }
+  return {
+    kind: 'anchored',
+    startLine: surviving.get(startLine)!,
+    endLine: surviving.get(endLine)!,
+  };
+}
+
+export function mapAnchor(
+  anchored: string,
+  current: string,
+  startLine: number,
+  endLine: number,
+): MappedAnchor {
+  if (anchored === current) {
+    return { kind: 'anchored', startLine, endLine };
+  }
+  return mapWithSurviving(survivingLines(anchored, current), startLine, endLine);
+}
+
+/**
+ * Cost is one diff per *distinct snapshot*, not per comment: comments are
+ * grouped by `content_hash` and share a single line-diff against the current
+ * source. In practice a page has only one or two snapshot versions, so this is
+ * a couple of KB-scale diffs.
+ *
+ * TODO(perf, #97): optional per-line-hash fast path. Store the anchored
+ * lines' hashes; at display time hash each current line into a set and, for
+ * comments whose line hashes are all still present, skip the diff entirely.
+ * Caveat: hashes only answer "does this line still exist" — duplicate lines
+ * (blank lines, repeated `---`, identical list items) collide, so the diff is
+ * still required to resolve the *new* line number via surrounding context.
+ */
+export function buildSnapshotMaps(
+  snapshots: { content_hash: string; source: string }[],
+  current: string,
+): Map<string, Map<number, number>> {
+  const maps = new Map<string, Map<number, number>>();
+  for (const s of snapshots) {
+    if (!maps.has(s.content_hash)) {
+      maps.set(s.content_hash, survivingLines(s.source, current));
+    }
+  }
+  return maps;
+}

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Compass,
@@ -35,6 +35,7 @@ import { MembersView } from '../components/views/MembersView';
 import { InviteDialog } from '../components/InviteDialog';
 import { PageEditor } from '../components/PageEditor';
 import { TransferDialog } from '../components/TransferDialog';
+import { CommentsProvider, CommentsPanel, CommentsHeaderToggle, commentMarkdownComponents } from '../components/PageCommentsLayer';
 import { C } from '@/lib/design';
 
 type ActiveView =
@@ -65,6 +66,7 @@ export function MainLayout() {
   const [spaceSources, setSpaceSources] = useState<Record<string, SourceItem[]>>({});
   const [activeView, setActiveView] = useState<ActiveView>(null);
   const [activeWorkspace, setActiveWorkspace] = useState<Workspace | null>(null);
+  const articleRef = useRef<HTMLElement>(null);
   const [reviewRefreshKey, setReviewRefreshKey] = useState(0);
   const [activeTab, setActiveTab] = useState<NavTab>('wiki');
   const [reviewCount, setReviewCount] = useState(0);
@@ -521,6 +523,12 @@ export function MainLayout() {
     return body;
   };
 
+  // Page-view comment context: active only when reading (not editing) a page.
+  const pageView = activeView?.kind === 'page' ? activeView : null;
+  const commentsActive = !!pageView?.content && !editingPage;
+  const commentPageSlug = commentsActive && pageView ? pageView.slug : '';
+  const commentSource = commentsActive && pageView?.content ? renderBody(pageView.content.body) : '';
+
   // Execute a pending rename/delete from the tree menus.
   const handlePathOp = async () => {
     if (!pathOp || !activeWorkspace) return;
@@ -622,6 +630,13 @@ export function MainLayout() {
 
           {/* Main Content Area */}
           <main style={{ flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
+            <CommentsProvider
+              workspaceSlug={activeWorkspace?.slug ?? ''}
+              pageSlug={commentPageSlug}
+              source={commentSource}
+              articleRef={articleRef}
+              currentUserId={auth?.id}
+            >
             {/* Top bar: breadcrumb + actions */}
             <div style={{
               position: 'sticky', top: 0, zIndex: 10,
@@ -718,6 +733,7 @@ export function MainLayout() {
                       {compiling ? <RefreshCw size={13} className="animate-spin" /> : <Zap size={13} color="#e2590b" />}
                       {compiling ? 'Compiling...' : 'Compile'}
                     </button>
+                    <CommentsHeaderToggle style={{ ...headerBtnStyle, marginLeft: 2 }} />
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <button style={{ ...headerBtnStyle, padding: '4px 6px' }} aria-label="More actions">
@@ -760,7 +776,7 @@ export function MainLayout() {
             />
 
             {/* Content */}
-            <div style={{ flex: 1, padding: '36px 56px 56px' }}>
+            <div style={{ flex: 1, padding: '36px 56px 56px', position: 'relative' }}>
               {/* Review detail */}
               {activeView?.kind === 'review-detail' ? (
                 <ReviewDetail
@@ -859,9 +875,18 @@ export function MainLayout() {
                     onCancel={() => setEditingPage(false)}
                   />
                 ) : (
-                  <article className="prose">
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{renderBody(activeView.content.body)}</ReactMarkdown>
-                  </article>
+                  // Fill the content box edge-to-edge: the doc scrolls on the left
+                  // (left-anchored, same left edge as every other view), the comment
+                  // panel is flush to the right edge and full height with its own
+                  // scroll. Opening it shrinks the doc from the right only.
+                  <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'stretch' }}>
+                    <article ref={articleRef} className="prose" style={{ flex: 1, minWidth: 0, overflow: 'auto', padding: '36px 48px 56px 56px' }}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} components={commentMarkdownComponents}>
+                        {renderBody(activeView.content.body)}
+                      </ReactMarkdown>
+                    </article>
+                    <CommentsPanel />
+                  </div>
                 )
 
               /* Discover */
@@ -878,6 +903,7 @@ export function MainLayout() {
                 </div>
               )}
             </div>
+            </CommentsProvider>
           </main>
         </div>
       </TooltipProvider>


### PR DESCRIPTION
Implements the roadmap items **设计 Comment System** and **用户 @ 功能（@ 提及，联动 Notification）** (assigned @wfnuser). Design + implementation in one PR, as discussed.

## What

Feishu-style "select text → comment" on a wiki page's read view, with @-mention notifications.

## Design (the key decisions)

- **Comments live entirely outside the markdown blob** → page diffs stay clean (cowiki's provenance model). They're stored in Postgres (`page_comments`), anchored to a **source line range**, page-scoped by `(workspace_slug, page_slug)` — not tied to a branch.
- **Re-anchoring = one git-style line diff per snapshot.** Each top-level comment stores the line range + a `content_hash` pointing at a deduped snapshot of the markdown the author saw (`page_comment_snapshots`). On display we diff snapshot→current-rendered-source and map the range forward:
  - line unchanged (even if shifted by edits elsewhere) → comment follows to its new line
  - line edited/removed → comment marked **outdated** (GitHub-style), shown in a side group instead of dragged onto changed text
- Comments re-anchor against **whatever branch the viewer is rendering** (usually their own draft) — so they float across branches via shared content, no branch coupling.
- We chose **line-level git-diff anchoring** over text-quote/fuzzy: cowiki is git-native, so diff mapping is exact and honest; text-quote fallback was dropped as unnecessary once snapshots make the diff always computable (per-line-hash fast path tracked in **#97**).

## Changes

**Backend** (`crates/`)
- migration `012_page_comments.sql`: `page_comments` + `page_comment_snapshots`
- `cowiki_db::page_comments`: CRUD + snapshot upsert/list
- `routes/page_comments`: list (comments + snapshots), create, resolve/unresolve, delete (author-only); `@handle` parsing → `mention` notifications via the existing `notifications` table
- unit tests for the mention parser + content hashing

**Frontend** (`web/`)
- `lib/comment-anchor.ts`: line-diff re-anchoring (`buildSnapshotMaps`, one diff per snapshot; TODO #97)
- read view tags blocks with `data-source-line` (react-markdown node positions)
- `PageCommentsLayer`: select → "评论" bubble → composer; comment panel with threads, replies, resolve/reopen, delete, **outdated** group; `@` member autocomplete
- `api.ts`: comments client

## Verification

Built the full stack locally (Postgres + server + vite) and drove it with Playwright:
- ✅ `cargo build/fmt/test` (4 unit tests) + `npm run build`
- ✅ select text → bubble → compose → comment persists, anchored to the right source line (3-3) with a snapshot
- ✅ **re-anchor**: inserting a section above moved the paragraph to line 7 and the comment **followed**; editing the commented line moved the comment to **Outdated** — exactly the intended behavior
- ✅ no console errors

## Related

- Editor groundwork: #96 (CodeMirror)
- Follow-up optimization: #97 (per-line-hash fast path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)