### PR TITLE
feat(wiki): page byline (author + edited date) + larger serif title

### DIFF
--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -540,6 +540,43 @@ impl WikiRepo {
         }
     }
 
+    /// Author name + unix timestamp of the most recent commit on `branch` that
+    /// changed `file_path` — i.e. who last edited the page and when.
+    pub fn last_commit_for(
+        &self,
+        branch: &str,
+        file_path: &str,
+    ) -> Result<Option<(String, i64)>, git2::Error> {
+        let repo = self.repo()?;
+        let head = repo
+            .find_branch(branch, BranchType::Local)?
+            .get()
+            .peel_to_commit()?;
+        let mut revwalk = repo.revwalk()?;
+        revwalk.push(head.id())?;
+        revwalk.set_sorting(git2::Sort::TIME)?;
+        let path = Path::new(file_path);
+        for oid in revwalk {
+            let commit = repo.find_commit(oid?)?;
+            let here = commit.tree()?.get_path(path).map(|e| e.id()).ok();
+            let parent = commit
+                .parent(0)
+                .ok()
+                .and_then(|p| p.tree().ok())
+                .and_then(|t| t.get_path(path).map(|e| e.id()).ok());
+            let changed = match (here, parent) {
+                (Some(a), Some(b)) => a != b,
+                (Some(_), None) => true,
+                _ => false,
+            };
+            if changed {
+                let name = commit.author().name().unwrap_or("Unknown").to_string();
+                return Ok(Some((name, commit.time().seconds())));
+            }
+        }
+        Ok(None)
+    }
+
     pub fn list_files(&self, branch: &str, dir: &str) -> Result<Vec<String>, git2::Error> {
         let repo = self.repo()?;
         let branch_ref = repo.find_branch(branch, BranchType::Local)?;

--- a/crates/server/src/routes/pages.rs
+++ b/crates/server/src/routes/pages.rs
@@ -33,6 +33,10 @@ pub struct PageResponse {
     pub summary: String,
     pub body: String,
     pub branch: String,
+    /// Last editor of this page on `branch` (from git history), for the byline.
+    pub edited_by: Option<String>,
+    /// Unix timestamp of that last edit.
+    pub edited_at: Option<i64>,
 }
 
 pub(crate) fn parse_frontmatter(content: &str) -> (Option<String>, String) {
@@ -246,12 +250,19 @@ pub async fn get_page_ws(
     let body = String::from_utf8_lossy(&content).into_owned();
     let (title, summary) = parse_frontmatter(&body);
     let title = title.unwrap_or_else(|| fallback_title_from_content_or_slug(&body, &slug));
+    // Best-effort: who last edited this page and when (for the byline).
+    let edited = repo
+        .last_commit_for(&branch, &format!("{dir}/{slug}.md"))
+        .ok()
+        .flatten();
     Ok(Json(PageResponse {
         slug,
         title,
         summary,
         body,
         branch,
+        edited_by: edited.as_ref().map(|(name, _)| name.clone()),
+        edited_at: edited.map(|(_, ts)| ts),
     }))
 }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -19,6 +19,10 @@ export interface PageMeta {
 
 export interface PageFull extends PageMeta {
   body: string;
+  /** Last editor of the page (git history), for the byline. */
+  edited_by?: string | null;
+  /** Unix timestamp (seconds) of that last edit. */
+  edited_at?: number | null;
 }
 
 export interface Submission {

--- a/web/src/components/PageByline.tsx
+++ b/web/src/components/PageByline.tsx
@@ -1,16 +1,5 @@
 import { C } from '@/lib/design';
-
-const BYLINE_COLORS = ['#2f6bb0', '#2f8a5b', '#8b5cf6', '#c2410c', '#e2590b', '#3f6c8c'];
-function colorFor(s: string): string {
-  let h = 0;
-  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
-  return BYLINE_COLORS[h % BYLINE_COLORS.length];
-}
-function initials(name: string): string {
-  const p = name.trim().split(/\s+/).filter(Boolean);
-  if (!p.length) return '?';
-  return (p.length === 1 ? p[0].slice(0, 2) : p[0][0] + p[1][0]).toUpperCase();
-}
+import { AvatarBadge } from './ui/avatar-badge';
 
 /** "● Author · Edited Jan 9, 2024" byline above a wiki page, from git history. */
 export function PageByline({ name, editedAt }: { name?: string | null; editedAt?: number | null }) {
@@ -20,12 +9,7 @@ export function PageByline({ name, editedAt }: { name?: string | null; editedAt?
     : null;
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 11, marginBottom: 20 }}>
-      <div style={{
-        width: 28, height: 28, borderRadius: '50%', background: colorFor(name), color: '#fff',
-        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 600,
-      }}>
-        {initials(name)}
-      </div>
+      <AvatarBadge name={name} size={28} />
       <span style={{ fontSize: 13.5, color: C.muted }}>{name}</span>
       {date && (
         <>

--- a/web/src/components/PageByline.tsx
+++ b/web/src/components/PageByline.tsx
@@ -1,0 +1,40 @@
+import { C } from '@/lib/design';
+
+const BYLINE_COLORS = ['#2f6bb0', '#2f8a5b', '#8b5cf6', '#c2410c', '#e2590b', '#3f6c8c'];
+function colorFor(s: string): string {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return BYLINE_COLORS[h % BYLINE_COLORS.length];
+}
+function initials(name: string): string {
+  const p = name.trim().split(/\s+/).filter(Boolean);
+  if (!p.length) return '?';
+  return (p.length === 1 ? p[0].slice(0, 2) : p[0][0] + p[1][0]).toUpperCase();
+}
+
+/** "● Author · Edited Jan 9, 2024" byline above a wiki page, from git history. */
+export function PageByline({ name, editedAt }: { name?: string | null; editedAt?: number | null }) {
+  if (!name) return null;
+  const date = editedAt
+    ? new Date(editedAt * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+    : null;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 11, marginBottom: 20 }}>
+      <div style={{
+        width: 28, height: 28, borderRadius: '50%', background: colorFor(name), color: '#fff',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 600,
+      }}>
+        {initials(name)}
+      </div>
+      <span style={{ fontSize: 13.5, color: C.muted }}>{name}</span>
+      {date && (
+        <>
+          <span style={{ color: C.line }}>·</span>
+          <span style={{ fontSize: 13.5, color: C.faint }}>Edited {date}</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default PageByline;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -62,7 +62,7 @@ body {
 .prose ::-moz-selection, .prose::-moz-selection { background: rgba(226, 89, 11, 0.18); }
 
 /* Notion-style prose */
-.prose h1 { font-family: var(--font-serif); font-size: 2.25rem; font-weight: 700; margin: 1.5rem 0 0.5rem; line-height: 1.2; }
+.prose h1 { font-family: var(--font-serif); font-size: 2.5rem; font-weight: 700; letter-spacing: -0.01em; margin: 1.5rem 0 0.5rem; line-height: 1.18; }
 .prose > h1:first-child, .prose h1:first-child { margin: 0 0 0.5rem; }
 .prose h2 { font-family: var(--font-serif); font-size: 1.5rem; font-weight: 600; margin: 1.6rem 0 0.6rem; line-height: 1.3; }
 .prose h3 { font-weight: 600; font-size: 1.125rem; margin: 1.25rem 0 0.35rem; }

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -34,6 +34,7 @@ import { ReviewDetail } from '../components/review/ReviewDetail';
 import { MembersView } from '../components/views/MembersView';
 import { InviteDialog } from '../components/InviteDialog';
 import { PageEditor } from '../components/PageEditor';
+import { PageByline } from '../components/PageByline';
 import { TransferDialog } from '../components/TransferDialog';
 import { CommentsProvider, CommentsPanel, CommentsHeaderToggle, commentMarkdownComponents } from '../components/PageCommentsLayer';
 import { C } from '@/lib/design';
@@ -881,6 +882,7 @@ export function MainLayout() {
                   // scroll. Opening it shrinks the doc from the right only.
                   <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'stretch' }}>
                     <article ref={articleRef} className="prose" style={{ flex: 1, minWidth: 0, overflow: 'auto', padding: '36px 48px 56px 56px' }}>
+                      <PageByline name={activeView.content.edited_by} editedAt={activeView.content.edited_at} />
                       <ReactMarkdown remarkPlugins={[remarkGfm]} components={commentMarkdownComponents}>
                         {renderBody(activeView.content.body)}
                       </ReactMarkdown>


### PR DESCRIPTION
Adds the doc **byline + serif title** from the design handoff (split out from the comments PR #99, as requested).

## What
- A byline above each wiki page: **● Author · Edited \<date\>**, sourced from git history (who last touched the file and when).
- Page title bumped to a larger serif (2.5rem) to match the design.

## How
- `core`: `WikiRepo::last_commit_for(branch, path)` — revwalk for the most recent commit that changed the file → (author, unix time).
- `server`: page read response now carries `edited_by` / `edited_at` (best-effort; never fails the read).
- `web`: `PageByline` (avatar + name + edited date) above the doc; `PageFull` gains the fields; `.prose h1` → 2.5rem serif.

## Verified (local stack + Playwright)
Read endpoint returns `edited_by: "Mei Lin"` + a real timestamp; the page renders the byline above a large serif "Welcome", matching the design — no console errors. `cargo build/fmt` + `npm run build` green.

## Note
Independent of #99 (comments). Touches the page read render in `MainLayout`, so a small rebase may be needed depending on merge order with #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)