### PR TITLE
feat: Obsidian-style live-preview editor + single-user local mode

### DIFF
--- a/cowiki.conf.example
+++ b/cowiki.conf.example
@@ -11,8 +11,13 @@ embedding_dimension = 1536
 [server]
 # Server port
 port = 3000
-# Data directory (git repo, wiki files)
-data_dir = "./data"
+# Single-user local mode: sign in automatically as the machine user, no OAuth.
+# Defaults to true when GitHub OAuth (GITHUB_CLIENT_ID) is not configured,
+# false when it is. Uncomment to force either way.
+# local_mode = true
+# Data directory (git repos, wiki files). Supports "~". Defaults to ~/cowiki
+# in local mode, ./data otherwise.
+# data_dir = "~/cowiki"
 
 [llm]
 # LLM (Language Model) provider: currently only "openai" is supported

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -7,11 +7,23 @@ pub use cowiki_utils::CliArgs;
 #[derive(Debug, Clone)]
 pub struct Config {
     pub database: cowiki_utils::DatabaseConfig,
-    pub server: cowiki_utils::ServerConfig,
+    pub server: ServerSettings,
     pub llm: cowiki_utils::LlmConfig,
     pub embedder: cowiki_utils::EmbedderConfig,
     pub auth: AuthConfig,
     pub frontend_url: String,
+}
+
+/// Server settings with local-mode defaults resolved.
+#[derive(Debug, Clone)]
+pub struct ServerSettings {
+    pub port: u16,
+    /// Wiki data directory: explicit config wins, else `~/cowiki` in local
+    /// mode, `./data` for hosted deploys.
+    pub data_dir: String,
+    /// Single-user local mode: `/api/auth/local` signs you in without OAuth.
+    /// Defaults to on when GitHub OAuth is not configured.
+    pub local_mode: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -33,9 +45,22 @@ impl Config {
                 .unwrap_or_else(|_| "http://localhost:3000/api/auth/github/callback".into()),
         };
 
+        // Local mode: explicit config wins; otherwise on iff GitHub OAuth is
+        // absent — hosted deploys (which set GITHUB_CLIENT_ID) are unaffected.
+        let local_mode = shared
+            .server
+            .local_mode
+            .unwrap_or_else(|| auth.github_client_id.is_empty());
+
+        let server = ServerSettings {
+            port: shared.server.port,
+            data_dir: cowiki_utils::resolve_data_dir(shared.server.data_dir.as_deref(), local_mode),
+            local_mode,
+        };
+
         Config {
             database: shared.database,
-            server: shared.server,
+            server,
             llm: shared.llm,
             embedder: shared.embedder,
             auth,

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -125,6 +125,7 @@ async fn main() {
             "/api/auth/regenerate-key",
             post(routes::auth::regenerate_key),
         )
+        .route("/api/auth/local", post(routes::auth::local_login))
         .route("/api/auth/github", get(routes::auth::github_login))
         .route(
             "/api/auth/github/callback",

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -87,6 +87,41 @@ pub async fn regenerate_key(
     }))
 }
 
+// ── Local mode ──
+
+/// Sign in as the machine's local user — no OAuth, no password. Only enabled
+/// in local mode (single-user install); hosted deploys 404 here. Reuses one
+/// account (named after $USER) and mints a fresh "Local session" key per
+/// fresh browser login, so existing sessions keep working.
+pub async fn local_login(State(state): State<Arc<AppState>>) -> Result<Json<AuthResponse>> {
+    if !state.config.server.local_mode {
+        return Err(AppError::NotFound("local login is disabled".into()));
+    }
+
+    let name = std::env::var("USER").unwrap_or_else(|_| "local".into());
+
+    let (user, raw_key) =
+        if let Some(existing) = cowiki_db::users::find_by_name(&state.db, &name).await? {
+            let minted = cowiki_db::api_keys::create(&state.db, existing.id, "Local session").await?;
+            (existing, minted.raw_key)
+        } else {
+            let (user, raw_key) = cowiki_db::users::create(&state.db, &name, None, None).await?;
+            init_user_space(&state, &user).await?;
+            tracing::info!("created local user {}", user.name);
+            (user, raw_key)
+        };
+
+    Ok(Json(AuthResponse {
+        api_key: raw_key,
+        user: UserInfo {
+            id: user.id.to_string(),
+            name: user.name,
+            email: user.email,
+            avatar_url: None,
+        },
+    }))
+}
+
 // ── GitHub OAuth ──
 
 pub async fn github_login(State(state): State<Arc<AppState>>) -> Redirect {

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -100,16 +100,17 @@ pub async fn local_login(State(state): State<Arc<AppState>>) -> Result<Json<Auth
 
     let name = std::env::var("USER").unwrap_or_else(|_| "local".into());
 
-    let (user, raw_key) =
-        if let Some(existing) = cowiki_db::users::find_by_name(&state.db, &name).await? {
-            let minted = cowiki_db::api_keys::create(&state.db, existing.id, "Local session").await?;
-            (existing, minted.raw_key)
-        } else {
-            let (user, raw_key) = cowiki_db::users::create(&state.db, &name, None, None).await?;
-            init_user_space(&state, &user).await?;
-            tracing::info!("created local user {}", user.name);
-            (user, raw_key)
-        };
+    let (user, raw_key) = if let Some(existing) =
+        cowiki_db::users::find_by_name(&state.db, &name).await?
+    {
+        let minted = cowiki_db::api_keys::create(&state.db, existing.id, "Local session").await?;
+        (existing, minted.raw_key)
+    } else {
+        let (user, raw_key) = cowiki_db::users::create(&state.db, &name, None, None).await?;
+        init_user_space(&state, &user).await?;
+        tracing::info!("created local user {}", user.name);
+        (user, raw_key)
+    };
 
     Ok(Json(AuthResponse {
         api_key: raw_key,

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -40,6 +40,7 @@ pub struct TomlDatabase {
 pub struct TomlServer {
     pub port: Option<u16>,
     pub data_dir: Option<String>,
+    pub local_mode: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -93,7 +94,33 @@ pub struct DatabaseConfig {
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     pub port: u16,
-    pub data_dir: String,
+    /// Wiki data directory as configured; `None` when not set anywhere.
+    /// Consumers resolve the default (`resolve_data_dir`) so local mode can
+    /// pick `~/cowiki` while hosted deploys keep `./data`.
+    pub data_dir: Option<String>,
+    /// Single-user local mode (no login). `None` = not configured; the server
+    /// defaults it to "on" when GitHub OAuth is not configured.
+    pub local_mode: Option<bool>,
+}
+
+/// Expand a leading `~/` to the user's home directory.
+pub fn expand_tilde(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return home.join(rest).to_string_lossy().into_owned();
+        }
+    }
+    path.to_string()
+}
+
+/// Resolve the wiki data directory: explicit config wins (with `~` expansion);
+/// otherwise `~/cowiki` in local mode, `./data` for hosted deploys.
+pub fn resolve_data_dir(configured: Option<&str>, local_mode: bool) -> String {
+    match configured {
+        Some(dir) if !dir.is_empty() => expand_tilde(dir),
+        _ if local_mode => expand_tilde("~/cowiki"),
+        _ => "./data".into(),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -229,11 +256,13 @@ impl CowikiConfig {
             },
             server: ServerConfig {
                 port: toml.server.as_ref().and_then(|s| s.port).unwrap_or(3000),
-                data_dir: toml
-                    .server
-                    .as_ref()
-                    .and_then(|s| s.data_dir.clone())
-                    .unwrap_or_else(|| "./data".into()),
+                data_dir: std::env::var("COWIKI_DATA_DIR")
+                    .ok()
+                    .or_else(|| toml.server.as_ref().and_then(|s| s.data_dir.clone())),
+                local_mode: std::env::var("COWIKI_LOCAL_MODE")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .or_else(|| toml.server.as_ref().and_then(|s| s.local_mode)),
             },
             llm: LlmConfig {
                 provider: toml
@@ -325,7 +354,10 @@ impl CowikiConfig {
             },
             server: ServerConfig {
                 port: server_port,
-                data_dir: std::env::var("COWIKI_DATA_DIR").unwrap_or_else(|_| "./data".into()),
+                data_dir: std::env::var("COWIKI_DATA_DIR").ok(),
+                local_mode: std::env::var("COWIKI_LOCAL_MODE")
+                    .ok()
+                    .and_then(|s| s.parse().ok()),
             },
             llm: LlmConfig {
                 provider: std::env::var("COWIKI_LLM_PROVIDER").unwrap_or_else(|_| "openai".into()),
@@ -448,7 +480,7 @@ dimension = 768
         let config = CowikiConfig::from_file(&path);
         assert_eq!(config.database.url, "postgres://test:test@localhost/testdb");
         assert_eq!(config.server.port, 4200);
-        assert_eq!(config.server.data_dir, "/tmp/cowiki-test");
+        assert_eq!(config.server.data_dir.as_deref(), Some("/tmp/cowiki-test"));
         assert_eq!(config.llm.provider, "test-provider");
         assert_eq!(config.llm.model, "test-model");
         assert_eq!(config.llm.api_key, "sk-test");

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,8 +8,18 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.20.3",
+        "@codemirror/commands": "^6.10.4",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/language-data": "^6.5.2",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.6",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/source-serif-4": "^5.2.9",
+        "@lezer/common": "^1.5.2",
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/markdown": "^1.6.4",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-select": "^2.3.0",
@@ -452,6 +462,396 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-angular": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-angular/-/lang-angular-0.1.4.tgz",
+      "integrity": "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.3"
+      }
+    },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz",
+      "integrity": "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-go": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-go/-/lang-go-6.0.1.tgz",
+      "integrity": "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/go": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-jinja": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.1.tgz",
+      "integrity": "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-less": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-less/-/lang-less-6.0.2.tgz",
+      "integrity": "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-liquid": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-liquid/-/lang-liquid-6.3.2.tgz",
+      "integrity": "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/lang-rust": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz",
+      "integrity": "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
+      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/sass": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-vue": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz",
+      "integrity": "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-wast": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
+      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/language-data": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.5.2.tgz",
+      "integrity": "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-angular": "^0.1.0",
+        "@codemirror/lang-cpp": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-go": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-java": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/lang-jinja": "^6.0.0",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-less": "^6.0.0",
+        "@codemirror/lang-liquid": "^6.0.0",
+        "@codemirror/lang-markdown": "^6.0.0",
+        "@codemirror/lang-php": "^6.0.0",
+        "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/lang-rust": "^6.0.0",
+        "@codemirror/lang-sass": "^6.0.0",
+        "@codemirror/lang-sql": "^6.0.0",
+        "@codemirror/lang-vue": "^0.1.1",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lang-yaml": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/legacy-modes": "^6.4.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.3.tgz",
+      "integrity": "sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -1042,6 +1442,189 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/cpp": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.6.tgz",
+      "integrity": "sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz",
+      "integrity": "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/go": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/go/-/go-1.0.1.tgz",
+      "integrity": "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.4.tgz",
+      "integrity": "sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.19.tgz",
+      "integrity": "sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/rust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
+      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz",
+      "integrity": "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -4953,6 +5536,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -9706,6 +10295,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -10350,6 +10945,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -10,8 +10,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.3",
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/language-data": "^6.5.2",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.6",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/source-serif-4": "^5.2.9",
+    "@lezer/common": "^1.5.2",
+    "@lezer/highlight": "^1.2.3",
+    "@lezer/markdown": "^1.6.4",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-select": "^2.3.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { MainLayout } from './pages/MainLayout';
 import { LoginPage } from './pages/LoginPage';
-import { getStoredAuth, storeAuth } from './auth';
+import { getStoredAuth, storeAuth, tryLocalLogin } from './auth';
 
 /** OAuth hands the credential over in the URL *fragment* (never sent to servers,
  *  logs, or Referer). Parse #api_key=...&user_name=...&user_id=..., store, then
@@ -34,8 +34,14 @@ export default function App() {
   // "no auth yet, fragment still present" state.
   const [ready, setReady] = useState(false);
   useEffect(() => {
-    consumeOAuthFragment();
-    setReady(true);
+    const bootstrap = async () => {
+      consumeOAuthFragment();
+      // Local-mode installs sign in automatically; hosted deploys fall
+      // through to the login page (the endpoint is disabled there).
+      if (!getStoredAuth()) await tryLocalLogin();
+      setReady(true);
+    };
+    void bootstrap();
   }, []);
 
   if (!ready) return null;

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -38,3 +38,22 @@ export function authHeaders(): Record<string, string> {
   if (!key) return {};
   return { Authorization: `Bearer ${key}` };
 }
+
+/**
+ * Local-mode sign-in: single-user installs expose /api/auth/local, which
+ * returns credentials for the machine's local user without OAuth. Returns
+ * true when local mode is active and auth was stored; false on hosted
+ * deploys (endpoint disabled) or network failure.
+ */
+export async function tryLocalLogin(): Promise<boolean> {
+  try {
+    const res = await fetch(`${import.meta.env.VITE_API_BASE || ''}/api/auth/local`, { method: 'POST' });
+    if (!res.ok) return false;
+    const data = await res.json();
+    if (!data?.api_key || !data?.user?.id) return false;
+    storeAuth(data.api_key, data.user.name, data.user.id);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/web/src/components/PageEditor.tsx
+++ b/web/src/components/PageEditor.tsx
@@ -1,141 +1,147 @@
-import { useEffect, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { Check, X } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Check, CircleDashed, CloudUpload, X } from 'lucide-react';
 import { C, fonts } from '@/lib/design';
+import { LivePreviewEditor } from './editor/LivePreviewEditor';
+
+type SaveStatus = 'saved' | 'dirty' | 'saving' | 'error';
 
 /**
- * In-page markdown editor with GitHub-style Write / Preview tabs.
- * Edits the raw page body (including the frontmatter block that defines
- * title/summary); preview renders the body without frontmatter.
+ * Obsidian-style live-preview editor for a page body (frontmatter included,
+ * shown as a dimmed block). Autosaves with a short debounce — the backend
+ * amends a single working commit per draft branch, so frequent saves are
+ * cheap. Esc or Done exits after flushing any pending save.
  */
 export function PageEditor({
   initialBody,
-  stripFrontmatter,
   onSave,
-  onCancel,
+  onDone,
+  onWikilink,
+  getPageSlugs,
 }: {
   initialBody: string;
-  /** Same body→rendered-markdown transform the page view uses. */
-  stripFrontmatter: (body: string) => string;
+  /** Persist the body; called on the autosave debounce, not on every keystroke. */
   onSave: (body: string) => Promise<void>;
-  onCancel: () => void;
+  /** Exit edit mode (pending changes are flushed first). */
+  onDone: () => void;
+  onWikilink?: (target: string) => void;
+  getPageSlugs?: () => string[];
 }) {
-  const [body, setBody] = useState(initialBody);
-  const [tab, setTab] = useState<'write' | 'preview'>('write');
-  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<SaveStatus>('saved');
   const [error, setError] = useState<string | null>(null);
-  const dirty = body !== initialBody;
 
-  // Cmd/Ctrl+S saves, Esc cancels.
+  const latestBody = useRef(initialBody);
+  const savedBody = useRef(initialBody);
+  const saving = useRef(false);
+  const timer = useRef<number | null>(null);
+
+  const flush = useCallback(async () => {
+    if (timer.current !== null) { window.clearTimeout(timer.current); timer.current = null; }
+    if (saving.current) return;
+    saving.current = true;
+    try {
+      while (latestBody.current !== savedBody.current) {
+        const body = latestBody.current;
+        setStatus('saving');
+        await onSave(body);
+        savedBody.current = body;
+      }
+      setStatus('saved');
+      setError(null);
+    } catch (e) {
+      setStatus('error');
+      setError(e instanceof Error ? e.message : 'Failed to save');
+    } finally {
+      saving.current = false;
+    }
+  }, [onSave]);
+
+  const handleDocChanged = useCallback((doc: string) => {
+    latestBody.current = doc;
+    if (timer.current !== null) window.clearTimeout(timer.current);
+    if (doc === savedBody.current) {
+      setStatus('saved');
+      return;
+    }
+    setStatus('dirty');
+    timer.current = window.setTimeout(() => { void flush(); }, 900);
+  }, [flush]);
+
+  const handleDone = useCallback(async () => {
+    await flush();
+    if (latestBody.current !== savedBody.current) return; // save failed — stay
+    onDone();
+  }, [flush, onDone]);
+
+  const handleWikilink = useCallback(async (target: string) => {
+    await flush();
+    onWikilink?.(target);
+  }, [flush, onWikilink]);
+
+  // Esc exits (unless CodeMirror already consumed it, e.g. closing autocomplete).
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
-        e.preventDefault();
-        void handleSave();
-      } else if (e.key === 'Escape') {
-        onCancel();
-      }
+      if (e.key === 'Escape' && !e.defaultPrevented) void handleDone();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [body, saving]);
+  }, [handleDone]);
 
-  const handleSave = async () => {
-    if (saving) return;
-    setSaving(true);
-    setError(null);
-    try {
-      await onSave(body);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to save');
-      setSaving(false);
-      return;
-    }
-    setSaving(false);
-  };
+  // Warn before closing the tab with unsaved edits.
+  useEffect(() => {
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (latestBody.current !== savedBody.current) e.preventDefault();
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, []);
 
-  const tabBtn = (key: 'write' | 'preview', label: string) => (
-    <button
-      onClick={() => setTab(key)}
-      style={{
-        padding: '7px 16px', fontSize: 13, fontWeight: tab === key ? 600 : 450,
-        color: tab === key ? C.ink : C.muted, background: tab === key ? C.panel : 'transparent',
-        border: 'none', borderBottom: tab === key ? `2px solid ${C.accent}` : '2px solid transparent',
-        cursor: 'pointer', marginBottom: -1,
-      }}
-    >
-      {label}
-    </button>
-  );
+  // Flush on unmount so navigating away never drops edits.
+  useEffect(() => () => { void flush(); }, [flush]);
+
+  const statusUi = {
+    saved: { icon: <Check size={12} />, text: 'Saved', color: C.muted },
+    dirty: { icon: <CircleDashed size={12} />, text: 'Editing…', color: C.faint },
+    saving: { icon: <CloudUpload size={12} />, text: 'Saving…', color: C.muted },
+    error: { icon: <X size={12} />, text: error || 'Save failed', color: C.red },
+  }[status];
 
   return (
-    <div style={{ border: `1px solid ${C.line}`, borderRadius: 12, overflow: 'hidden', background: C.panel }}>
-      {/* Tab bar */}
-      <div style={{
-        display: 'flex', alignItems: 'center', background: C.bg,
-        borderBottom: `1px solid ${C.line}`, padding: '0 8px',
-      }}>
-        {tabBtn('write', 'Write')}
-        {tabBtn('preview', 'Preview')}
-        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px' }}>
-          {error && <span style={{ fontSize: 12.5, color: C.red, maxWidth: 380, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{error}</span>}
-          <button
-            onClick={onCancel}
-            disabled={saving}
-            style={{
-              display: 'flex', alignItems: 'center', gap: 5, padding: '6px 12px', borderRadius: 7,
-              fontSize: 12.5, fontWeight: 550, color: C.ink2, background: '#fff',
-              border: `1px solid ${C.line}`, cursor: 'pointer',
-            }}
-          >
-            <X size={13} /> Cancel
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={saving || !dirty}
-            style={{
-              display: 'flex', alignItems: 'center', gap: 5, padding: '6px 14px', borderRadius: 7,
-              fontSize: 12.5, fontWeight: 600, color: '#fff',
-              background: dirty ? C.accent : C.faint,
-              border: 'none', cursor: dirty ? 'pointer' : 'default',
-              opacity: saving ? 0.6 : 1,
-            }}
-          >
-            <Check size={13} /> {saving ? 'Saving…' : 'Save'}
-          </button>
-        </div>
-      </div>
+    <div style={{ position: 'absolute', inset: 0 }}>
+      <LivePreviewEditor
+        initialDoc={initialBody}
+        onDocChanged={handleDocChanged}
+        onRequestSave={() => { void flush(); }}
+        onWikilink={handleWikilink}
+        getPageSlugs={getPageSlugs}
+      />
 
-      {/* Body */}
-      {tab === 'write' ? (
-        <textarea
-          value={body}
-          onChange={(e) => setBody(e.target.value)}
-          spellCheck={false}
-          autoFocus
+      {/* Floating status + Done */}
+      <div style={{
+        position: 'absolute', top: 10, right: 16, zIndex: 10,
+        display: 'flex', alignItems: 'center', gap: 10,
+        padding: '5px 6px 5px 12px', borderRadius: 999,
+        background: C.panel, border: `1px solid ${C.line}`,
+        boxShadow: '0 1px 2px rgba(29, 28, 26, 0.06)',
+      }}>
+        <span
+          title="Autosaves as you type · ⌘S to save now · Esc to finish"
           style={{
-            display: 'block', width: '100%', minHeight: 460, padding: '16px 20px',
-            border: 'none', outline: 'none', resize: 'vertical', boxSizing: 'border-box',
-            fontFamily: fonts.mono, fontSize: 13.5, lineHeight: 1.65, color: C.ink,
-            background: C.panel,
+            display: 'flex', alignItems: 'center', gap: 5,
+            fontSize: 12, color: statusUi.color, fontFamily: fonts.sans,
+            maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
           }}
-        />
-      ) : (
-        <div className="prose" style={{ padding: '16px 24px', minHeight: 460 }}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{stripFrontmatter(body)}</ReactMarkdown>
-        </div>
-      )}
-
-      {/* Footer hint */}
-      <div style={{
-        padding: '7px 14px', borderTop: `1px solid ${C.lineSoft}`, background: C.bg,
-        fontSize: 11.5, color: C.faint, display: 'flex', gap: 14,
-      }}>
-        <span>Markdown supported</span>
-        <span>The top <code style={{ fontFamily: fonts.mono }}>---</code> frontmatter block sets the page title & summary</span>
-        <span style={{ marginLeft: 'auto' }}>⌘S to save · Esc to cancel</span>
+        >
+          {statusUi.icon} {statusUi.text}
+        </span>
+        <button
+          onClick={() => { void handleDone(); }}
+          style={{
+            padding: '4px 14px', borderRadius: 999, fontSize: 12.5, fontWeight: 600,
+            color: '#fff', background: C.accent, border: 'none', cursor: 'pointer',
+          }}
+        >
+          Done
+        </button>
       </div>
     </div>
   );

--- a/web/src/components/editor/LivePreviewEditor.tsx
+++ b/web/src/components/editor/LivePreviewEditor.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef } from 'react';
+import { EditorView, keymap, drawSelection } from '@codemirror/view';
+import { EditorState, Prec } from '@codemirror/state';
+import { history, defaultKeymap, historyKeymap, indentWithTab } from '@codemirror/commands';
+import { indentUnit } from '@codemirror/language';
+import { markdown, markdownLanguage, markdownKeymap } from '@codemirror/lang-markdown';
+import { languages } from '@codemirror/language-data';
+import { autocompletion } from '@codemirror/autocomplete';
+import type { CompletionContext, CompletionResult } from '@codemirror/autocomplete';
+import { livePreview, livePreviewConfig } from './livePreview';
+import { WikiLink, Frontmatter } from './markdownExtensions';
+import { editorTheme, editorHighlighting } from './theme';
+
+export interface LivePreviewEditorProps {
+  initialDoc: string;
+  /** Fired on every document change with the full new text. */
+  onDocChanged: (doc: string) => void;
+  /** Cmd/Ctrl+S — the host flushes its pending save. */
+  onRequestSave?: () => void;
+  onWikilink?: (target: string) => void;
+  /** Candidate slugs for `[[` autocompletion. */
+  getPageSlugs?: () => string[];
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Obsidian-style live-preview markdown editor: markdown source with
+ * formatting rendered in place; syntax marks reveal themselves around
+ * the cursor.
+ */
+export function LivePreviewEditor({
+  initialDoc,
+  onDocChanged,
+  onRequestSave,
+  onWikilink,
+  getPageSlugs,
+  className,
+  style,
+}: LivePreviewEditorProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const viewRef = useRef<EditorView | null>(null);
+
+  // Keep callbacks fresh without recreating the editor.
+  const callbacks = useRef({ onDocChanged, onRequestSave, onWikilink, getPageSlugs });
+  useEffect(() => {
+    callbacks.current = { onDocChanged, onRequestSave, onWikilink, getPageSlugs };
+  });
+
+  useEffect(() => {
+    if (!hostRef.current) return;
+
+    const wikilinkCompletion = (ctx: CompletionContext): CompletionResult | null => {
+      const match = ctx.matchBefore(/\[\[([^\][|]*)$/);
+      if (!match) return null;
+      const slugs = callbacks.current.getPageSlugs?.() ?? [];
+      if (slugs.length === 0) return null;
+      return {
+        from: match.from + 2,
+        options: slugs.map((slug) => ({
+          label: slug,
+          type: 'text',
+          apply: (view, _completion, from, to) => {
+            const after = view.state.sliceDoc(to, to + 2);
+            const insert = slug + (after === ']]' ? '' : ']]');
+            view.dispatch({
+              changes: { from, to, insert },
+              selection: { anchor: from + insert.length + (after === ']]' ? 2 : 0) },
+            });
+          },
+        })),
+        validFor: /^[^\][|]*$/,
+      };
+    };
+
+    const view = new EditorView({
+      parent: hostRef.current,
+      state: EditorState.create({
+        doc: initialDoc,
+        extensions: [
+          history(),
+          drawSelection(),
+          EditorView.lineWrapping,
+          indentUnit.of('  '),
+          markdown({
+            base: markdownLanguage,
+            codeLanguages: languages,
+            extensions: [WikiLink, Frontmatter],
+          }),
+          editorTheme,
+          editorHighlighting,
+          livePreview,
+          livePreviewConfig.of({
+            onWikilink: (target) => callbacks.current.onWikilink?.(target),
+          }),
+          autocompletion({ override: [wikilinkCompletion], icons: false }),
+          Prec.high(keymap.of([
+            {
+              key: 'Mod-s',
+              run: () => { callbacks.current.onRequestSave?.(); return true; },
+            },
+          ])),
+          keymap.of([...markdownKeymap, ...defaultKeymap, ...historyKeymap, indentWithTab]),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) callbacks.current.onDocChanged(update.state.doc.toString());
+          }),
+        ],
+      }),
+    });
+    viewRef.current = view;
+    view.focus();
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // The editor is created once per mount; remount (via key) to reset the doc.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <div ref={hostRef} className={className} style={{ height: '100%', ...style }} />;
+}
+
+export default LivePreviewEditor;

--- a/web/src/components/editor/livePreview.ts
+++ b/web/src/components/editor/livePreview.ts
@@ -1,0 +1,311 @@
+import { Decoration, EditorView, ViewPlugin, WidgetType } from '@codemirror/view';
+import type { DecorationSet, ViewUpdate } from '@codemirror/view';
+import { Facet } from '@codemirror/state';
+import type { EditorState, Range } from '@codemirror/state';
+import { syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+
+/** Editor-level callbacks the host app provides (wikilink navigation). */
+export interface LivePreviewConfig {
+  onWikilink?: (target: string) => void;
+}
+
+export const livePreviewConfig = Facet.define<LivePreviewConfig, LivePreviewConfig>({
+  combine: (values) => values[0] ?? {},
+});
+
+// ── Widgets ──────────────────────────────────────────────────────────
+
+class BulletWidget extends WidgetType {
+  toDOM() {
+    const span = document.createElement('span');
+    span.className = 'cm-lp-bullet';
+    span.textContent = '•';
+    return span;
+  }
+  eq() { return true; }
+}
+
+class CheckboxWidget extends WidgetType {
+  checked: boolean;
+  constructor(checked: boolean) { super(); this.checked = checked; }
+  toDOM() {
+    const box = document.createElement('input');
+    box.type = 'checkbox';
+    box.checked = this.checked;
+    box.className = 'cm-lp-checkbox';
+    return box;
+  }
+  eq(other: CheckboxWidget) { return other.checked === this.checked; }
+  ignoreEvent() { return false; }
+}
+
+class HrWidget extends WidgetType {
+  toDOM() {
+    const div = document.createElement('div');
+    div.className = 'cm-lp-hr';
+    return div;
+  }
+  eq() { return true; }
+}
+
+class ImageWidget extends WidgetType {
+  src: string;
+  alt: string;
+  constructor(src: string, alt: string) { super(); this.src = src; this.alt = alt; }
+  toDOM() {
+    const img = document.createElement('img');
+    img.src = this.src;
+    img.alt = this.alt;
+    img.className = 'cm-lp-image';
+    return img;
+  }
+  eq(other: ImageWidget) { return other.src === this.src && other.alt === this.alt; }
+}
+
+// ── Decoration builder ───────────────────────────────────────────────
+
+const bulletDeco = Decoration.replace({ widget: new BulletWidget() });
+const hide = Decoration.replace({});
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const decos: Range<Decoration>[] = [];
+  const { state } = view;
+  const doc = state.doc;
+
+  /** True when a selection endpoint or range touches [from, to]. */
+  const reveal = (from: number, to: number) =>
+    state.selection.ranges.some((r) => r.from <= to && r.to >= from);
+  /** Reveal across the whole line(s) the range sits on (for block markup). */
+  const revealLine = (from: number, to: number) =>
+    reveal(doc.lineAt(from).from, doc.lineAt(Math.min(to, doc.length)).to);
+
+  const decoratedLines = new Set<string>();
+  const lineDeco = (pos: number, className: string) => {
+    const line = doc.lineAt(pos);
+    const key = `${line.from}:${className}`;
+    if (decoratedLines.has(key)) return;
+    decoratedLines.add(key);
+    decos.push(Decoration.line({ class: className }).range(line.from));
+  };
+  const eachLine = (from: number, to: number, fn: (lineFrom: number, first: boolean, last: boolean) => void) => {
+    let pos = from;
+    while (pos <= to) {
+      const line = doc.lineAt(pos);
+      fn(line.from, line.from <= from, line.to >= to);
+      if (line.to >= to) break;
+      pos = line.to + 1;
+    }
+  };
+
+  /** Hide a mark, swallowing one following space (e.g. `# `, `> `). */
+  const hideMark = (from: number, to: number, limit: number) => {
+    const end = to < limit && state.sliceDoc(to, to + 1) === ' ' ? to + 1 : to;
+    decos.push(hide.range(from, end));
+  };
+
+  const hideChildMarks = (node: SyntaxNode, markName: string) => {
+    for (let child = node.firstChild; child; child = child.nextSibling) {
+      if (child.name === markName) decos.push(hide.range(child.from, child.to));
+    }
+  };
+
+  for (const { from, to } of view.visibleRanges) {
+    syntaxTree(state).iterate({
+      from, to,
+      enter: (nodeRef) => {
+        const name = nodeRef.name;
+        const nFrom = nodeRef.from;
+        const nTo = nodeRef.to;
+
+        // Headings: size the whole line, hide the leading `# ` marks.
+        const headingLevel = name.startsWith('ATXHeading') ? Number(name.slice(10)) : 0;
+        if (headingLevel) {
+          lineDeco(nFrom, `cm-lp-h${headingLevel}`);
+          if (!revealLine(nFrom, nTo)) {
+            const mark = nodeRef.node.getChild('HeaderMark');
+            if (mark) hideMark(mark.from, mark.to, nTo);
+          }
+          return;
+        }
+        if (name === 'SetextHeading1' || name === 'SetextHeading2') {
+          lineDeco(nFrom, name === 'SetextHeading1' ? 'cm-lp-h1' : 'cm-lp-h2');
+          return;
+        }
+
+        switch (name) {
+          case 'Emphasis':
+          case 'StrongEmphasis':
+            if (!reveal(nFrom, nTo)) hideChildMarks(nodeRef.node, 'EmphasisMark');
+            return;
+
+          case 'Strikethrough':
+            if (!reveal(nFrom, nTo)) hideChildMarks(nodeRef.node, 'StrikethroughMark');
+            return;
+
+          case 'InlineCode':
+            if (!reveal(nFrom, nTo)) hideChildMarks(nodeRef.node, 'CodeMark');
+            return;
+
+          case 'Link': {
+            if (reveal(nFrom, nTo)) return;
+            const node = nodeRef.node;
+            const marks = node.getChildren('LinkMark');
+            const url = node.getChild('URL');
+            // `[text](url)` → keep `text`, hide the brackets and the URL tail.
+            if (marks.length >= 2) {
+              const textFrom = marks[0].to;
+              const textTo = marks[1].from;
+              decos.push(hide.range(nFrom, textFrom));
+              decos.push(hide.range(textTo, nTo));
+              if (textTo > textFrom) {
+                decos.push(Decoration.mark({
+                  class: 'cm-lp-link',
+                  attributes: url ? { 'data-lp-href': state.sliceDoc(url.from, url.to) } : {},
+                }).range(textFrom, textTo));
+              }
+            }
+            return false;
+          }
+
+          case 'Image': {
+            if (revealLine(nFrom, nTo)) return;
+            const node = nodeRef.node;
+            const url = node.getChild('URL');
+            if (url) {
+              const marks = node.getChildren('LinkMark');
+              const alt = marks.length >= 2 ? state.sliceDoc(marks[0].to, marks[1].from) : '';
+              decos.push(Decoration.replace({
+                widget: new ImageWidget(state.sliceDoc(url.from, url.to), alt),
+              }).range(nFrom, nTo));
+            }
+            return false;
+          }
+
+          case 'WikiLink': {
+            if (reveal(nFrom, nTo)) return;
+            const inner = state.sliceDoc(nFrom + 2, nTo - 2);
+            const pipe = inner.indexOf('|');
+            const target = (pipe >= 0 ? inner.slice(0, pipe) : inner).trim();
+            // Hide `[[` plus, for aliased links, the `target|` part.
+            decos.push(hide.range(nFrom, nFrom + 2 + (pipe >= 0 ? pipe + 1 : 0)));
+            decos.push(hide.range(nTo - 2, nTo));
+            const textFrom = nFrom + 2 + (pipe >= 0 ? pipe + 1 : 0);
+            if (nTo - 2 > textFrom) {
+              decos.push(Decoration.mark({
+                class: 'cm-lp-wikilink',
+                attributes: { 'data-lp-wikilink': target },
+              }).range(textFrom, nTo - 2));
+            }
+            return false;
+          }
+
+          case 'Blockquote':
+            eachLine(nFrom, nTo, (lineFrom) => lineDeco(lineFrom, 'cm-lp-quote'));
+            return;
+
+          case 'QuoteMark':
+            if (!revealLine(nFrom, nTo)) hideMark(nFrom, nTo, doc.length);
+            return;
+
+          case 'ListMark': {
+            const text = state.sliceDoc(nFrom, nTo);
+            if (/^[-*+]$/.test(text) && !revealLine(nFrom, nTo)) {
+              // Skip the bullet swap when a task checkbox follows: the box is enough.
+              const after = state.sliceDoc(nTo + 1, nTo + 2);
+              if (after === '[') decos.push(hide.range(nFrom, Math.min(nTo + 1, doc.length)));
+              else decos.push(bulletDeco.range(nFrom, nTo));
+            }
+            return;
+          }
+
+          case 'TaskMarker': {
+            if (revealLine(nFrom, nTo)) return;
+            const checked = /x/i.test(state.sliceDoc(nFrom, nTo));
+            hideMark(nFrom, nTo, doc.length);
+            decos.push(Decoration.widget({ widget: new CheckboxWidget(checked), side: 1 }).range(nFrom));
+            return;
+          }
+
+          case 'HorizontalRule':
+            if (!revealLine(nFrom, nTo)) {
+              decos.push(Decoration.replace({ widget: new HrWidget() }).range(nFrom, nTo));
+            }
+            return;
+
+          case 'FencedCode':
+            eachLine(nFrom, nTo, (lineFrom, first, last) => {
+              lineDeco(lineFrom, 'cm-lp-code');
+              if (first) lineDeco(lineFrom, 'cm-lp-code-first');
+              if (last) lineDeco(lineFrom, 'cm-lp-code-last');
+            });
+            return;
+
+          case 'Frontmatter':
+            eachLine(nFrom, nTo, (lineFrom) => lineDeco(lineFrom, 'cm-lp-frontmatter'));
+            return;
+
+          case 'Table':
+            eachLine(nFrom, nTo, (lineFrom) => lineDeco(lineFrom, 'cm-lp-table'));
+            return;
+        }
+      },
+    });
+  }
+
+  return Decoration.set(decos, true);
+}
+
+// ── Click handling ───────────────────────────────────────────────────
+
+/** Toggle the `[ ]`/`[x]` marker that starts at the widget's position. */
+function toggleCheckbox(view: EditorView, pos: number): boolean {
+  const text = view.state.sliceDoc(pos, pos + 3);
+  const m = /^\[( |x|X)\]$/.exec(text);
+  if (!m) return false;
+  view.dispatch({
+    changes: { from: pos, to: pos + 3, insert: m[1] === ' ' ? '[x]' : '[ ]' },
+  });
+  return true;
+}
+
+// ── Plugin ───────────────────────────────────────────────────────────
+
+export const livePreview = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.selectionSet || update.viewportChanged) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+    eventHandlers: {
+      mousedown(event, view) {
+        const target = event.target as HTMLElement;
+        if (target.classList.contains('cm-lp-checkbox')) {
+          return toggleCheckbox(view, view.posAtDOM(target));
+        }
+        const link = target.closest('.cm-lp-link[data-lp-href]') as HTMLElement | null;
+        if (link) {
+          const href = link.getAttribute('data-lp-href')!;
+          if (/^https?:\/\//.test(href)) window.open(href, '_blank', 'noopener');
+          return true;
+        }
+        const wiki = target.closest('.cm-lp-wikilink[data-lp-wikilink]') as HTMLElement | null;
+        if (wiki) {
+          view.state.facet(livePreviewConfig).onWikilink?.(wiki.getAttribute('data-lp-wikilink')!);
+          return true;
+        }
+        return false;
+      },
+    },
+  },
+);
+
+export type { EditorState };

--- a/web/src/components/editor/markdownExtensions.ts
+++ b/web/src/components/editor/markdownExtensions.ts
@@ -1,0 +1,62 @@
+import type { MarkdownConfig } from '@lezer/markdown';
+import { tags as t } from '@lezer/highlight';
+
+const BRACKET_L = 91; /* [ */
+const BRACKET_R = 93; /* ] */
+const NEWLINE = 10;
+
+/**
+ * Inline parser for Obsidian-style wikilinks: `[[target]]` and
+ * `[[target|alias]]`. Produces a WikiLink node wrapping two WikiLinkMark
+ * nodes for the `[[` / `]]` delimiters.
+ */
+export const WikiLink: MarkdownConfig = {
+  defineNodes: [
+    { name: 'WikiLink', style: t.link },
+    { name: 'WikiLinkMark', style: t.processingInstruction },
+  ],
+  parseInline: [{
+    name: 'WikiLink',
+    before: 'Link',
+    parse(cx, next, pos) {
+      if (next !== BRACKET_L || cx.char(pos + 1) !== BRACKET_L) return -1;
+      let close = -1;
+      for (let i = pos + 2; i < cx.end - 1; i++) {
+        const ch = cx.char(i);
+        if (ch === NEWLINE) return -1;
+        if (ch === BRACKET_R && cx.char(i + 1) === BRACKET_R) { close = i; break; }
+      }
+      if (close < 0 || close === pos + 2) return -1;
+      return cx.addElement(cx.elt('WikiLink', pos, close + 2, [
+        cx.elt('WikiLinkMark', pos, pos + 2),
+        cx.elt('WikiLinkMark', close, close + 2),
+      ]));
+    },
+  }],
+};
+
+/**
+ * Block parser for a YAML frontmatter fence at the very start of the
+ * document. Without this, the parser reads the `---` fences as horizontal
+ * rules / setext headings and renders the metadata as prose.
+ * An unterminated fence swallows the rest of the document; pages always
+ * carry a closing fence in practice.
+ */
+export const Frontmatter: MarkdownConfig = {
+  defineNodes: [{ name: 'Frontmatter', block: true, style: t.meta }],
+  parseBlock: [{
+    name: 'Frontmatter',
+    before: 'LinkReference',
+    parse(cx, line) {
+      if (cx.lineStart !== 0 || line.text.trim() !== '---') return false;
+      const start = cx.lineStart;
+      let end = cx.lineStart + line.text.length;
+      while (cx.nextLine()) {
+        end = cx.lineStart + line.text.length;
+        if (line.text.trim() === '---') { cx.nextLine(); break; }
+      }
+      cx.addElement(cx.elt('Frontmatter', start, end));
+      return true;
+    },
+  }],
+};

--- a/web/src/components/editor/theme.ts
+++ b/web/src/components/editor/theme.ts
@@ -1,0 +1,152 @@
+import { EditorView } from '@codemirror/view';
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+import { C, fonts } from '@/lib/design';
+
+/**
+ * Editor chrome + live-preview line styles, mirroring the `.prose`
+ * typography of the read view so edit mode is visually seamless.
+ */
+export const editorTheme = EditorView.theme({
+  '&': {
+    fontSize: '14px',
+    color: C.ink,
+    backgroundColor: 'transparent',
+    height: '100%',
+  },
+  '&.cm-focused': { outline: 'none' },
+  '.cm-scroller': {
+    fontFamily: fonts.sans,
+    lineHeight: '1.72',
+    overflow: 'auto',
+  },
+  '.cm-content': {
+    padding: '36px 48px 56px 56px',
+    caretColor: C.ink,
+    maxWidth: '820px',
+  },
+  '.cm-line': { padding: '0.08rem 0' },
+
+  // Headings — match .prose h1/h2/h3
+  '.cm-lp-h1': {
+    fontFamily: fonts.serif, fontSize: '2.25rem', fontWeight: '700',
+    lineHeight: '1.25', paddingTop: '1.1rem', paddingBottom: '0.35rem',
+  },
+  '.cm-lp-h2': {
+    fontFamily: fonts.serif, fontSize: '1.5rem', fontWeight: '600',
+    lineHeight: '1.3', paddingTop: '1.15rem', paddingBottom: '0.4rem',
+  },
+  '.cm-lp-h3': {
+    fontSize: '1.125rem', fontWeight: '600',
+    paddingTop: '0.9rem', paddingBottom: '0.25rem',
+  },
+  '.cm-lp-h4, .cm-lp-h5, .cm-lp-h6': {
+    fontSize: '1rem', fontWeight: '600',
+    paddingTop: '0.7rem', paddingBottom: '0.2rem',
+  },
+
+  // Blockquote
+  '.cm-lp-quote': {
+    borderLeft: `3px solid ${C.line}`,
+    paddingLeft: '1rem',
+    color: C.ink2,
+  },
+
+  // Fenced code blocks
+  '.cm-lp-code': {
+    backgroundColor: C.sidebar,
+    fontFamily: fonts.mono,
+    fontSize: '0.85em',
+    lineHeight: '1.6',
+    padding: '0 1rem',
+  },
+  '.cm-lp-code-first': { borderRadius: '6px 6px 0 0', paddingTop: '0.5rem' },
+  '.cm-lp-code-last': { borderRadius: '0 0 6px 6px', paddingBottom: '0.5rem' },
+
+  // Frontmatter
+  '.cm-lp-frontmatter': {
+    fontFamily: fonts.mono,
+    fontSize: '0.8em',
+    color: C.muted,
+    lineHeight: '1.6',
+  },
+
+  // Tables stay source-mode; mono keeps the pipes aligned
+  '.cm-lp-table': { fontFamily: fonts.mono, fontSize: '0.85em', lineHeight: '1.6' },
+
+  // Inline widgets
+  '.cm-lp-bullet': { color: C.faint, display: 'inline-block', width: '1em' },
+  '.cm-lp-hr': {
+    display: 'inline-block', width: '100%', verticalAlign: 'middle',
+    borderTop: `1px solid ${C.line}`,
+  },
+  '.cm-lp-checkbox': {
+    accentColor: C.accent,
+    width: '14px', height: '14px',
+    verticalAlign: 'middle',
+    margin: '0 0.45em 0.2em 0',
+    cursor: 'pointer',
+  },
+  '.cm-lp-image': {
+    maxWidth: '100%', maxHeight: '480px',
+    borderRadius: '6px', display: 'block', margin: '0.4rem 0',
+  },
+
+  // Links
+  '.cm-lp-link': {
+    textDecoration: 'underline', textUnderlineOffset: '2px',
+    cursor: 'pointer',
+  },
+  '.cm-lp-wikilink': {
+    color: C.accent,
+    textDecoration: 'underline', textUnderlineOffset: '2px',
+    textDecorationColor: 'rgba(226, 89, 11, 0.4)',
+    cursor: 'pointer',
+  },
+
+  // Autocomplete popup
+  '.cm-tooltip.cm-tooltip-autocomplete': {
+    border: `1px solid ${C.line}`,
+    borderRadius: '8px',
+    backgroundColor: C.panel,
+    boxShadow: '0 8px 28px rgba(29, 28, 26, 0.12)',
+    overflow: 'hidden',
+  },
+  '.cm-tooltip-autocomplete ul li': { padding: '3px 10px', fontSize: '13px' },
+  '.cm-tooltip-autocomplete ul li[aria-selected]': {
+    backgroundColor: C.accentSoft, color: C.ink,
+  },
+});
+
+/** Inline markdown + code-token colors (GitHub-light-ish, warmed to match). */
+export const editorHighlighting = syntaxHighlighting(HighlightStyle.define([
+  { tag: t.strong, fontWeight: '700' },
+  { tag: t.emphasis, fontStyle: 'italic' },
+  { tag: t.strikethrough, textDecoration: 'line-through' },
+  {
+    tag: t.monospace,
+    fontFamily: fonts.mono, fontSize: '0.85em',
+    color: C.accent, backgroundColor: C.rail,
+    borderRadius: '3px', padding: '1px 4px',
+  },
+  { tag: t.link, textDecoration: 'underline', textUnderlineOffset: '2px' },
+  { tag: t.url, color: C.muted },
+  // Markdown punctuation (visible only near the cursor)
+  { tag: t.processingInstruction, color: C.faint },
+  { tag: t.meta, color: C.muted },
+  { tag: t.contentSeparator, color: C.faint },
+  { tag: t.quote, color: C.ink2 },
+  { tag: t.labelName, color: C.blue },
+  // Code tokens inside fenced blocks
+  { tag: t.keyword, color: '#cf222e' },
+  { tag: [t.string, t.special(t.string)], color: '#0a3069' },
+  { tag: t.comment, color: '#6e7781', fontStyle: 'italic' },
+  { tag: [t.number, t.bool, t.atom], color: '#0550ae' },
+  { tag: [t.typeName, t.className, t.namespace], color: '#953800' },
+  { tag: [t.function(t.variableName), t.function(t.propertyName)], color: '#8250df' },
+  { tag: t.propertyName, color: '#0550ae' },
+  { tag: t.operator, color: '#cf222e' },
+  { tag: t.tagName, color: '#116329' },
+  { tag: t.attributeName, color: '#0550ae' },
+  { tag: t.heading, fontWeight: '600' },
+]));

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -565,20 +565,29 @@ export function MainLayout() {
     }
   };
 
-  // Save an in-page edit to the user's draft branch, then refresh the page + tree.
+  // Autosave an in-page edit to the user's draft branch (the backend amends a
+  // single working commit, so frequent saves are fine). Refresh the tree so
+  // frontmatter title changes show up while editing.
   const handleSavePage = async (body: string) => {
     if (!activeWorkspace || activeView?.kind !== 'page') return;
     const ws = activeWorkspace;
-    const slug = activeView.slug;
-    await writePage(slug, body, userBranch, ws.slug);
-    setEditingPage(false);
-    setMessage({ text: 'Saved to your draft.', type: 'success' });
-    try {
-      const page = await getPage(slug, userBranch, ws.slug);
-      setActiveView((prev) => (prev?.kind === 'page' ? { ...prev, content: page } : prev));
-    } catch { /* keep the stale view; tree reload below still runs */ }
+    await writePage(activeView.slug, body, userBranch, ws.slug);
     loadSpacePages(ws);
   };
+
+  // Leave edit mode; pull the saved page back so the read view is fresh.
+  const handleDoneEditing = async () => {
+    setEditingPage(false);
+    if (!activeWorkspace || activeView?.kind !== 'page') return;
+    try {
+      const page = await getPage(activeView.slug, userBranch, activeWorkspace.slug);
+      setActiveView((prev) => (prev?.kind === 'page' ? { ...prev, content: page } : prev));
+    } catch { /* keep the stale view */ }
+  };
+
+  // Flat slug list for the editor's [[wikilink]] autocompletion.
+  const collectSlugs = (pages: PageMeta[]): string[] =>
+    pages.flatMap((p) => (p.kind === 'folder' ? collectSlugs(p.children) : [p.slug]));
 
   const personal = activeWorkspace ? isPersonalSpace(activeWorkspace) : false;
   const isOwner = activeWorkspace?.role === 'owner';
@@ -870,9 +879,10 @@ export function MainLayout() {
                   <PageEditor
                     key={activeView.slug}
                     initialBody={activeView.content.body}
-                    stripFrontmatter={renderBody}
                     onSave={handleSavePage}
-                    onCancel={() => setEditingPage(false)}
+                    onDone={() => { void handleDoneEditing(); }}
+                    onWikilink={(target) => activeWorkspace && selectPage(activeWorkspace, target)}
+                    getPageSlugs={() => (activeWorkspace ? collectSlugs(spacePages[activeWorkspace.id] || []) : [])}
                   />
                 ) : (
                   // Fill the content box edge-to-edge: the doc scrolls on the left


### PR DESCRIPTION
## What

Two pieces toward the local-first V1 direction (#117):

### 1. Obsidian-style live-preview editor

Replaces the textarea + Write/Preview tabs with a CodeMirror 6 live-preview editor — markdown renders in place, and raw syntax reveals itself only around the cursor (same interaction model as Obsidian's Live Preview):

- headings / bold / italic / strike / inline code / quotes / lists / hr render live; fenced code gets per-language syntax highlighting; frontmatter shows as a dimmed mono block
- `[[wikilink]]` support: custom lezer parser, click-to-navigate, `[[` autocompletes existing page slugs
- task checkboxes are clickable and toggle the underlying `[ ]`/`[x]`
- **autosave** on a 900ms debounce — the backend already amends a single working commit per draft branch, so frequent saves are cheap; a floating pill shows Saved / Saving / error, Done or Esc exits after flushing

### 2. Single-user local mode

- when GitHub OAuth is not configured, the server enables `POST /api/auth/local`: signs in as the machine user (`$USER`), creating the account + spaces on first use; the frontend tries this at startup, so a local install boots straight into the wiki with no login page
- wiki data dir defaults to `~/cowiki` in local mode (`./data` for hosted), supports `~` expansion, still configurable via `[server] data_dir` / `COWIKI_DATA_DIR`
- explicit override: `[server] local_mode` / `COWIKI_LOCAL_MODE`; hosted deploys with `GITHUB_CLIENT_ID` set are unaffected

## Verification

- `tsc`, eslint, vite build clean; `cargo test -p cowiki-utils -p cowiki-server` all pass
- Playwright walkthrough against the running stack: auto-login lands directly on a page, edit mode renders all constructs live, syntax reveals on cursor, checkbox toggling persists, autosave pill reaches "Saved", `[[` completion pops
- fresh install verified end-to-end on a machine with no prior server state (`~/cowiki` auto-created)

## Notes

- Stacked on `feat/doc-comments` (base of this PR) since the editor wiring builds on the doc-comments MainLayout; retarget to `main` after that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)