### PR TITLE
refactor(wiki): drop _index.md folder concept; anchor empty folders with .gitkeep

### DIFF
--- a/cli/src/commands/submit.ts
+++ b/cli/src/commands/submit.ts
@@ -9,7 +9,7 @@ import type { SubmitRequest, PageMeta } from '../types.js';
 
 const KNOWN_DIRS = ['wiki', 'entities', 'concepts'];
 
-/** Flatten a page tree to a list of repo paths, skipping folders and _index */
+/** Flatten a page tree to a list of repo paths, skipping folder nodes */
 function flattenPaths(pages: PageMeta[]): string[] {
   const paths: string[] = [];
   for (const p of pages) {

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -670,6 +670,64 @@ impl WikiRepo {
         Ok(())
     }
 
+    /// List directory paths under `dir` (full paths, e.g. `wiki/research`) that
+    /// contain a `.gitkeep` marker, excluding `dir` itself. Git cannot track an
+    /// empty directory, so an empty folder is anchored by a `.gitkeep`; this lets
+    /// the page tree surface those otherwise-invisible folders.
+    pub fn list_marker_dirs(&self, branch: &str, dir: &str) -> Result<Vec<String>, git2::Error> {
+        let repo = self.repo()?;
+        let branch_ref = repo.find_branch(branch, BranchType::Local)?;
+        let commit = branch_ref.get().peel_to_commit()?;
+        let tree = commit.tree()?;
+
+        let subtree = if dir.is_empty() {
+            tree
+        } else {
+            match tree.get_path(Path::new(dir)) {
+                Ok(entry) => repo.find_tree(entry.id())?,
+                Err(_) => return Ok(Vec::new()),
+            }
+        };
+
+        let mut dirs = Vec::new();
+        self.walk_marker_dirs(&repo, &subtree, dir, &mut dirs)?;
+        dirs.retain(|d| d != dir);
+        Ok(dirs)
+    }
+
+    fn walk_marker_dirs(
+        &self,
+        repo: &Repository,
+        tree: &git2::Tree,
+        prefix: &str,
+        dirs: &mut Vec<String>,
+    ) -> Result<(), git2::Error> {
+        let mut has_marker = false;
+        for entry in tree.iter() {
+            let name = match entry.name() {
+                Some(n) => n,
+                None => continue,
+            };
+            match entry.kind() {
+                Some(git2::ObjectType::Tree) => {
+                    let full_path = if prefix.is_empty() {
+                        name.to_string()
+                    } else {
+                        format!("{prefix}/{name}")
+                    };
+                    let subtree = repo.find_tree(entry.id())?;
+                    self.walk_marker_dirs(repo, &subtree, &full_path, dirs)?;
+                }
+                Some(git2::ObjectType::Blob) if name == ".gitkeep" => has_marker = true,
+                _ => {}
+            }
+        }
+        if has_marker && !prefix.is_empty() {
+            dirs.push(prefix.to_string());
+        }
+        Ok(())
+    }
+
     pub fn diff_files(&self, branch: &str, paths: &[String]) -> Result<Vec<FileDiff>, git2::Error> {
         let mut diffs = Vec::new();
         for p in paths {
@@ -1263,12 +1321,36 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// list_marker_dirs surfaces directories anchored only by a `.gitkeep` (empty
+    /// folders), excludes the queried dir itself, and ignores `.md`-bearing dirs.
+    #[test]
+    fn list_marker_dirs_finds_empty_folders() {
+        let (repo, dir) = temp_repo("marker-dirs");
+        repo.ensure_branch_exists("user/m").unwrap();
+        // An empty folder, anchored by a .gitkeep
+        repo.write_file("user/m", "wiki/empty/.gitkeep", b"", "e", "m")
+            .unwrap();
+        // A nested empty folder
+        repo.write_file("user/m", "wiki/parent/child/.gitkeep", b"", "e", "m")
+            .unwrap();
+        // A normal page (no marker)
+        repo.write_file("user/m", "wiki/page.md", b"# p\n", "e", "m")
+            .unwrap();
+
+        let mut dirs = repo.list_marker_dirs("user/m", "wiki").unwrap();
+        dirs.sort();
+        assert_eq!(dirs, vec!["wiki/empty", "wiki/parent/child"]);
+        // The queried dir itself (whose .gitkeep was seeded at init) is excluded.
+        assert!(!dirs.contains(&"wiki".to_string()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// delete_path on a directory removes the whole subtree.
     #[test]
     fn delete_folder_removes_subtree() {
         let (repo, dir) = temp_repo("delete-folder");
         repo.ensure_branch_exists("user/d2").unwrap();
-        repo.write_file("user/d2", "wiki/proj/_index.md", b"i\n", "e", "d")
+        repo.write_file("user/d2", "wiki/proj/.gitkeep", b"", "e", "d")
             .unwrap();
         repo.write_file("user/d2", "wiki/proj/x.md", b"x\n", "e", "d")
             .unwrap();
@@ -1276,7 +1358,7 @@ mod tests {
             .unwrap();
         repo.delete_path("user/d2", "wiki/proj", "rm folder", "d")
             .unwrap();
-        assert!(read(&repo, "user/d2", "wiki/proj/_index.md").is_none());
+        assert!(read(&repo, "user/d2", "wiki/proj/.gitkeep").is_none());
         assert!(read(&repo, "user/d2", "wiki/proj/x.md").is_none());
         assert_eq!(
             read(&repo, "user/d2", "wiki/other.md").as_deref(),

--- a/crates/server/src/routes/pages.rs
+++ b/crates/server/src/routes/pages.rs
@@ -20,7 +20,8 @@ pub struct PageListItem {
     pub title: String,
     pub summary: String,
     pub branch: String,
-    /// "page" or "folder" (folder has _index.md)
+    /// "page" or "folder" (a folder is a directory containing pages, or an
+    /// empty directory anchored by a `.gitkeep` marker)
     pub kind: String,
     /// For folders: child pages
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -146,11 +147,7 @@ fn fallback_title_from_content_or_slug(content: &str, slug: &str) -> String {
 }
 
 fn title_from_slug(slug: &str) -> String {
-    let base = slug
-        .trim_end_matches("/_index")
-        .rsplit('/')
-        .next()
-        .unwrap_or(slug);
+    let base = slug.rsplit('/').next().unwrap_or(slug);
     let title = base
         .replace(['-', '_'], " ")
         .split_whitespace()
@@ -183,7 +180,8 @@ pub struct WritePage {
     pub summary: Option<String>,
 }
 
-/// Create a folder (directory with _index.md)
+/// Create a folder. Git can't track an empty directory, so we anchor it with an
+/// empty `.gitkeep` marker; the folder is otherwise pure structure (no page).
 #[derive(Deserialize)]
 pub struct CreateFolder {
     pub name: String,
@@ -343,21 +341,17 @@ pub async fn create_folder_ws(
         AppError::BadRequest("parent is required (e.g. wiki, entities, entities/people)".into())
     })?;
     let dir = format!("{parent}/{slug}");
-    let index_path = format!("{dir}/_index.md");
-    let body = format!(
-        "---\ntitle: \"{}\"\nsummary: \"\"\nkind: overview\n---\n\n",
-        input.name
-    );
+    let gitkeep_path = format!("{dir}/.gitkeep");
     repo.write_file(
         &input.branch,
-        &index_path,
-        body.as_bytes(),
+        &gitkeep_path,
+        b"",
         &format!("create folder: {}", input.name),
         &guard.user.name,
     )
     .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(Json(
-        serde_json::json!({"ok": true, "slug": format!("{slug}/_index"), "path": dir}),
+        serde_json::json!({"ok": true, "slug": slug, "path": dir}),
     ))
 }
 
@@ -415,13 +409,16 @@ fn list_pages_from_dir(
     dir: &str,
     files: &[String],
 ) -> Result<Json<Vec<PageListItem>>> {
-    // Collect all items: pages and folder _index metadata
+    // Collect all items. A `page` item is a real `.md` file; a `marker` item is a
+    // synthetic placeholder for an otherwise-empty directory (anchored in git by a
+    // `.gitkeep`) so the folder still surfaces in the tree. Markers never render as
+    // pages — they only cause their directory to appear as a folder node.
     struct RawItem {
         slug: String,
         title: String,
         summary: String,
-        is_index: bool, // true if this is a folder's _index.md
-        dir: String,    // parent directory path (e.g. "test-folder" or "test-folder/sub")
+        is_marker: bool,
+        dir: String, // parent directory path (e.g. "test-folder" or "test-folder/sub")
     }
 
     let mut items: Vec<RawItem> = Vec::new();
@@ -444,24 +441,35 @@ fn list_pages_from_dir(
                 )));
             }
         };
-        let parts: Vec<&str> = slug.split('/').collect();
-        if parts.len() == 1 {
+        let item_dir = match slug.rsplit_once('/') {
+            Some((parent, _)) => parent.to_string(),
+            None => String::new(),
+        };
+        items.push(RawItem {
+            slug,
+            title,
+            summary,
+            is_marker: false,
+            dir: item_dir,
+        });
+    }
+
+    // Surface empty folders: directories whose only content is a `.gitkeep` marker
+    // (git can't track an empty directory). Each becomes a marker item so its
+    // directory appears as an (empty) folder node.
+    if let Ok(marker_dirs) = repo.list_marker_dirs(branch, dir) {
+        let prefix = format!("{dir}/");
+        for marker_dir in marker_dirs {
+            let rel_dir = marker_dir.strip_prefix(&prefix).unwrap_or(&marker_dir);
+            if rel_dir.is_empty() || items.iter().any(|i| i.dir == rel_dir) {
+                continue;
+            }
             items.push(RawItem {
-                slug: slug.clone(),
-                title,
-                summary,
-                is_index: false,
-                dir: String::new(),
-            });
-        } else {
-            let dir = parts[..parts.len() - 1].join("/");
-            let filename = *parts.last().unwrap();
-            items.push(RawItem {
-                slug: slug.clone(),
-                title,
-                summary,
-                is_index: filename == "_index",
-                dir,
+                slug: rel_dir.to_string(),
+                title: String::new(),
+                summary: String::new(),
+                is_marker: true,
+                dir: rel_dir.to_string(),
             });
         }
     }
@@ -475,9 +483,9 @@ fn list_pages_from_dir(
     ) -> Vec<PageListItem> {
         let mut result: Vec<PageListItem> = Vec::new();
 
-        // Find pages directly in this directory (not _index)
+        // Find pages directly in this directory (markers are not pages)
         for item in items {
-            if item.dir == parent_dir && !item.is_index {
+            if item.dir == parent_dir && !item.is_marker {
                 result.push(PageListItem {
                     slug: item.slug.clone(),
                     // item.slug is the full relative path under dir (e.g. "people/alice"),
@@ -492,7 +500,7 @@ fn list_pages_from_dir(
             }
         }
 
-        // Find subdirectories (folders that have _index or have children at this level)
+        // Find subdirectories (any directory holding pages or an empty-folder marker)
         let mut subdirs: Vec<String> = Vec::new();
         for item in items {
             if let Some(child) = immediate_child_dir(&item.dir, parent_dir) {
@@ -505,22 +513,14 @@ fn list_pages_from_dir(
         subdirs.dedup();
 
         for subdir in subdirs {
-            // Find _index for this subdir
-            let (title, summary) = items
-                .iter()
-                .find(|i| i.dir == subdir && i.is_index)
-                .map(|i| (i.title.clone(), i.summary.clone()))
-                .unwrap_or_else(|| {
-                    let name = subdir.rsplit('/').next().unwrap_or(&subdir);
-                    (name.to_string(), String::new())
-                });
-
+            // Folder display name is just the directory name.
+            let title = subdir.rsplit('/').next().unwrap_or(&subdir).to_string();
             let children = build_level(items, &subdir, branch, dir);
             result.push(PageListItem {
-                slug: format!("{subdir}/_index"),
-                path: format!("{dir}/{subdir}/_index"),
+                slug: subdir.clone(),
+                path: format!("{dir}/{subdir}"),
                 title,
-                summary,
+                summary: String::new(),
                 branch: branch.into(),
                 kind: "folder".into(),
                 children,
@@ -636,22 +636,18 @@ fn list_pages_all_dirs(
     let mut tree: Vec<PageListItem> = Vec::new();
 
     for dir in cowiki_core::wiki_fs::all_dirs() {
-        let files = match cowiki_core::wiki_fs::list_pages_recursive(repo, branch, dir) {
-            Ok(f) => f,
-            Err(_) => continue,
-        };
+        let files =
+            cowiki_core::wiki_fs::list_pages_recursive(repo, branch, dir).unwrap_or_default();
 
-        if files.is_empty() {
-            continue;
-        }
-
-        // Build the subtree for this directory using the shared helper
+        // Build the subtree for this directory using the shared helper. This also
+        // surfaces empty sub-folders (anchored by `.gitkeep`), so a section with no
+        // pages yet but with folders still renders.
         let subtree_json = list_pages_from_dir(repo, branch, dir, &files)?;
         let children = subtree_json.0;
 
         let dir_node = PageListItem {
-            slug: format!("{dir}/_index"),
-            path: format!("{dir}/_index"),
+            slug: dir.to_string(),
+            path: dir.to_string(),
             title: dir.to_string(),
             summary: String::new(),
             branch: branch.into(),

--- a/crates/server/src/routes/submit.rs
+++ b/crates/server/src/routes/submit.rs
@@ -71,10 +71,6 @@ pub async fn submit(
     // Generate embeddings for dedup
     let mut embeddings = Vec::new();
     for p in &input.paths {
-        // Skip synthetic _index folders
-        if p.ends_with("/_index") {
-            continue;
-        }
         let file_path = format!("{p}.md");
         let content = repo
             .read_file(&input.branch, &file_path)

--- a/web/src/components/layout/SpacePanel.tsx
+++ b/web/src/components/layout/SpacePanel.tsx
@@ -224,7 +224,7 @@ export function SpacePanel({
           emptyText="No pages yet"
           renderItem={(p) => (
             <PageTreeItem
-              key={p.slug}
+              key={`${p.kind}:${p.slug}`}
               page={p}
               dir="wiki"
               activePage={wikiActive ? activePage : null}
@@ -261,7 +261,7 @@ export function SpacePanel({
           emptyText="No pages yet"
           renderItem={(p) => (
             <PageTreeItem
-              key={p.slug}
+              key={`${p.kind}:${p.slug}`}
               page={p}
               dir="entities"
               activePage={wikiActive ? activePage : null}
@@ -298,7 +298,7 @@ export function SpacePanel({
           emptyText="No pages yet"
           renderItem={(p) => (
             <PageTreeItem
-              key={p.slug}
+              key={`${p.kind}:${p.slug}`}
               page={p}
               dir="concepts"
               activePage={wikiActive ? activePage : null}
@@ -346,7 +346,7 @@ export function SpacePanel({
 
 /** Filter pages by slug prefix and sort folders-first, then A→Z */
 function filterAndSortPages(pages: PageMeta[], prefix: ContentDir): PageMeta[] {
-  const dirNode = pages.find((p) => p.slug === `${prefix}/_index` && p.kind === 'folder');
+  const dirNode = pages.find((p) => p.slug === prefix && p.kind === 'folder');
   if (!dirNode || !dirNode.children) return [];
   return sortPages(dirNode.children);
 }
@@ -513,8 +513,8 @@ function PageTreeItem({
   }, [page.kind, page.children]);
 
   if (page.kind === 'folder') {
-    // folderPath strips the _index suffix and prepends the dir prefix
-    const folderPath = dir + '/' + page.slug.replace('/_index', '');
+    // page.slug is the folder's path relative to the content dir; prepend the dir prefix
+    const folderPath = dir + '/' + page.slug;
 
     return (
       <>
@@ -561,7 +561,7 @@ function PageTreeItem({
         </div>
         {open && sortedChildren.map((child) => (
           <PageTreeItem
-            key={child.slug}
+            key={`${child.kind}:${child.slug}`}
             page={child}
             dir={dir}
             activePage={activePage}

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -201,8 +201,8 @@ export function MainLayout() {
 
   /** Walk the page tree and recursively merge draft pages into main pages by path.
    *  When both trees have a folder at the same path, their children are merged
-   *  recursively so that draft-only pages under existing section nodes (wiki/_index,
-   *  entities/_index, concepts/_index) are not silently dropped. */
+   *  recursively so that draft-only pages under existing section nodes (wiki,
+   *  entities, concepts) are not silently dropped. */
   function mergePageTrees(main: PageMeta[], draft: PageMeta[]): PageMeta[] {
     const merged: PageMeta[] = [...main];
     const pathToIndex = new Map(merged.map((p, i) => [p.path, i] as const));


### PR DESCRIPTION
## Why

The `_index.md` folder-marker carried its weight as a *concept*, not as code. Non-empty folders are already derived purely from their child pages' directory paths (`build_level` in `pages.rs`), so `_index.md` only ever did two things:

1. Optionally **override a folder's display name** via frontmatter `title` — but the default fallback was already the directory name, which is what we want.
2. Act as a **placeholder so an empty folder exists in git** (git can't track empty dirs).

Meanwhile it actively *looked like a content page* — real markdown, `kind: overview` frontmatter, surfaced in `cowiki list` as a writable slug — so editing agents (and the UI) were tempted to treat it as an index/landing page to maintain. We don't want directory landing pages. So: remove the concept entirely and use a plain `.gitkeep` for the one thing we still need (empty folders).

## What changed

- **create_folder** writes an empty `.gitkeep` instead of `_index.md` + frontmatter.
- **Folder display name** is always the directory name — no title override.
- **Folder tree nodes** use the bare dir path as `slug`/`path` (no `/_index` suffix).
- **Empty folders** are surfaced via a new `WikiRepo::list_marker_dirs(branch, dir)`, which walks the tree for directories anchored only by a `.gitkeep` (the normal `.md` listing skips dotfiles, so empty folders would otherwise vanish).
- Removed now-dead `_index` handling in **submit** (server `submit.rs` + CLI `submit.ts`) and the **web** (`SpacePanel.tsx`, `MainLayout.tsx`).
- Sidebar React keys are now `${kind}:${slug}` so a same-named page and folder can't collide, now that folder slugs are bare dir paths.

> Note: `wiki/team-space-home.md` in `auth.rs` still has `kind: overview` frontmatter — that's a real welcome page, unrelated to the folder marker, left as-is.

## Verification

- `cargo build -p cowiki-server -p cowiki-core` ✓
- `cargo test -p cowiki-core` (32 tests, incl. new `list_marker_dirs_finds_empty_folders` and updated folder-delete) ✓
- `cargo test -p cowiki-server` ✓
- `cargo fmt --check` ✓
- web `tsc -b && vite build` ✓
- cli `tsc --noEmit` ✓, `vitest` (72 passed) ✓

### Manual check still worth doing
Run the app and confirm in the sidebar: create an empty folder → it appears; add a page under `entities/foo/` → folder shows with the dir name; submit a draft with nested pages → no "page not found" on a folder. I built/tested but did not run the full app end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)