### PR TITLE
feat(desktop): add Space history checkpoints

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "npm run test:auth-flow && npm run test:versioned-document && npm run test:local-space && npm run test:sidebar-layout && npm run test:client-settings && npm run test:page-frontmatter && npm run test:agent-terminal && npm run test:okf-pages && npm run test:window-chrome && npm run test:page-header && npm run test:source-ingest",
+    "test": "npm run test:auth-flow && npm run test:versioned-document && npm run test:local-space && npm run test:sidebar-layout && npm run test:client-settings && npm run test:page-frontmatter && npm run test:agent-terminal && npm run test:okf-pages && npm run test:window-chrome && npm run test:page-header && npm run test:source-ingest && npm run test:history",
     "test:auth-flow": "node --experimental-strip-types --test tests/auth-flow.test.ts",
     "test:versioned-document": "node --experimental-strip-types --test tests/versioned-document.test.ts",
     "test:local-space": "node --experimental-strip-types --test tests/local-space.test.ts",
@@ -20,6 +20,7 @@
     "test:window-chrome": "node --experimental-strip-types --test tests/window-chrome.test.ts",
     "test:page-header": "node --experimental-strip-types --test tests/page-header.test.ts",
     "test:source-ingest": "node --experimental-strip-types --test tests/source-ingest.test.ts",
+    "test:history": "node --experimental-strip-types --test tests/history.test.ts",
     "tauri": "tauri",
     "desktop:dev": "tauri dev",
     "desktop:build": "tauri build"

--- a/web/src-tauri/src/lib.rs
+++ b/web/src-tauri/src/lib.rs
@@ -6,8 +6,8 @@ mod okf;
 mod terminal;
 
 use local_engine::{
-    FileDiff, IngestFileOutcome, LocalEngine, PageFull, PageMeta, SearchResponse, SourceContent,
-    SourceItem, Space, SubmitResult,
+    Checkpoint, FileDiff, IngestFileOutcome, LocalEngine, PageFull, PageMeta, SearchResponse,
+    SourceContent, SourceItem, Space, SpaceHistory, SubmitResult,
 };
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -218,6 +218,23 @@ fn local_keep_working_diff(
     engine.keep_working_diff(&space_slug, &expected)
 }
 
+#[tauri::command]
+fn local_history(
+    engine: State<'_, LocalEngine>,
+    space_slug: String,
+) -> Result<SpaceHistory, String> {
+    engine.history(&space_slug)
+}
+
+#[tauri::command]
+fn local_create_checkpoint(
+    engine: State<'_, LocalEngine>,
+    space_slug: String,
+    name: Option<String>,
+) -> Result<Checkpoint, String> {
+    engine.create_checkpoint(&space_slug, name.as_deref())
+}
+
 pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
@@ -240,6 +257,8 @@ pub fn run() {
             local_submit,
             local_working_diff,
             local_keep_working_diff,
+            local_history,
+            local_create_checkpoint,
             terminal::terminal_create,
             terminal::terminal_write,
             terminal::terminal_resize,

--- a/web/src-tauri/src/local_engine.rs
+++ b/web/src-tauri/src/local_engine.rs
@@ -28,6 +28,27 @@ pub struct SubmitResult {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Checkpoint {
+    pub id: String,
+    pub name: String,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DraftStatus {
+    pub changed_files: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SpaceHistory {
+    pub current_draft: DraftStatus,
+    pub checkpoints: Vec<Checkpoint>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct PageMeta {
     pub slug: String,
     pub path: String,
@@ -823,6 +844,98 @@ impl LocalEngine {
         Ok(has_changes)
     }
 
+    pub fn history(&self, space_slug: &str) -> Result<SpaceHistory, String> {
+        let repo = self.repo(space_slug)?;
+        let changed_files = draft_statuses(&repo)?.len();
+        let mut checkpoints = Vec::new();
+        let mut current = checkpoint_tip(&repo)?;
+
+        while let Some(oid) = current {
+            if repo.find_reference(&checkpoint_reference(oid)).is_err() {
+                break;
+            }
+            let commit = repo.find_commit(oid).map_err(|error| error.to_string())?;
+            checkpoints.push(Checkpoint {
+                id: oid.to_string(),
+                name: commit.summary().unwrap_or("Checkpoint").to_string(),
+                created_at: commit.time().seconds(),
+            });
+            current = if commit.parent_count() == 0 {
+                None
+            } else {
+                Some(commit.parent_id(0).map_err(|error| error.to_string())?)
+            };
+        }
+
+        Ok(SpaceHistory {
+            current_draft: DraftStatus { changed_files },
+            checkpoints,
+        })
+    }
+
+    pub fn create_checkpoint(
+        &self,
+        space_slug: &str,
+        name: Option<&str>,
+    ) -> Result<Checkpoint, String> {
+        let repo = self.repo(space_slug)?;
+        let root = repo
+            .workdir()
+            .ok_or_else(|| "local Space repository has no working directory".to_string())?;
+        let mut snapshot = repo.index().map_err(|error| error.to_string())?;
+        reset_index_to_head(&repo, &mut snapshot)?;
+        for relative in draft_statuses(&repo)? {
+            let path = Path::new(&relative);
+            if root.join(path).symlink_metadata().is_ok() {
+                snapshot.add_path(path).map_err(|error| error.to_string())?;
+            } else {
+                let _ = snapshot.remove_path(path);
+            }
+        }
+        let tree_id = snapshot.write_tree().map_err(|error| error.to_string())?;
+        let tree = repo.find_tree(tree_id).map_err(|error| error.to_string())?;
+        let parent_oid = checkpoint_tip(&repo)?.or_else(|| {
+            repo.head()
+                .ok()
+                .and_then(|head| head.peel_to_commit().ok())
+                .map(|commit| commit.id())
+        });
+        let parent = parent_oid
+            .map(|oid| repo.find_commit(oid).map_err(|error| error.to_string()))
+            .transpose()?;
+        let parents = parent.iter().collect::<Vec<_>>();
+        let signature = Signature::now("CoWiki Checkpoint", "checkpoint@cowiki.app")
+            .map_err(|error| error.to_string())?;
+        let label = name
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("Checkpoint {}", signature.when().seconds()));
+        let oid = repo
+            .commit(None, &signature, &signature, &label, &tree, &parents)
+            .map_err(|error| error.to_string())?;
+        let immutable_ref = checkpoint_reference(oid);
+        repo.reference(&immutable_ref, oid, false, "Create CoWiki checkpoint")
+            .map_err(|error| error.to_string())?;
+        if let Err(error) = repo.reference(
+            CHECKPOINT_TIP_REF,
+            oid,
+            true,
+            "Advance CoWiki checkpoint history",
+        ) {
+            if let Ok(mut reference) = repo.find_reference(&immutable_ref) {
+                let _ = reference.delete();
+            }
+            return Err(error.to_string());
+        }
+
+        Ok(Checkpoint {
+            id: oid.to_string(),
+            name: label,
+            created_at: signature.when().seconds(),
+        })
+    }
+
     pub fn submit(&self, space_slug: &str, paths: &[String]) -> Result<SubmitResult, String> {
         let repo = self.repo(space_slug)?;
         let root = repo
@@ -975,6 +1088,39 @@ impl LocalEngine {
         let space = self.find_space(space_slug)?;
         Repository::open(&space.local_path).map_err(|e| e.to_string())
     }
+}
+
+const CHECKPOINT_TIP_REF: &str = "refs/cowiki/checkpoints/latest";
+
+fn checkpoint_reference(oid: Oid) -> String {
+    format!("refs/cowiki/checkpoints/{oid}")
+}
+
+fn checkpoint_tip(repo: &Repository) -> Result<Option<Oid>, String> {
+    match repo.find_reference(CHECKPOINT_TIP_REF) {
+        Ok(reference) => reference
+            .target()
+            .map(Some)
+            .ok_or_else(|| "CoWiki checkpoint history points to a symbolic ref".to_string()),
+        Err(error) if error.code() == git2::ErrorCode::NotFound => Ok(None),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn draft_statuses(repo: &Repository) -> Result<Vec<String>, String> {
+    let mut options = StatusOptions::new();
+    options
+        .include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .include_ignored(false);
+    let statuses = repo
+        .statuses(Some(&mut options))
+        .map_err(|error| error.to_string())?;
+    Ok(statuses
+        .iter()
+        .filter_map(|entry| entry.path().map(str::to_string))
+        .filter(|relative| safe_repo_path(relative).is_ok())
+        .collect())
 }
 
 fn reset_index_to_head(repo: &Repository, index: &mut git2::Index) -> Result<(), String> {
@@ -1879,6 +2025,116 @@ mod tests {
             .get_path(std::path::Path::new("notes/renamed.md"))
             .is_err());
         assert!(!engine.has_uncommitted_changes(&space.slug).unwrap());
+    }
+
+    #[test]
+    fn checkpoint_snapshots_the_current_draft_without_moving_head() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        let repo = git2::Repository::open(&folder).unwrap();
+        let head_before = repo.head().unwrap().target().unwrap();
+        let branch_before = repo.head().unwrap().name().unwrap().to_string();
+        drop(repo);
+
+        engine
+            .write_page(&space.slug, "draft", "# Draft\n\nFirst checkpoint\n")
+            .unwrap();
+        let saved_draft = engine.history(&space.slug).unwrap();
+        assert_eq!(saved_draft.current_draft.changed_files, 2);
+        assert!(saved_draft.checkpoints.is_empty());
+        let index_before = std::fs::read(folder.join(".git/index")).unwrap();
+        let checkpoint = engine
+            .create_checkpoint(&space.slug, Some("Checkpoint 2026-07-15 23:45"))
+            .unwrap();
+
+        let repo = git2::Repository::open(&folder).unwrap();
+        assert_eq!(repo.head().unwrap().target().unwrap(), head_before);
+        assert_eq!(repo.head().unwrap().name().unwrap(), branch_before);
+        assert_eq!(
+            std::fs::read(folder.join(".git/index")).unwrap(),
+            index_before
+        );
+        assert!(engine.has_uncommitted_changes(&space.slug).unwrap());
+        let snapshot = repo
+            .find_commit(git2::Oid::from_str(&checkpoint.id).unwrap())
+            .unwrap()
+            .tree()
+            .unwrap();
+        let blob = repo
+            .find_blob(
+                snapshot
+                    .get_path(std::path::Path::new("draft.md"))
+                    .unwrap()
+                    .id(),
+            )
+            .unwrap();
+        assert!(std::str::from_utf8(blob.content())
+            .unwrap()
+            .contains("First checkpoint"));
+        assert_eq!(checkpoint.name, "Checkpoint 2026-07-15 23:45");
+
+        let history = engine.history(&space.slug).unwrap();
+        assert_eq!(history.current_draft.changed_files, 2);
+        assert_eq!(history.checkpoints, vec![checkpoint]);
+        assert!(repo
+            .find_reference(&format!(
+                "refs/cowiki/checkpoints/{}",
+                history.checkpoints[0].id
+            ))
+            .is_ok());
+    }
+
+    #[test]
+    fn later_checkpoints_capture_the_exact_draft_and_list_newest_first() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+
+        engine
+            .write_page(&space.slug, "temporary", "# Temporary\n")
+            .unwrap();
+        let first = engine
+            .create_checkpoint(&space.slug, Some("First checkpoint"))
+            .unwrap();
+        engine.delete_path(&space.slug, "temporary.md").unwrap();
+        let second = engine
+            .create_checkpoint(&space.slug, Some("Second checkpoint"))
+            .unwrap();
+
+        let history = engine.history(&space.slug).unwrap();
+        assert_eq!(
+            history
+                .checkpoints
+                .iter()
+                .map(|checkpoint| checkpoint.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Second checkpoint", "First checkpoint"]
+        );
+        assert_eq!(history.current_draft.changed_files, 0);
+
+        let repo = git2::Repository::open(&folder).unwrap();
+        let first_commit = repo
+            .find_commit(git2::Oid::from_str(&first.id).unwrap())
+            .unwrap();
+        let second_commit = repo
+            .find_commit(git2::Oid::from_str(&second.id).unwrap())
+            .unwrap();
+        assert_eq!(second_commit.parent_id(0).unwrap(), first_commit.id());
+        assert!(first_commit
+            .tree()
+            .unwrap()
+            .get_path(std::path::Path::new("temporary.md"))
+            .is_ok());
+        assert!(second_commit
+            .tree()
+            .unwrap()
+            .get_path(std::path::Path::new("temporary.md"))
+            .is_err());
     }
 
     #[test]

--- a/web/src-tauri/src/local_engine.rs
+++ b/web/src-tauri/src/local_engine.rs
@@ -1,5 +1,5 @@
 use git2::build::CheckoutBuilder;
-use git2::{IndexEntry, IndexTime, Oid, Repository, Signature, StatusOptions};
+use git2::{DiffOptions, IndexEntry, IndexTime, Oid, Repository, Signature, StatusOptions};
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -846,7 +846,7 @@ impl LocalEngine {
 
     pub fn history(&self, space_slug: &str) -> Result<SpaceHistory, String> {
         let repo = self.repo(space_slug)?;
-        let changed_files = draft_statuses(&repo)?.len();
+        let changed_files = draft_changed_files(&repo)?;
         let mut checkpoints = Vec::new();
         let mut current = checkpoint_tip(&repo)?;
 
@@ -1121,6 +1121,28 @@ fn draft_statuses(repo: &Repository) -> Result<Vec<String>, String> {
         .filter_map(|entry| entry.path().map(str::to_string))
         .filter(|relative| safe_repo_path(relative).is_ok())
         .collect())
+}
+
+fn draft_changed_files(repo: &Repository) -> Result<usize, String> {
+    let baseline_oid = checkpoint_tip(repo)?.or_else(|| {
+        repo.head()
+            .ok()
+            .and_then(|head| head.peel_to_commit().ok())
+            .map(|commit| commit.id())
+    });
+    let baseline = baseline_oid
+        .map(|oid| {
+            repo.find_commit(oid)
+                .and_then(|commit| commit.tree())
+                .map_err(|error| error.to_string())
+        })
+        .transpose()?;
+    let mut options = DiffOptions::new();
+    options.include_untracked(true).recurse_untracked_dirs(true);
+    let diff = repo
+        .diff_tree_to_workdir(baseline.as_ref(), Some(&mut options))
+        .map_err(|error| error.to_string())?;
+    Ok(diff.deltas().count())
 }
 
 fn reset_index_to_head(repo: &Repository, index: &mut git2::Index) -> Result<(), String> {
@@ -2077,8 +2099,12 @@ mod tests {
         assert_eq!(checkpoint.name, "Checkpoint 2026-07-15 23:45");
 
         let history = engine.history(&space.slug).unwrap();
-        assert_eq!(history.current_draft.changed_files, 2);
+        assert_eq!(history.current_draft.changed_files, 0);
         assert_eq!(history.checkpoints, vec![checkpoint]);
+        assert_eq!(
+            std::fs::read(folder.join(".git/index")).unwrap(),
+            index_before
+        );
         assert!(repo
             .find_reference(&format!(
                 "refs/cowiki/checkpoints/{}",
@@ -2102,6 +2128,14 @@ mod tests {
             .create_checkpoint(&space.slug, Some("First checkpoint"))
             .unwrap();
         engine.delete_path(&space.slug, "temporary.md").unwrap();
+        assert_eq!(
+            engine
+                .history(&space.slug)
+                .unwrap()
+                .current_draft
+                .changed_files,
+            2
+        );
         let second = engine
             .create_checkpoint(&space.slug, Some("Second checkpoint"))
             .unwrap();
@@ -2135,6 +2169,47 @@ mod tests {
             .unwrap()
             .get_path(std::path::Path::new("temporary.md"))
             .is_err());
+    }
+
+    #[test]
+    fn draft_changes_are_measured_from_the_latest_checkpoint() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        engine
+            .write_page(&space.slug, "draft", "# Draft\n\nFirst version\n")
+            .unwrap();
+
+        engine
+            .create_checkpoint(&space.slug, Some("First checkpoint"))
+            .unwrap();
+        assert_eq!(
+            engine
+                .history(&space.slug)
+                .unwrap()
+                .current_draft
+                .changed_files,
+            0
+        );
+
+        std::fs::write(folder.join("draft.md"), "# Draft\n\nSecond version\n").unwrap();
+        assert_eq!(
+            engine
+                .history(&space.slug)
+                .unwrap()
+                .current_draft
+                .changed_files,
+            1
+        );
+
+        engine
+            .create_checkpoint(&space.slug, Some("Second checkpoint"))
+            .unwrap();
+        let history = engine.history(&space.slug).unwrap();
+        assert_eq!(history.current_draft.changed_files, 0);
+        assert_eq!(history.checkpoints.len(), 2);
     }
 
     #[test]

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -117,6 +117,20 @@ export interface Workspace {
   localPath?: string;
 }
 
+export interface Checkpoint {
+  id: string;
+  name: string;
+  /** Unix timestamp in seconds. */
+  createdAt: number;
+}
+
+export interface SpaceHistory {
+  currentDraft: {
+    changedFiles: number;
+  };
+  checkpoints: Checkpoint[];
+}
+
 export interface MemberInfo {
   id: string;
   name: string;
@@ -419,6 +433,20 @@ export async function getLocalWorkingDiff(workspaceSlug: string): Promise<FileDi
 export async function keepLocalWorkingDiff(workspaceSlug: string, expected: FileDiff[]): Promise<void> {
   if (!isDesktopClient()) throw new Error('Local Review is available only in the desktop app');
   await localApi.keepWorkingDiff(workspaceSlug, expected);
+}
+
+export async function getSpaceHistory(workspaceSlug: string): Promise<SpaceHistory> {
+  if (!isDesktopClient()) {
+    throw new Error('History is available only for local Spaces in the desktop app');
+  }
+  return localApi.history(workspaceSlug);
+}
+
+export async function createLocalCheckpoint(workspaceSlug: string, name?: string): Promise<Checkpoint> {
+  if (!isDesktopClient()) {
+    throw new Error('Checkpoints are available only for local Spaces in the desktop app');
+  }
+  return localApi.createCheckpoint(workspaceSlug, name);
 }
 
 export async function getReview(workspaceSlug: string, id: string): Promise<ReviewDetail> {

--- a/web/src/components/layout/SpacePanel.tsx
+++ b/web/src/components/layout/SpacePanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import {
   ChevronRight, FileText, Folder, Upload,
-  MoreHorizontal, Plus, FolderPlus, Settings, BookOpen, GitPullRequest, Users, Activity,
+  MoreHorizontal, Plus, FolderPlus, Settings, BookOpen, GitPullRequest, Users, History,
   FileCode, Pencil, Trash2, Search,
   PanelLeft,
 } from 'lucide-react';
@@ -13,7 +13,7 @@ import {
 import { C, spaceTileColors } from '@/lib/design';
 import { conceptIdFromPath, visiblePageTree } from '@/lib/okf-pages';
 
-export type NavTab = 'wiki' | 'reviews' | 'members' | 'activity';
+export type NavTab = 'wiki' | 'reviews' | 'members' | 'history';
 
 interface SpacePanelProps {
   workspace: Workspace | null;
@@ -93,7 +93,7 @@ export function SpacePanel({
     { tab: 'wiki', icon: <BookOpen size={16} />, label: 'Wiki' },
     { tab: 'reviews', icon: <GitPullRequest size={16} />, label: 'Reviews', badge: reviewCount || undefined, hide: !showReviews },
     { tab: 'members', icon: <Users size={16} />, label: 'Members & roles', hide: isPersonal },
-    { tab: 'activity', icon: <Activity size={16} />, label: 'Activity' },
+    { tab: 'history', icon: <History size={16} />, label: 'History' },
   ];
 
   const wikiActive = activeTab === 'wiki';

--- a/web/src/components/views/HistoryView.tsx
+++ b/web/src/components/views/HistoryView.tsx
@@ -15,7 +15,11 @@ import {
 } from '@/api';
 import { Button } from '@/components/ui/button';
 import { C } from '@/lib/design';
-import { defaultCheckpointName, draftChangeLabel } from '@/lib/history';
+import {
+  canCreateCheckpoint,
+  defaultCheckpointName,
+  draftChangeLabel,
+} from '@/lib/history';
 
 interface HistoryViewProps {
   workspaceSlug: string;
@@ -27,6 +31,7 @@ export function HistoryView({ workspaceSlug, local }: HistoryViewProps) {
   const [loading, setLoading] = useState(local);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState('');
+  const checkpointReady = canCreateCheckpoint(spaceHistory?.currentDraft.changedFiles);
 
   const refresh = useCallback(async () => {
     if (!local) return;
@@ -97,7 +102,9 @@ export function HistoryView({ workspaceSlug, local }: HistoryViewProps) {
                   <span style={currentBadgeStyle}>Live</span>
                 </div>
                 <p style={{ margin: '5px 0 0', color: C.ink2, fontSize: 12.5 }}>
-                  {spaceHistory ? draftChangeLabel(spaceHistory.currentDraft.changedFiles) : 'Reading saved Draft…'}
+                  {spaceHistory
+                    ? draftChangeLabel(spaceHistory.currentDraft.changedFiles, spaceHistory.checkpoints.length > 0)
+                    : 'Reading saved Draft…'}
                 </p>
                 <p style={{ margin: '8px 0 0', color: C.muted, fontSize: 12, lineHeight: 1.55 }}>
                   Auto Save updates this Draft only. It never creates a checkpoint.
@@ -107,12 +114,15 @@ export function HistoryView({ workspaceSlug, local }: HistoryViewProps) {
             <Button
               type="button"
               onClick={() => { void createCheckpoint(); }}
-              disabled={creating || loading}
+              disabled={creating || loading || !checkpointReady}
+              title={checkpointReady ? 'Record the current Draft as a local Git snapshot' : 'Save a change before creating another checkpoint'}
               style={{ flexShrink: 0 }}
             >
               {creating
                 ? <><LoaderCircle size={14} className="animate-spin" /> Creating…</>
-                : <><BookmarkPlus size={14} /> Create checkpoint</>}
+                : checkpointReady
+                  ? <><BookmarkPlus size={14} /> Create checkpoint</>
+                  : <><BookmarkPlus size={14} /> No new changes</>}
             </Button>
           </article>
 

--- a/web/src/components/views/HistoryView.tsx
+++ b/web/src/components/views/HistoryView.tsx
@@ -1,0 +1,282 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  BookmarkPlus,
+  CircleAlert,
+  FilePenLine,
+  GitCommitHorizontal,
+  History,
+  LoaderCircle,
+} from 'lucide-react';
+
+import {
+  createLocalCheckpoint,
+  getSpaceHistory,
+  type SpaceHistory,
+} from '@/api';
+import { Button } from '@/components/ui/button';
+import { C } from '@/lib/design';
+import { defaultCheckpointName, draftChangeLabel } from '@/lib/history';
+
+interface HistoryViewProps {
+  workspaceSlug: string;
+  local: boolean;
+}
+
+export function HistoryView({ workspaceSlug, local }: HistoryViewProps) {
+  const [spaceHistory, setSpaceHistory] = useState<SpaceHistory | null>(null);
+  const [loading, setLoading] = useState(local);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState('');
+
+  const refresh = useCallback(async () => {
+    if (!local) return;
+    setLoading(true);
+    setError('');
+    try {
+      setSpaceHistory(await getSpaceHistory(workspaceSlug));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not load Space history');
+    } finally {
+      setLoading(false);
+    }
+  }, [local, workspaceSlug]);
+
+  useEffect(() => {
+    const task = window.setTimeout(() => { void refresh(); }, 0);
+    return () => window.clearTimeout(task);
+  }, [refresh]);
+
+  const createCheckpoint = async () => {
+    setCreating(true);
+    setError('');
+    try {
+      await createLocalCheckpoint(workspaceSlug, defaultCheckpointName());
+      setSpaceHistory(await getSpaceHistory(workspaceSlug));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not create checkpoint');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <section style={{ width: 'min(760px, 100%)', margin: '0 auto' }}>
+      <header style={{ marginBottom: 30 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+          <History size={20} color={C.accent} strokeWidth={1.8} />
+          <h1 className="page-title page-title--compact" style={{ margin: 0 }}>History</h1>
+        </div>
+        <p style={{ margin: 0, maxWidth: 590, color: C.muted, fontSize: 13.5, lineHeight: 1.65 }}>
+          Your Space stays in one editable Draft. A checkpoint records a named local Git snapshot
+          without taking you out of that Draft.
+        </p>
+      </header>
+
+      {!local ? (
+        <div style={noticeStyle}>
+          <CircleAlert size={18} color={C.amber} />
+          <div>
+            <strong style={{ display: 'block', color: C.ink2, fontSize: 13.5, marginBottom: 3 }}>
+              Local history only
+            </strong>
+            <span style={{ color: C.muted, fontSize: 12.5, lineHeight: 1.55 }}>
+              Checkpoints are stored in the Space&apos;s local Git repository. Cloud history is not enabled.
+            </span>
+          </div>
+        </div>
+      ) : (
+        <>
+          <article style={draftCardStyle}>
+            <div style={{ display: 'flex', gap: 14, minWidth: 0, alignItems: 'flex-start' }}>
+              <div style={draftIconStyle}><FilePenLine size={19} /></div>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                  <h2 style={{ margin: 0, color: C.ink, fontFamily: 'var(--font-serif)', fontSize: 19, fontWeight: 650 }}>
+                    Current Draft
+                  </h2>
+                  <span style={currentBadgeStyle}>Live</span>
+                </div>
+                <p style={{ margin: '5px 0 0', color: C.ink2, fontSize: 12.5 }}>
+                  {spaceHistory ? draftChangeLabel(spaceHistory.currentDraft.changedFiles) : 'Reading saved Draft…'}
+                </p>
+                <p style={{ margin: '8px 0 0', color: C.muted, fontSize: 12, lineHeight: 1.55 }}>
+                  Auto Save updates this Draft only. It never creates a checkpoint.
+                </p>
+              </div>
+            </div>
+            <Button
+              type="button"
+              onClick={() => { void createCheckpoint(); }}
+              disabled={creating || loading}
+              style={{ flexShrink: 0 }}
+            >
+              {creating
+                ? <><LoaderCircle size={14} className="animate-spin" /> Creating…</>
+                : <><BookmarkPlus size={14} /> Create checkpoint</>}
+            </Button>
+          </article>
+
+          {error && (
+            <div role="alert" style={{ ...noticeStyle, marginTop: 14, borderColor: '#f0cbc5', background: C.redBgSoft }}>
+              <CircleAlert size={17} color={C.red} />
+              <span style={{ flex: 1, color: C.red, fontSize: 12.5 }}>{error}</span>
+              <button type="button" onClick={() => { void refresh(); }} style={retryStyle}>Retry</button>
+            </div>
+          )}
+
+          <div style={{ marginTop: 30 }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 14 }}>
+              <h2 style={{ margin: 0, color: C.ink2, fontSize: 12, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+                Checkpoints
+              </h2>
+              {spaceHistory && (
+                <span style={{ color: C.faint, fontSize: 11.5 }}>{spaceHistory.checkpoints.length} total</span>
+              )}
+            </div>
+
+            {loading ? (
+              <div style={emptyStyle}><LoaderCircle size={17} className="animate-spin" /> Loading history…</div>
+            ) : spaceHistory?.checkpoints.length ? (
+              <ol style={{ margin: 0, padding: 0, listStyle: 'none' }}>
+                {spaceHistory.checkpoints.map((checkpoint, index) => (
+                  <li key={checkpoint.id} style={{ position: 'relative', display: 'grid', gridTemplateColumns: '34px 1fr', gap: 12, paddingBottom: 18 }}>
+                    {index < spaceHistory.checkpoints.length - 1 && <span aria-hidden style={timelineStyle} />}
+                    <span style={commitIconStyle}><GitCommitHorizontal size={16} /></span>
+                    <div style={checkpointCardStyle}>
+                      <div style={{ minWidth: 0 }}>
+                        <strong style={{ display: 'block', color: C.ink2, fontSize: 13.5, fontWeight: 620, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                          {checkpoint.name}
+                        </strong>
+                        <time dateTime={new Date(checkpoint.createdAt * 1000).toISOString()} style={{ display: 'block', marginTop: 4, color: C.muted, fontSize: 11.5 }}>
+                          {new Date(checkpoint.createdAt * 1000).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' })}
+                        </time>
+                      </div>
+                      <code title={checkpoint.id} style={commitCodeStyle}>{checkpoint.id.slice(0, 8)}</code>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <div style={emptyStyle}>
+                No checkpoints yet. Your saved work is still in Current Draft.
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+const draftCardStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 22,
+  padding: '20px 20px 20px 18px',
+  border: `1px solid #edcbb7`,
+  borderRadius: 12,
+  background: 'linear-gradient(135deg, #fffaf5 0%, #fbeadd 100%)',
+};
+
+const draftIconStyle: React.CSSProperties = {
+  width: 38,
+  height: 38,
+  borderRadius: 11,
+  display: 'grid',
+  placeItems: 'center',
+  flexShrink: 0,
+  color: C.accent,
+  background: '#fff8f2',
+  border: '1px solid #f0d4c4',
+};
+
+const currentBadgeStyle: React.CSSProperties = {
+  padding: '2px 7px',
+  borderRadius: 999,
+  background: C.accent,
+  color: '#fff',
+  fontSize: 9.5,
+  fontWeight: 750,
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+};
+
+const noticeStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: 10,
+  padding: '14px 16px',
+  borderRadius: 9,
+  border: `1px solid ${C.line}`,
+  background: C.amberSoft,
+};
+
+const checkpointCardStyle: React.CSSProperties = {
+  minWidth: 0,
+  minHeight: 62,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 16,
+  padding: '12px 14px',
+  border: `1px solid ${C.line}`,
+  borderRadius: 9,
+  background: C.panel,
+};
+
+const commitIconStyle: React.CSSProperties = {
+  position: 'relative',
+  zIndex: 1,
+  width: 34,
+  height: 34,
+  display: 'grid',
+  placeItems: 'center',
+  borderRadius: 999,
+  color: C.green,
+  background: C.greenSoft,
+  border: '3px solid #faf9f7',
+};
+
+const timelineStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 31,
+  bottom: -3,
+  left: 16,
+  width: 1,
+  background: C.line,
+};
+
+const commitCodeStyle: React.CSSProperties = {
+  flexShrink: 0,
+  padding: '3px 7px',
+  borderRadius: 5,
+  color: C.muted,
+  background: C.rail,
+  fontSize: 10.5,
+  letterSpacing: '0.02em',
+};
+
+const emptyStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 8,
+  minHeight: 90,
+  padding: 20,
+  border: `1px dashed ${C.line}`,
+  borderRadius: 9,
+  color: C.muted,
+  fontSize: 12.5,
+  background: 'rgba(253, 252, 251, 0.55)',
+};
+
+const retryStyle: React.CSSProperties = {
+  border: 0,
+  padding: 0,
+  background: 'transparent',
+  color: C.red,
+  fontSize: 12,
+  fontWeight: 650,
+  cursor: 'pointer',
+};

--- a/web/src/lib/history.ts
+++ b/web/src/lib/history.ts
@@ -1,0 +1,16 @@
+function twoDigits(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+export function defaultCheckpointName(now = new Date()): string {
+  return [
+    `Checkpoint ${now.getFullYear()}-${twoDigits(now.getMonth() + 1)}-${twoDigits(now.getDate())}`,
+    `${twoDigits(now.getHours())}:${twoDigits(now.getMinutes())}`,
+  ].join(' ');
+}
+
+export function draftChangeLabel(changedFiles: number): string {
+  if (changedFiles === 0) return 'No saved changes in the current draft';
+  if (changedFiles === 1) return '1 saved file in the current draft';
+  return `${changedFiles} saved files in the current draft`;
+}

--- a/web/src/lib/history.ts
+++ b/web/src/lib/history.ts
@@ -9,8 +9,17 @@ export function defaultCheckpointName(now = new Date()): string {
   ].join(' ');
 }
 
-export function draftChangeLabel(changedFiles: number): string {
+export function draftChangeLabel(changedFiles: number, hasCheckpoint: boolean): string {
+  if (changedFiles === 0 && hasCheckpoint) return 'No changes since the latest checkpoint';
   if (changedFiles === 0) return 'No saved changes in the current draft';
+  if (hasCheckpoint) {
+    if (changedFiles === 1) return '1 saved file changed since the latest checkpoint';
+    return `${changedFiles} saved files changed since the latest checkpoint`;
+  }
   if (changedFiles === 1) return '1 saved file in the current draft';
   return `${changedFiles} saved files in the current draft`;
+}
+
+export function canCreateCheckpoint(changedFiles: number | undefined): boolean {
+  return changedFiles !== undefined && changedFiles > 0;
 }

--- a/web/src/local-api.ts
+++ b/web/src/local-api.ts
@@ -4,9 +4,11 @@ import type {
   PageMeta,
   FileDiff,
   IngestFileOutcome,
+  Checkpoint,
   SearchResponse,
   SourceContent,
   SourceItem,
+  SpaceHistory,
   Workspace,
 } from './api';
 
@@ -76,6 +78,14 @@ export function workingDiff(spaceSlug: string): Promise<FileDiff[]> {
 
 export function keepWorkingDiff(spaceSlug: string, expected: FileDiff[]): Promise<unknown> {
   return invoke('local_keep_working_diff', { spaceSlug, expected });
+}
+
+export function history(spaceSlug: string): Promise<SpaceHistory> {
+  return invoke('local_history', { spaceSlug });
+}
+
+export function createCheckpoint(spaceSlug: string, name?: string): Promise<Checkpoint> {
+  return invoke('local_create_checkpoint', { spaceSlug, name });
 }
 
 export function search(spaceSlug: string, query: string, limit: number): Promise<SearchResponse> {

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -30,6 +30,7 @@ type CreateSpaceMode = 'choose' | 'local' | 'import';
 import { ReviewList } from '../components/review/ReviewList';
 import { ReviewDetail } from '../components/review/ReviewDetail';
 import { MembersView } from '../components/views/MembersView';
+import { HistoryView } from '../components/views/HistoryView';
 import { InviteDialog } from '../components/InviteDialog';
 import { PageEditor, type PageEditorHandle } from '../components/PageEditor';
 import { PageByline } from '../components/PageByline';
@@ -66,7 +67,7 @@ type ActiveView =
   | { kind: 'review-list'; workspaceSlug: string }
   | { kind: 'review-detail'; workspaceSlug: string; submissionId: string }
   | { kind: 'members'; workspaceSlug: string }
-  | { kind: 'activity'; workspaceSlug: string }
+  | { kind: 'history'; workspaceSlug: string }
   | { kind: 'notifications' }
   | null;
 
@@ -579,9 +580,9 @@ export function MainLayout() {
         setActiveView({ kind: 'members', workspaceSlug: activeWorkspace.slug });
         navigate(`/${owner}/${activeWorkspace.slug}/members`);
         break;
-      case 'activity':
-        setActiveView({ kind: 'activity', workspaceSlug: activeWorkspace.slug });
-        navigate(`/${owner}/${activeWorkspace.slug}/activity`);
+      case 'history':
+        setActiveView({ kind: 'history', workspaceSlug: activeWorkspace.slug });
+        navigate(`/${owner}/${activeWorkspace.slug}/history`);
         break;
     }
   };
@@ -968,10 +969,10 @@ export function MainLayout() {
                     <span style={{ color: C.ink }}>Members</span>
                   </>
                 )}
-                {activeView?.kind === 'activity' && (
+                {activeView?.kind === 'history' && (
                   <>
                     <span style={{ color: C.faint }}>/</span>
-                    <span style={{ color: C.ink }}>Activity</span>
+                    <span style={{ color: C.ink }}>History</span>
                   </>
                 )}
                 {activeView?.kind === 'notifications' && (
@@ -1080,14 +1081,12 @@ export function MainLayout() {
                   onTransfer={() => setShowTransferDialog(activeWorkspace)}
                 />
 
-              /* Activity */
-              ) : activeView?.kind === 'activity' ? (
-                <div>
-                  <h1 className="page-title">
-                    Activity
-                  </h1>
-                  <p style={{ color: C.muted, fontSize: 13 }}>Activity feed coming soon.</p>
-                </div>
+              /* Space history */
+              ) : activeView?.kind === 'history' && activeWorkspace ? (
+                <HistoryView
+                  workspaceSlug={activeWorkspace.slug}
+                  local={desktop && !!activeWorkspace.localPath}
+                />
 
               /* Source view */
               ) : activeView?.kind === 'source' && activeView.content ? (

--- a/web/tests/history.test.ts
+++ b/web/tests/history.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { defaultCheckpointName, draftChangeLabel } from '../src/lib/history.ts';
+import {
+  canCreateCheckpoint,
+  defaultCheckpointName,
+  draftChangeLabel,
+} from '../src/lib/history.ts';
 
 const mainLayout = readFileSync(new URL('../src/pages/MainLayout.tsx', import.meta.url), 'utf8');
 const spacePanel = readFileSync(new URL('../src/components/layout/SpacePanel.tsx', import.meta.url), 'utf8');
@@ -14,9 +18,16 @@ test('checkpoint names use the user local date and time', () => {
 });
 
 test('the current draft distinguishes saved files from checkpoints', () => {
-  assert.equal(draftChangeLabel(0), 'No saved changes in the current draft');
-  assert.equal(draftChangeLabel(1), '1 saved file in the current draft');
-  assert.equal(draftChangeLabel(3), '3 saved files in the current draft');
+  assert.equal(draftChangeLabel(0, false), 'No saved changes in the current draft');
+  assert.equal(draftChangeLabel(1, false), '1 saved file in the current draft');
+  assert.equal(draftChangeLabel(3, true), '3 saved files changed since the latest checkpoint');
+  assert.equal(draftChangeLabel(0, true), 'No changes since the latest checkpoint');
+});
+
+test('a checkpoint requires at least one change from its baseline', () => {
+  assert.equal(canCreateCheckpoint(undefined), false);
+  assert.equal(canCreateCheckpoint(0), false);
+  assert.equal(canCreateCheckpoint(1), true);
 });
 
 test('space navigation replaces Activity with History', () => {

--- a/web/tests/history.test.ts
+++ b/web/tests/history.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { defaultCheckpointName, draftChangeLabel } from '../src/lib/history.ts';
+
+const mainLayout = readFileSync(new URL('../src/pages/MainLayout.tsx', import.meta.url), 'utf8');
+const spacePanel = readFileSync(new URL('../src/components/layout/SpacePanel.tsx', import.meta.url), 'utf8');
+
+test('checkpoint names use the user local date and time', () => {
+  const localTime = new Date(2026, 6, 15, 23, 5);
+
+  assert.equal(defaultCheckpointName(localTime), 'Checkpoint 2026-07-15 23:05');
+});
+
+test('the current draft distinguishes saved files from checkpoints', () => {
+  assert.equal(draftChangeLabel(0), 'No saved changes in the current draft');
+  assert.equal(draftChangeLabel(1), '1 saved file in the current draft');
+  assert.equal(draftChangeLabel(3), '3 saved files in the current draft');
+});
+
+test('space navigation replaces Activity with History', () => {
+  assert.doesNotMatch(spacePanel, /label: 'Activity'/);
+  assert.match(spacePanel, /label: 'History'/);
+  assert.doesNotMatch(mainLayout, /kind: 'activity'/);
+  assert.match(mainLayout, /kind: 'history'/);
+});


### PR DESCRIPTION
## Summary
- replace the placeholder Activity navigation with a Space-level History view
- show Current Draft plus named local checkpoints with timestamp and commit ID
- create immutable local Git snapshot commits under `refs/cowiki/checkpoints/<oid>` and track the latest checkpoint without moving `HEAD` or writing the real index
- compare Current Draft with the latest checkpoint (falling back to `HEAD` before the first checkpoint) and disable duplicate checkpoints when there are no new changes
- keep the feature local to the Tauri desktop engine; no Cloud API or sync behavior is added

## Save ≠ Checkpoint
Auto Save only writes the editable Current Draft. It does **not** create a Git commit, ref, or checkpoint.

Only **Create checkpoint** records a named Git snapshot. The user remains in Current Draft afterward; the current branch, `HEAD`, working tree, and real Git index stay in place.

## Test plan
- [x] `cd web && npm test` (40 tests)
- [x] `cd web && npm run build`
- [x] `cd web/src-tauri && cargo test` (65 tests)
- [x] `cd web/src-tauri && cargo fmt --check`
- [x] `cd web/src-tauri && cargo clippy --all-targets -- -D warnings`
- [x] ESLint on every touched Web source/test file (0 errors; 5 pre-existing `MainLayout.tsx` hook warnings)

## Notes
- Checkpoints are local-only and are not pushed or synchronized to CoWiki Cloud.
- This MVP lists checkpoint metadata and creates snapshots; restore, rename, and delete actions are intentionally out of scope.
- Repo-wide `npm run lint` still reports 20 pre-existing errors in unrelated files; this PR does not modify those files.
