### PR TITLE
feat(desktop): add live and background agent changes

### DIFF
--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "calamine",
  "docx-rs",
  "git2",
+ "libc",
  "pdf-extract",
  "percent-encoding",
  "portable-pty",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri = { version = "2", features = [] }
 time = "=0.3.44"
 url = "2"
 git2 = "0.20"
+libc = "0.2"
 portable-pty = "0.9"
 pulldown-cmark = "0.13"
 percent-encoding = "2"

--- a/web/src-tauri/src/lib.rs
+++ b/web/src-tauri/src/lib.rs
@@ -238,18 +238,22 @@ fn local_list_agent_changes(
 #[tauri::command]
 fn local_merge_agent_change(
     engine: State<'_, LocalEngine>,
+    terminals: State<'_, terminal::TerminalState>,
     space_slug: String,
     change_id: String,
 ) -> Result<AgentChange, String> {
+    let _closing = terminals.begin_change_close(&space_slug, &change_id)?;
     engine.merge_agent_change(&space_slug, &change_id)
 }
 
 #[tauri::command]
 fn local_discard_agent_change(
     engine: State<'_, LocalEngine>,
+    terminals: State<'_, terminal::TerminalState>,
     space_slug: String,
     change_id: String,
 ) -> Result<AgentChange, String> {
+    let _closing = terminals.begin_change_close(&space_slug, &change_id)?;
     engine.discard_agent_change(&space_slug, &change_id)
 }
 

--- a/web/src-tauri/src/lib.rs
+++ b/web/src-tauri/src/lib.rs
@@ -62,6 +62,7 @@ fn local_add_space(
     local_path: String,
     create_directory: bool,
 ) -> Result<Space, String> {
+    let _mutation = engine.lock_mutations()?;
     let selected = PathBuf::from(local_path);
     let folder = if create_directory {
         if name.trim().is_empty() || name.contains(['/', '\\']) || matches!(name.trim(), "." | "..")
@@ -104,6 +105,7 @@ fn local_write_page(
     expected_content: Option<String>,
     create_only: Option<bool>,
 ) -> Result<(), String> {
+    let _mutation = engine.lock_mutations()?;
     engine.write_page_checked(
         &space_slug,
         &page_slug,
@@ -120,6 +122,7 @@ fn local_create_folder(
     name: String,
     parent: Option<String>,
 ) -> Result<(), String> {
+    let _mutation = engine.lock_mutations()?;
     engine.create_folder(&space_slug, &name, parent.as_deref())
 }
 
@@ -148,6 +151,7 @@ fn local_ingest(
     content: String,
     filename: Option<String>,
 ) -> Result<SourceItem, String> {
+    let _mutation = engine.lock_mutations()?;
     engine.ingest(&space_slug, &source_type, &content, filename.as_deref())
 }
 
@@ -158,9 +162,12 @@ async fn local_ingest_files(
     source_paths: Vec<String>,
 ) -> Result<Vec<IngestFileOutcome>, String> {
     let engine = engine.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || engine.ingest_files(&space_slug, &source_paths))
-        .await
-        .map_err(|error| format!("local source import task failed: {error}"))?
+    tauri::async_runtime::spawn_blocking(move || {
+        let _mutation = engine.lock_mutations()?;
+        engine.ingest_files(&space_slug, &source_paths)
+    })
+    .await
+    .map_err(|error| format!("local source import task failed: {error}"))?
 }
 
 #[tauri::command]
@@ -170,6 +177,7 @@ fn local_rename_path(
     from: String,
     to: String,
 ) -> Result<(), String> {
+    let _mutation = engine.lock_mutations()?;
     engine.rename_path(&space_slug, &from, &to)
 }
 
@@ -179,6 +187,7 @@ fn local_delete_path(
     space_slug: String,
     path: String,
 ) -> Result<(), String> {
+    let _mutation = engine.lock_mutations()?;
     engine.delete_path(&space_slug, &path)
 }
 
@@ -198,6 +207,7 @@ fn local_submit(
     space_slug: String,
     paths: Vec<String>,
 ) -> Result<SubmitResult, String> {
+    let _mutation = engine.lock_mutations()?;
     engine.submit(&space_slug, &paths)
 }
 
@@ -206,6 +216,7 @@ fn local_working_diff(
     engine: State<'_, LocalEngine>,
     space_slug: String,
 ) -> Result<Vec<FileDiff>, String> {
+    let _mutation = engine.lock_mutations()?;
     engine.working_diff(&space_slug)
 }
 
@@ -215,6 +226,7 @@ fn local_keep_working_diff(
     space_slug: String,
     expected: Vec<FileDiff>,
 ) -> Result<SubmitResult, String> {
+    let _mutation = engine.lock_mutations()?;
     engine.keep_working_diff(&space_slug, &expected)
 }
 
@@ -224,6 +236,7 @@ fn local_create_agent_change(
     space_slug: String,
     agent_name: String,
 ) -> Result<AgentChange, String> {
+    let _mutation = engine.lock_mutations()?;
     engine.create_agent_change(&space_slug, &agent_name)
 }
 
@@ -242,7 +255,10 @@ fn local_merge_agent_change(
     space_slug: String,
     change_id: String,
 ) -> Result<AgentChange, String> {
+    // Lock order is terminal close gate, then Draft mutation. Terminal starts
+    // only touch their registry and never wait on the mutation lock.
     let _closing = terminals.begin_change_close(&space_slug, &change_id)?;
+    let _mutation = engine.lock_mutations()?;
     engine.merge_agent_change(&space_slug, &change_id)
 }
 
@@ -253,7 +269,9 @@ fn local_discard_agent_change(
     space_slug: String,
     change_id: String,
 ) -> Result<AgentChange, String> {
+    // Keep the same order as merge to avoid a registry/mutation lock cycle.
     let _closing = terminals.begin_change_close(&space_slug, &change_id)?;
+    let _mutation = engine.lock_mutations()?;
     engine.discard_agent_change(&space_slug, &change_id)
 }
 

--- a/web/src-tauri/src/lib.rs
+++ b/web/src-tauri/src/lib.rs
@@ -6,8 +6,8 @@ mod okf;
 mod terminal;
 
 use local_engine::{
-    FileDiff, IngestFileOutcome, LocalEngine, PageFull, PageMeta, SearchResponse, SourceContent,
-    SourceItem, Space, SubmitResult,
+    AgentChange, FileDiff, IngestFileOutcome, LocalEngine, PageFull, PageMeta, SearchResponse,
+    SourceContent, SourceItem, Space, SubmitResult,
 };
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -218,6 +218,41 @@ fn local_keep_working_diff(
     engine.keep_working_diff(&space_slug, &expected)
 }
 
+#[tauri::command]
+fn local_create_agent_change(
+    engine: State<'_, LocalEngine>,
+    space_slug: String,
+    agent_name: String,
+) -> Result<AgentChange, String> {
+    engine.create_agent_change(&space_slug, &agent_name)
+}
+
+#[tauri::command]
+fn local_list_agent_changes(
+    engine: State<'_, LocalEngine>,
+    space_slug: String,
+) -> Result<Vec<AgentChange>, String> {
+    engine.list_agent_changes(&space_slug)
+}
+
+#[tauri::command]
+fn local_merge_agent_change(
+    engine: State<'_, LocalEngine>,
+    space_slug: String,
+    change_id: String,
+) -> Result<AgentChange, String> {
+    engine.merge_agent_change(&space_slug, &change_id)
+}
+
+#[tauri::command]
+fn local_discard_agent_change(
+    engine: State<'_, LocalEngine>,
+    space_slug: String,
+    change_id: String,
+) -> Result<AgentChange, String> {
+    engine.discard_agent_change(&space_slug, &change_id)
+}
+
 pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
@@ -240,6 +275,10 @@ pub fn run() {
             local_submit,
             local_working_diff,
             local_keep_working_diff,
+            local_create_agent_change,
+            local_list_agent_changes,
+            local_merge_agent_change,
+            local_discard_agent_change,
             terminal::terminal_create,
             terminal::terminal_write,
             terminal::terminal_resize,

--- a/web/src-tauri/src/local_engine.rs
+++ b/web/src-tauri/src/local_engine.rs
@@ -97,6 +97,9 @@ pub struct FileDiff {
     pub path: String,
     pub old_content: Option<String>,
     pub new_content: Option<String>,
+    pub is_binary: bool,
+    pub old_binary_hash: Option<String>,
+    pub new_binary_hash: Option<String>,
     pub hunks: Vec<DiffHunk>,
     pub additions: usize,
     pub deletions: usize,
@@ -901,6 +904,14 @@ impl LocalEngine {
         reset_index_to_head(&repo, &mut index)?;
         for diff in expected {
             let path = safe_repo_path(&diff.path)?;
+            if diff.is_binary {
+                if diff.new_binary_hash.is_some() {
+                    index.add_path(path).map_err(|error| error.to_string())?;
+                } else {
+                    let _ = index.remove_path(path);
+                }
+                continue;
+            }
             if let Some(content) = &diff.new_content {
                 let entry = IndexEntry {
                     ctime: IndexTime::new(0, 0),
@@ -954,17 +965,17 @@ impl LocalEngine {
             if safe_repo_path(relative).is_err() {
                 continue;
             }
-            let old_content = head_text(&repo, relative)?;
+            let old_bytes = head_bytes(&repo, relative)?;
             let new_path = space.local_path.join(relative);
-            let new_content = if new_path.is_file() {
-                std::fs::read_to_string(&new_path).ok()
+            let new_bytes = if new_path.is_file() {
+                std::fs::read(&new_path).ok()
             } else {
                 None
             };
-            if old_content.is_none() && new_content.is_none() {
+            if old_bytes.is_none() && new_bytes.is_none() {
                 continue;
             }
-            result.push(text_file_diff(relative, old_content, new_content));
+            result.push(file_diff_from_bytes(relative, old_bytes, new_bytes));
         }
         result.sort_by(|left, right| left.path.cmp(&right.path));
         Ok(result)
@@ -1360,7 +1371,7 @@ fn commit_okf_migration(repo: &Repository) -> Result<(), String> {
     Ok(())
 }
 
-fn head_text(repo: &Repository, relative: &str) -> Result<Option<String>, String> {
+fn head_bytes(repo: &Repository, relative: &str) -> Result<Option<Vec<u8>>, String> {
     let Ok(head) = repo.head() else {
         return Ok(None);
     };
@@ -1372,9 +1383,60 @@ fn head_text(repo: &Repository, relative: &str) -> Result<Option<String>, String
     let blob = repo
         .find_blob(entry.id())
         .map_err(|error| error.to_string())?;
-    Ok(std::str::from_utf8(blob.content())
+    Ok(Some(blob.content().to_vec()))
+}
+
+fn file_diff_from_bytes(
+    path: &str,
+    old_bytes: Option<Vec<u8>>,
+    new_bytes: Option<Vec<u8>>,
+) -> FileDiff {
+    let old_content = old_bytes
+        .as_deref()
+        .map(std::str::from_utf8)
+        .transpose()
         .ok()
-        .map(ToOwned::to_owned))
+        .flatten()
+        .map(ToOwned::to_owned);
+    let new_content = new_bytes
+        .as_deref()
+        .map(std::str::from_utf8)
+        .transpose()
+        .ok()
+        .flatten()
+        .map(ToOwned::to_owned);
+    let is_binary = old_bytes.as_deref().is_some_and(is_binary_content)
+        || new_bytes.as_deref().is_some_and(is_binary_content);
+    if !is_binary {
+        return text_file_diff(path, old_content, new_content);
+    }
+    FileDiff {
+        path: path.to_string(),
+        old_content: None,
+        new_content: None,
+        is_binary: true,
+        old_binary_hash: old_bytes.as_deref().map(sha256_bytes),
+        new_binary_hash: new_bytes.as_deref().map(sha256_bytes),
+        hunks: vec![DiffHunk {
+            header: "Binary file changed".to_string(),
+            lines: vec![DiffLine {
+                kind: "ctx".to_string(),
+                old_line: None,
+                new_line: None,
+                text: "Binary file changed (contents cannot be displayed).".to_string(),
+            }],
+        }],
+        additions: 0,
+        deletions: 0,
+    }
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn is_binary_content(bytes: &[u8]) -> bool {
+    bytes.contains(&0) || std::str::from_utf8(bytes).is_err()
 }
 
 fn text_file_diff(
@@ -1429,6 +1491,9 @@ fn text_file_diff(
         path: path.to_string(),
         old_content,
         new_content,
+        is_binary: false,
+        old_binary_hash: None,
+        new_binary_hash: None,
         hunks: vec![DiffHunk {
             header: format!(
                 "@@ -1,{} +1,{} @@",
@@ -1705,6 +1770,7 @@ pub(crate) fn markdown_title(body: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{sha256_file, LocalEngine};
+    use git2::Repository;
 
     #[test]
     fn fresh_local_engine_waits_for_a_folder() {
@@ -2513,6 +2579,140 @@ mod tests {
     }
 
     #[test]
+    fn binary_draft_and_agent_deltas_remain_visible_and_merge_raw_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        let baseline = [0_u8, 159, 146, 150];
+        std::fs::write(folder.join("asset.bin"), baseline).unwrap();
+        engine
+            .submit(&space.slug, &["asset.bin".to_string()])
+            .unwrap();
+
+        let human_bytes = [0_u8, 255, 1, 2, 3];
+        std::fs::write(folder.join("asset.bin"), human_bytes).unwrap();
+        let draft = engine.working_diff(&space.slug).unwrap();
+        let binary_draft = draft.iter().find(|diff| diff.path == "asset.bin").unwrap();
+        assert!(binary_draft.is_binary);
+        assert!(binary_draft.old_binary_hash.is_some());
+        assert!(binary_draft.new_binary_hash.is_some());
+        assert!(binary_draft.hunks[0].lines[0].text.contains("Binary file"));
+        engine.keep_working_diff(&space.slug, &draft).unwrap();
+        assert!(engine.working_diff(&space.slug).unwrap().is_empty());
+
+        let change = engine.create_agent_change(&space.slug, "Codex").unwrap();
+        let agent_bytes = [255_u8, 0, 42, 11];
+        std::fs::write(change.worktree_path.join("asset.bin"), agent_bytes).unwrap();
+        let added_bytes = [254_u8, 253, 0, 1];
+        std::fs::write(change.worktree_path.join("new.bin"), added_bytes).unwrap();
+        let listed = engine.list_agent_changes(&space.slug).unwrap();
+        let modified = listed[0]
+            .diffs
+            .iter()
+            .find(|diff| diff.path == "asset.bin")
+            .unwrap();
+        let added = listed[0]
+            .diffs
+            .iter()
+            .find(|diff| diff.path == "new.bin")
+            .unwrap();
+        assert!(modified.is_binary);
+        assert!(modified.old_binary_hash.is_some());
+        assert!(modified.new_binary_hash.is_some());
+        assert!(added.is_binary);
+        assert!(added.old_binary_hash.is_none());
+        assert!(added.new_binary_hash.is_some());
+
+        let merged = engine.merge_agent_change(&space.slug, &change.id).unwrap();
+        assert_eq!(merged.status, "merged");
+        assert_eq!(
+            std::fs::read(folder.join("asset.bin")).unwrap(),
+            agent_bytes
+        );
+        assert_eq!(std::fs::read(folder.join("new.bin")).unwrap(), added_bytes);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ignored_symlink_parent_cannot_escape_draft_during_merge() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&folder).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        let change = engine.create_agent_change(&space.slug, "Codex").unwrap();
+        std::fs::create_dir_all(change.worktree_path.join("redirect")).unwrap();
+        std::fs::write(
+            change.worktree_path.join("redirect/escaped.md"),
+            "# Must stay inside\n",
+        )
+        .unwrap();
+        engine.list_agent_changes(&space.slug).unwrap();
+
+        std::fs::write(folder.join(".git/info/exclude"), "redirect/\n").unwrap();
+        symlink(&outside, folder.join("redirect")).unwrap();
+        let error = engine
+            .merge_agent_change(&space.slug, &change.id)
+            .unwrap_err();
+        assert!(error.to_lowercase().contains("symbolic link"));
+        assert!(!outside.join("escaped.md").exists());
+        assert!(folder.join("redirect").is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ignored_symlink_target_cannot_be_replaced_during_merge() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        let outside = temp.path().join("outside.md");
+        std::fs::create_dir_all(&folder).unwrap();
+        std::fs::write(&outside, "# Outside\n").unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        let change = engine.create_agent_change(&space.slug, "Codex").unwrap();
+        std::fs::write(change.worktree_path.join("escaped.md"), "# Agent result\n").unwrap();
+        engine.list_agent_changes(&space.slug).unwrap();
+
+        std::fs::write(folder.join(".git/info/exclude"), "escaped.md\n").unwrap();
+        symlink(&outside, folder.join("escaped.md")).unwrap();
+        let error = engine
+            .merge_agent_change(&space.slug, &change.id)
+            .unwrap_err();
+        assert!(error.to_lowercase().contains("symbolic link"));
+        assert_eq!(std::fs::read_to_string(outside).unwrap(), "# Outside\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_agent_worktree_rejects_symlink_replacement() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&folder).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        let change = engine.create_agent_change(&space.slug, "Codex").unwrap();
+        std::fs::remove_dir_all(&change.worktree_path).unwrap();
+        symlink(&outside, &change.worktree_path).unwrap();
+
+        let error = engine
+            .agent_change_worktree(&space.slug, &change.id)
+            .unwrap_err();
+        assert!(error.to_lowercase().contains("symbolic link"));
+    }
+
+    #[test]
     fn clean_agent_merge_preserves_human_draft_and_head() {
         let temp = tempfile::tempdir().unwrap();
         let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
@@ -2566,6 +2766,19 @@ mod tests {
         let draft = engine.working_diff(&space.slug).unwrap();
         assert!(draft.iter().any(|diff| diff.path == "human.md"));
         assert!(draft.iter().any(|diff| diff.path == "agent.md"));
+        assert!(!change.worktree_path.exists());
+        let repo = Repository::open(&folder).unwrap();
+        assert!(!repo
+            .path()
+            .join("worktrees")
+            .join(format!("cowiki-agent-{}", change.id))
+            .exists());
+        let closed = engine.list_agent_changes(&space.slug).unwrap();
+        assert_eq!(closed[0].status, "merged");
+        assert!(closed[0].diffs.iter().any(|diff| diff.path == "agent.md"));
+        assert!(engine
+            .agent_change_worktree(&space.slug, &change.id)
+            .is_err());
     }
 
     #[test]
@@ -2637,6 +2850,46 @@ mod tests {
                 .target()
                 .unwrap(),
             head_before
+        );
+        assert!(!change.worktree_path.exists());
+        let repo = Repository::open(&folder).unwrap();
+        assert!(!repo
+            .path()
+            .join("worktrees")
+            .join(format!("cowiki-agent-{}", change.id))
+            .exists());
+        let closed = engine.list_agent_changes(&space.slug).unwrap();
+        assert_eq!(closed[0].status, "discarded");
+        assert!(closed[0].diffs.iter().any(|diff| diff.path == "shared.md"));
+        assert!(engine
+            .agent_change_worktree(&space.slug, &change.id)
+            .is_err());
+    }
+
+    #[test]
+    fn concurrent_draft_change_before_write_is_not_overwritten() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        std::fs::write(folder.join("shared.md"), "# Baseline\n").unwrap();
+        engine.submit(&space.slug, &[]).unwrap();
+        let change = engine.create_agent_change(&space.slug, "Codex").unwrap();
+        std::fs::write(change.worktree_path.join("shared.md"), "# Agent result\n").unwrap();
+        let concurrent = b"# Concurrent human change\n".to_vec();
+
+        let error = engine
+            .merge_agent_change_with_pre_write_hook(&space.slug, &change.id, |_| {
+                std::fs::write(folder.join("shared.md"), &concurrent)
+                    .map_err(|error| error.to_string())
+            })
+            .unwrap_err();
+        assert!(error.contains("changed while"));
+        assert_eq!(std::fs::read(folder.join("shared.md")).unwrap(), concurrent);
+        assert_eq!(
+            engine.list_agent_changes(&space.slug).unwrap()[0].status,
+            "open"
         );
     }
 

--- a/web/src-tauri/src/local_engine.rs
+++ b/web/src-tauri/src/local_engine.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 use similar::{ChangeTag, TextDiff};
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::knowledge_index::{self, SearchHit};
 use crate::okf::{self, DocumentKind};
@@ -109,6 +109,10 @@ pub struct FileDiff {
 pub struct LocalEngine {
     db: Arc<Mutex<Connection>>,
     metadata_dir: PathBuf,
+    // Product-owned Draft writers serialize here. External filesystem writers
+    // cannot join this protocol, so merge still performs its final no-follow
+    // content CAS immediately before each replacement.
+    mutation_lock: Arc<Mutex<()>>,
 }
 
 impl LocalEngine {
@@ -131,9 +135,16 @@ impl LocalEngine {
         let engine = Self {
             db: Arc::new(Mutex::new(connection)),
             metadata_dir: metadata_dir.to_path_buf(),
+            mutation_lock: Arc::new(Mutex::new(())),
         };
         engine.rebuild_all_search_indexes()?;
         Ok(engine)
+    }
+
+    pub(crate) fn lock_mutations(&self) -> Result<MutexGuard<'_, ()>, String> {
+        self.mutation_lock
+            .lock()
+            .map_err(|_| "local mutation lock is unavailable".to_string())
     }
 
     pub fn list_spaces(&self) -> Result<Vec<Space>, String> {
@@ -1771,6 +1782,8 @@ pub(crate) fn markdown_title(body: &str) -> Option<String> {
 mod tests {
     use super::{sha256_file, LocalEngine};
     use git2::Repository;
+    use std::sync::{mpsc, Arc, Barrier};
+    use std::time::Duration;
 
     #[test]
     fn fresh_local_engine_waits_for_a_folder() {
@@ -1778,6 +1791,28 @@ mod tests {
         let engine = LocalEngine::open(temp.path()).unwrap();
 
         assert!(engine.list_spaces().unwrap().is_empty());
+    }
+
+    #[test]
+    fn cloned_engines_share_a_live_mutation_lock_that_releases_cleanly() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(temp.path()).unwrap();
+        let held = engine.lock_mutations().unwrap();
+        let contender = engine.clone();
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_barrier = barrier.clone();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            worker_barrier.wait();
+            let _guard = contender.lock_mutations().unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        barrier.wait();
+        assert!(acquired_rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(held);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        worker.join().unwrap();
     }
 
     #[test]
@@ -2891,6 +2926,67 @@ mod tests {
             engine.list_agent_changes(&space.slug).unwrap()[0].status,
             "open"
         );
+    }
+
+    #[test]
+    fn merged_change_succeeds_when_cleanup_fails_and_list_retries_cleanup() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        let change = engine.create_agent_change(&space.slug, "Codex").unwrap();
+        std::fs::write(change.worktree_path.join("agent.md"), "# Agent result\n").unwrap();
+
+        let merged = engine
+            .merge_agent_change_with_cleanup_hook(&space.slug, &change.id, || {
+                Err("injected cleanup failure".to_string())
+            })
+            .unwrap();
+        assert_eq!(merged.status, "merged");
+        assert!(merged.diffs.iter().any(|diff| diff.path == "agent.md"));
+        assert!(change.worktree_path.exists());
+        assert_eq!(
+            std::fs::read_to_string(folder.join("agent.md")).unwrap(),
+            "# Agent result\n"
+        );
+
+        let listed = engine.list_agent_changes(&space.slug).unwrap();
+        assert_eq!(listed[0].status, "merged");
+        assert!(listed[0].diffs.iter().any(|diff| diff.path == "agent.md"));
+        assert!(!change.worktree_path.exists());
+        assert!(engine
+            .agent_change_worktree(&space.slug, &change.id)
+            .is_err());
+    }
+
+    #[test]
+    fn discarded_change_succeeds_when_cleanup_fails_and_list_retries_cleanup() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        let change = engine.create_agent_change(&space.slug, "Codex").unwrap();
+        std::fs::write(change.worktree_path.join("agent.md"), "# Discard me\n").unwrap();
+
+        let discarded = engine
+            .discard_agent_change_with_cleanup_hook(&space.slug, &change.id, || {
+                Err("injected cleanup failure".to_string())
+            })
+            .unwrap();
+        assert_eq!(discarded.status, "discarded");
+        assert!(discarded.diffs.iter().any(|diff| diff.path == "agent.md"));
+        assert!(change.worktree_path.exists());
+        assert!(!folder.join("agent.md").exists());
+
+        let listed = engine.list_agent_changes(&space.slug).unwrap();
+        assert_eq!(listed[0].status, "discarded");
+        assert!(listed[0].diffs.iter().any(|diff| diff.path == "agent.md"));
+        assert!(!change.worktree_path.exists());
+        assert!(engine
+            .agent_change_worktree(&space.slug, &change.id)
+            .is_err());
     }
 
     #[test]

--- a/web/src-tauri/src/local_engine.rs
+++ b/web/src-tauri/src/local_engine.rs
@@ -11,6 +11,9 @@ use std::sync::{Arc, Mutex};
 use crate::knowledge_index::{self, SearchHit};
 use crate::okf::{self, DocumentKind};
 
+mod agent_changes;
+pub use agent_changes::AgentChange;
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Space {
@@ -102,6 +105,7 @@ pub struct FileDiff {
 #[derive(Clone)]
 pub struct LocalEngine {
     db: Arc<Mutex<Connection>>,
+    metadata_dir: PathBuf,
 }
 
 impl LocalEngine {
@@ -123,6 +127,7 @@ impl LocalEngine {
         knowledge_index::initialize(&connection)?;
         let engine = Self {
             db: Arc::new(Mutex::new(connection)),
+            metadata_dir: metadata_dir.to_path_buf(),
         };
         engine.rebuild_all_search_indexes()?;
         Ok(engine)
@@ -272,12 +277,6 @@ impl LocalEngine {
             .into_iter()
             .find(|space| space.slug == slug)
             .ok_or_else(|| format!("Space '{slug}' is not registered on this device"))
-    }
-
-    pub fn find_space_by_path(&self, path: &Path) -> Result<Space, String> {
-        let canonical = path.canonicalize().map_err(|e| e.to_string())?;
-        self.space_by_path(&canonical)?
-            .ok_or_else(|| "directory is not an opened CoWiki Space".to_string())
     }
 
     #[cfg(test)]
@@ -2472,6 +2471,173 @@ mod tests {
             .submit(&space.slug, &["draft.md".to_string()])
             .unwrap();
         assert!(engine.working_diff(&space.slug).unwrap().is_empty());
+    }
+
+    #[test]
+    fn background_agent_change_is_isolated_and_lists_its_diff() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        std::fs::write(folder.join("draft.md"), "# Draft at dispatch\n").unwrap();
+        let index_before = std::fs::read(folder.join(".git/index")).unwrap();
+
+        let change = engine.create_agent_change(&space.slug, "Codex").unwrap();
+        assert_eq!(
+            std::fs::read(folder.join(".git/index")).unwrap(),
+            index_before
+        );
+        assert_eq!(
+            std::fs::read_to_string(change.worktree_path.join("draft.md")).unwrap(),
+            "# Draft at dispatch\n"
+        );
+        std::fs::write(
+            change.worktree_path.join("agent.md"),
+            "# Background result\n",
+        )
+        .unwrap();
+
+        assert!(!folder.join("agent.md").exists());
+        let changes = engine.list_agent_changes(&space.slug).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].id, change.id);
+        assert_eq!(changes[0].status, "open");
+        let diff = changes[0]
+            .diffs
+            .iter()
+            .find(|diff| diff.path == "agent.md")
+            .unwrap();
+        assert!(diff.old_content.is_none());
+        assert_eq!(diff.new_content.as_deref(), Some("# Background result\n"));
+    }
+
+    #[test]
+    fn clean_agent_merge_preserves_human_draft_and_head() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        std::fs::write(folder.join("human.md"), "# Human baseline\n").unwrap();
+        std::fs::write(folder.join("agent.md"), "# Agent baseline\n").unwrap();
+        engine.submit(&space.slug, &[]).unwrap();
+        let change = engine.create_agent_change(&space.slug, "Codex").unwrap();
+        let head_before = git2::Repository::open(&folder)
+            .unwrap()
+            .head()
+            .unwrap()
+            .target()
+            .unwrap();
+
+        std::fs::write(folder.join("human.md"), "# Human latest Draft\n").unwrap();
+        let index_repo = git2::Repository::open(&folder).unwrap();
+        let mut user_index = index_repo.index().unwrap();
+        user_index
+            .add_path(std::path::Path::new("human.md"))
+            .unwrap();
+        user_index.write().unwrap();
+        drop(user_index);
+        drop(index_repo);
+        let index_before = std::fs::read(folder.join(".git/index")).unwrap();
+        std::fs::write(
+            change.worktree_path.join("agent.md"),
+            "# Background Agent result\n",
+        )
+        .unwrap();
+
+        let merged = engine.merge_agent_change(&space.slug, &change.id).unwrap();
+        assert_eq!(merged.status, "merged");
+        assert_eq!(
+            std::fs::read_to_string(folder.join("human.md")).unwrap(),
+            "# Human latest Draft\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(folder.join("agent.md")).unwrap(),
+            "# Background Agent result\n"
+        );
+        let repo = git2::Repository::open(&folder).unwrap();
+        assert_eq!(repo.head().unwrap().target().unwrap(), head_before);
+        assert_eq!(
+            std::fs::read(folder.join(".git/index")).unwrap(),
+            index_before
+        );
+        drop(repo);
+        let draft = engine.working_diff(&space.slug).unwrap();
+        assert!(draft.iter().any(|diff| diff.path == "human.md"));
+        assert!(draft.iter().any(|diff| diff.path == "agent.md"));
+    }
+
+    #[test]
+    fn conflicting_agent_merge_leaves_draft_bytes_unchanged() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        std::fs::write(folder.join("shared.md"), "# Shared baseline\n").unwrap();
+        engine.submit(&space.slug, &[]).unwrap();
+        let change = engine
+            .create_agent_change(&space.slug, "Claude Code")
+            .unwrap();
+
+        std::fs::write(folder.join("shared.md"), "# Human latest Draft\n").unwrap();
+        std::fs::write(
+            change.worktree_path.join("shared.md"),
+            "# Background Agent result\n",
+        )
+        .unwrap();
+        let draft_before = std::fs::read(folder.join("shared.md")).unwrap();
+
+        let conflict = engine.merge_agent_change(&space.slug, &change.id).unwrap();
+        assert_eq!(conflict.status, "needsResolution");
+        assert_eq!(
+            std::fs::read(folder.join("shared.md")).unwrap(),
+            draft_before
+        );
+        let listed = engine.list_agent_changes(&space.slug).unwrap();
+        assert_eq!(listed[0].status, "needsResolution");
+    }
+
+    #[test]
+    fn discarding_agent_change_does_not_modify_draft() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("notes");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Notes", "notes", &folder).unwrap();
+        std::fs::write(folder.join("shared.md"), "# Baseline\n").unwrap();
+        engine.submit(&space.slug, &[]).unwrap();
+        let change = engine
+            .create_agent_change(&space.slug, "Gemini CLI")
+            .unwrap();
+        std::fs::write(folder.join("shared.md"), "# Human Draft\n").unwrap();
+        std::fs::write(change.worktree_path.join("shared.md"), "# Agent result\n").unwrap();
+        let draft_before = std::fs::read(folder.join("shared.md")).unwrap();
+        let head_before = git2::Repository::open(&folder)
+            .unwrap()
+            .head()
+            .unwrap()
+            .target()
+            .unwrap();
+
+        let discarded = engine
+            .discard_agent_change(&space.slug, &change.id)
+            .unwrap();
+        assert_eq!(discarded.status, "discarded");
+        assert_eq!(
+            std::fs::read(folder.join("shared.md")).unwrap(),
+            draft_before
+        );
+        assert_eq!(
+            git2::Repository::open(&folder)
+                .unwrap()
+                .head()
+                .unwrap()
+                .target()
+                .unwrap(),
+            head_before
+        );
     }
 
     #[test]

--- a/web/src-tauri/src/local_engine/agent_changes.rs
+++ b/web/src-tauri/src/local_engine/agent_changes.rs
@@ -1,7 +1,8 @@
-use super::{safe_repo_path, text_file_diff, FileDiff, LocalEngine};
+use super::{file_diff_from_bytes, safe_repo_path, FileDiff, LocalEngine};
 use git2::{Oid, Repository, Signature, StatusOptions};
 use serde::Serialize;
 use std::collections::BTreeSet;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 const BASE_REF_PREFIX: &str = "refs/cowiki/agent-bases/";
@@ -58,10 +59,14 @@ impl LocalEngine {
             return Err(error.to_string());
         }
 
-        let worktree_path = self.change_worktree_path(&space.id, &id);
-        if let Some(parent) = worktree_path.parent() {
-            std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
-        }
+        let worktree_path = match self.prepare_change_worktree_path(&space.id, &id) {
+            Ok(path) => path,
+            Err(error) => {
+                delete_reference_if_present(&repo, &branch_ref);
+                delete_reference_if_present(&repo, &base_ref);
+                return Err(error);
+            }
+        };
         let branch = repo
             .find_reference(&branch_ref)
             .map_err(|error| error.to_string())?;
@@ -113,6 +118,31 @@ impl LocalEngine {
         space_slug: &str,
         change_id: &str,
     ) -> Result<AgentChange, String> {
+        self.merge_agent_change_internal(space_slug, change_id, |_| Ok(()))
+    }
+
+    #[cfg(test)]
+    pub fn merge_agent_change_with_pre_write_hook<F>(
+        &self,
+        space_slug: &str,
+        change_id: &str,
+        before_write: F,
+    ) -> Result<AgentChange, String>
+    where
+        F: FnMut(&Path) -> Result<(), String>,
+    {
+        self.merge_agent_change_internal(space_slug, change_id, before_write)
+    }
+
+    fn merge_agent_change_internal<F>(
+        &self,
+        space_slug: &str,
+        change_id: &str,
+        mut before_write: F,
+    ) -> Result<AgentChange, String>
+    where
+        F: FnMut(&Path) -> Result<(), String>,
+    {
         validate_change_id(change_id)?;
         let space = self.find_space(space_slug)?;
         let repo = Repository::open(&space.local_path).map_err(|error| error.to_string())?;
@@ -155,7 +185,13 @@ impl LocalEngine {
         let merged_tree = repo
             .find_tree(merged_tree_id)
             .map_err(|error| error.to_string())?;
-        apply_tree_transition(&repo, &space.local_path, &draft_tree, &merged_tree)?;
+        apply_tree_transition(
+            &repo,
+            &space.local_path,
+            &draft_tree,
+            &merged_tree,
+            &mut before_write,
+        )?;
         repo.reference(
             &merged_ref(change_id),
             result_id,
@@ -164,6 +200,7 @@ impl LocalEngine {
         )
         .map_err(|error| error.to_string())?;
         delete_reference_if_present(&repo, &conflict_ref(change_id));
+        self.cleanup_agent_worktree(&repo, &space.id, change_id)?;
         drop(merged_tree);
         drop(result_tree);
         drop(base_tree);
@@ -192,6 +229,7 @@ impl LocalEngine {
         )
         .map_err(|error| error.to_string())?;
         delete_reference_if_present(&repo, &conflict_ref(change_id));
+        self.cleanup_agent_worktree(&repo, &space.id, change_id)?;
         drop(repo);
         self.agent_change(space_slug, change_id)
     }
@@ -204,11 +242,8 @@ impl LocalEngine {
         validate_change_id(change_id)?;
         let space = self.find_space(space_slug)?;
         let repo = Repository::open(&space.local_path).map_err(|error| error.to_string())?;
-        reference_commit(&repo, &base_ref(change_id))?;
-        let worktree_path = self.change_worktree_path(&space.id, change_id);
-        worktree_path
-            .canonicalize()
-            .map_err(|error| format!("Agent Change worktree is unavailable: {error}"))
+        ensure_active_change(&repo, change_id)?;
+        self.validate_managed_worktree_path(&space.id, change_id)
     }
 
     fn agent_change(&self, space_slug: &str, change_id: &str) -> Result<AgentChange, String> {
@@ -247,10 +282,7 @@ impl LocalEngine {
     ) -> Result<Oid, String> {
         let branch_ref = branch_ref(change_id);
         let current = reference_commit(repo, &branch_ref)?;
-        let worktree_path = self.change_worktree_path(space_id, change_id);
-        if !worktree_path.is_dir() {
-            return Ok(current.id());
-        }
+        let worktree_path = self.validate_managed_worktree_path(space_id, change_id)?;
         let worktree_repo = Repository::open(&worktree_path).map_err(|error| error.to_string())?;
         let head_name = worktree_repo
             .head()
@@ -279,9 +311,69 @@ impl LocalEngine {
 
     fn change_worktree_path(&self, space_id: &str, change_id: &str) -> PathBuf {
         self.metadata_dir
+            .canonicalize()
+            .unwrap_or_else(|_| self.metadata_dir.clone())
             .join("agent-worktrees")
             .join(space_id)
             .join(change_id)
+    }
+
+    fn prepare_change_worktree_path(
+        &self,
+        space_id: &str,
+        change_id: &str,
+    ) -> Result<PathBuf, String> {
+        validate_change_id(change_id)?;
+        let metadata = self
+            .metadata_dir
+            .canonicalize()
+            .map_err(|error| error.to_string())?;
+        let parent = ensure_safe_directory_tree(
+            &metadata,
+            Path::new("agent-worktrees").join(space_id).as_path(),
+        )?;
+        let path = parent.join(change_id);
+        if std::fs::symlink_metadata(&path).is_ok() {
+            return Err("Agent Change worktree path already exists".to_string());
+        }
+        Ok(path)
+    }
+
+    fn validate_managed_worktree_path(
+        &self,
+        space_id: &str,
+        change_id: &str,
+    ) -> Result<PathBuf, String> {
+        let metadata = self
+            .metadata_dir
+            .canonicalize()
+            .map_err(|error| error.to_string())?;
+        let expected = metadata
+            .join("agent-worktrees")
+            .join(space_id)
+            .join(change_id);
+        validate_no_symlink_components(&metadata, &expected)?;
+        let canonical = expected
+            .canonicalize()
+            .map_err(|error| format!("Agent Change worktree is unavailable: {error}"))?;
+        if canonical != expected || !canonical.starts_with(&metadata) || !canonical.is_dir() {
+            return Err("Agent Change worktree escaped its managed location".to_string());
+        }
+        Ok(canonical)
+    }
+
+    fn cleanup_agent_worktree(
+        &self,
+        repo: &Repository,
+        space_id: &str,
+        change_id: &str,
+    ) -> Result<(), String> {
+        let worktree_path = self.validate_managed_worktree_path(space_id, change_id)?;
+        std::fs::remove_dir_all(&worktree_path).map_err(|error| error.to_string())?;
+        let worktree = repo
+            .find_worktree(&worktree_name(change_id))
+            .map_err(|error| error.to_string())?;
+        worktree.prune(None).map_err(|error| error.to_string())
     }
 }
 
@@ -313,7 +405,9 @@ fn snapshot_worktree(repo: &Repository) -> Result<Oid, String> {
         let Some(relative) = status.path() else {
             continue;
         };
-        let relative = safe_repo_path(relative)?;
+        let Ok(relative) = safe_repo_path(relative) else {
+            continue;
+        };
         if std::fs::symlink_metadata(root.join(relative)).is_ok() {
             index
                 .add_path(relative)
@@ -350,22 +444,26 @@ fn tree_diffs(
         if safe_repo_path(path_text).is_err() {
             continue;
         }
-        let old_content = tree_text(repo, old_tree, &path)?;
-        let new_content = tree_text(repo, new_tree, &path)?;
-        if old_content.is_none() && new_content.is_none() {
+        let old_bytes = tree_bytes(repo, old_tree, &path)?;
+        let new_bytes = tree_bytes(repo, new_tree, &path)?;
+        if old_bytes.is_none() && new_bytes.is_none() {
             continue;
         }
-        result.push(text_file_diff(path_text, old_content, new_content));
+        result.push(file_diff_from_bytes(path_text, old_bytes, new_bytes));
     }
     Ok(result)
 }
 
-fn apply_tree_transition(
+fn apply_tree_transition<F>(
     repo: &Repository,
     root: &Path,
     from_tree: &git2::Tree<'_>,
     to_tree: &git2::Tree<'_>,
-) -> Result<(), String> {
+    before_write: &mut F,
+) -> Result<(), String>
+where
+    F: FnMut(&Path) -> Result<(), String>,
+{
     let diff = repo
         .diff_tree_to_tree(Some(from_tree), Some(to_tree), None)
         .map_err(|error| error.to_string())?;
@@ -385,9 +483,8 @@ fn apply_tree_transition(
             .to_str()
             .ok_or_else(|| "merged Agent Change contains a non-UTF-8 path".to_string())?;
         safe_repo_path(relative_text)?;
-        let path = root.join(&relative);
         let expected = tree_bytes(repo, from_tree, &relative)?;
-        let actual = read_optional_file(&path)?;
+        let actual = read_optional_file_no_follow(root, &relative)?;
         if actual != expected {
             return Err(
                 "The current Draft changed while the Agent Change was merging. Retry the merge."
@@ -395,28 +492,37 @@ fn apply_tree_transition(
             );
         }
         let target = tree_bytes(repo, to_tree, &relative)?;
-        operations.push((path, actual, target));
+        operations.push((relative, actual, target));
     }
 
-    let mut applied = 0usize;
-    for (path, _, target) in &operations {
-        if let Err(error) = write_optional_file(path, target.as_deref()) {
-            for (rollback_path, previous, _) in operations[..applied].iter().rev() {
-                let _ = write_optional_file(rollback_path, previous.as_deref());
+    for (applied, (relative, previous, target)) in operations.iter().enumerate() {
+        before_write(&root.join(relative))?;
+        if let Err(error) =
+            write_optional_file_cas(root, relative, previous.as_deref(), target.as_deref())
+        {
+            let mut rollback_errors = Vec::new();
+            for (rollback_path, rollback_previous, rollback_target) in
+                operations[..applied].iter().rev()
+            {
+                if let Err(rollback_error) = write_optional_file_cas(
+                    root,
+                    rollback_path,
+                    rollback_target.as_deref(),
+                    rollback_previous.as_deref(),
+                ) {
+                    rollback_errors.push(format!("{}: {rollback_error}", rollback_path.display()));
+                }
+            }
+            if !rollback_errors.is_empty() {
+                return Err(format!(
+                    "{error}; concurrent changes prevented rollback for {}",
+                    rollback_errors.join(", ")
+                ));
             }
             return Err(error);
         }
-        applied += 1;
     }
     Ok(())
-}
-
-fn tree_text(
-    repo: &Repository,
-    tree: &git2::Tree<'_>,
-    path: &Path,
-) -> Result<Option<String>, String> {
-    Ok(tree_bytes(repo, tree, path)?.and_then(|bytes| String::from_utf8(bytes).ok()))
 }
 
 fn tree_bytes(
@@ -436,37 +542,203 @@ fn tree_bytes(
     Ok(Some(blob.content().to_vec()))
 }
 
-fn read_optional_file(path: &Path) -> Result<Option<Vec<u8>>, String> {
-    match std::fs::read(path) {
-        Ok(bytes) => Ok(Some(bytes)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error.to_string()),
+fn read_optional_file_no_follow(root: &Path, relative: &Path) -> Result<Option<Vec<u8>>, String> {
+    let path = root.join(relative);
+    validate_no_symlink_components(root, &path)?;
+    let metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "symbolic link target is not allowed while merging: {}",
+            path.display()
+        ));
     }
+    if !metadata.is_file() {
+        return Err(format!(
+            "merged path is not a regular file: {}",
+            path.display()
+        ));
+    }
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options.open(&path).map_err(|error| error.to_string())?;
+    if !file
+        .metadata()
+        .map_err(|error| error.to_string())?
+        .is_file()
+    {
+        return Err(format!(
+            "merged path is not a regular file: {}",
+            path.display()
+        ));
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|error| error.to_string())?;
+    Ok(Some(bytes))
 }
 
-fn write_optional_file(path: &Path, content: Option<&[u8]>) -> Result<(), String> {
+fn write_optional_file_cas(
+    root: &Path,
+    relative: &Path,
+    expected: Option<&[u8]>,
+    content: Option<&[u8]>,
+) -> Result<(), String> {
+    let path = root.join(relative);
+    if content.is_some() {
+        ensure_safe_parent_directories(root, relative)?;
+    }
+    ensure_expected_content(root, relative, expected)?;
     match content {
         Some(content) => {
             let parent = path
                 .parent()
                 .ok_or_else(|| "merged path has no parent directory".to_string())?;
-            std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+            validate_no_symlink_components(root, parent)?;
             let temporary = parent.join(format!(
                 ".cowiki-merge-{}.tmp",
                 uuid::Uuid::new_v4().simple()
             ));
-            std::fs::write(&temporary, content).map_err(|error| error.to_string())?;
-            if let Err(error) = std::fs::rename(&temporary, path) {
+            let mut options = std::fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+            }
+            let mut file = options
+                .open(&temporary)
+                .map_err(|error| error.to_string())?;
+            if let Err(error) = file.write_all(content).and_then(|_| file.flush()) {
+                drop(file);
+                let _ = std::fs::remove_file(&temporary);
+                return Err(error.to_string());
+            }
+            drop(file);
+            validate_no_symlink_components(root, parent)?;
+            if let Err(error) = ensure_expected_content(root, relative, expected) {
+                let _ = std::fs::remove_file(&temporary);
+                return Err(error);
+            }
+            if let Err(error) = std::fs::rename(&temporary, &path) {
                 let _ = std::fs::remove_file(&temporary);
                 return Err(error.to_string());
             }
             Ok(())
         }
-        None => match std::fs::remove_file(path) {
-            Ok(()) => Ok(()),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(error.to_string()),
-        },
+        None => {
+            ensure_expected_content(root, relative, expected)?;
+            match std::fs::remove_file(&path) {
+                Ok(()) => Ok(()),
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::NotFound && expected.is_none() =>
+                {
+                    Ok(())
+                }
+                Err(error) => Err(error.to_string()),
+            }
+        }
+    }
+}
+
+fn ensure_expected_content(
+    root: &Path,
+    relative: &Path,
+    expected: Option<&[u8]>,
+) -> Result<(), String> {
+    let current = read_optional_file_no_follow(root, relative)?;
+    if current.as_deref() != expected {
+        return Err(
+            "The current Draft changed while the Agent Change was merging. Retry the merge."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn ensure_safe_parent_directories(root: &Path, relative: &Path) -> Result<(), String> {
+    let parent = relative
+        .parent()
+        .ok_or_else(|| "merged path has no parent directory".to_string())?;
+    ensure_safe_directory_tree(root, parent).map(|_| ())
+}
+
+fn ensure_safe_directory_tree(root: &Path, relative: &Path) -> Result<PathBuf, String> {
+    let mut current = root.to_path_buf();
+    validate_directory(&current)?;
+    for component in relative.components() {
+        let std::path::Component::Normal(component) = component else {
+            return Err("managed path may not escape its root".to_string());
+        };
+        current.push(component);
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) => validate_directory_metadata(&current, &metadata)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match std::fs::create_dir(&current) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                    Err(error) => return Err(error.to_string()),
+                }
+                validate_directory(&current)?;
+            }
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    Ok(current)
+}
+
+fn validate_no_symlink_components(root: &Path, path: &Path) -> Result<(), String> {
+    let relative = path
+        .strip_prefix(root)
+        .map_err(|_| "managed path escaped its root".to_string())?;
+    validate_directory(root)?;
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        let std::path::Component::Normal(component) = component else {
+            return Err("managed path may not escape its root".to_string());
+        };
+        current.push(component);
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(format!(
+                    "symbolic link is not allowed in managed path: {}",
+                    current.display()
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    Ok(())
+}
+
+fn validate_directory(path: &Path) -> Result<(), String> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    validate_directory_metadata(path, &metadata)
+}
+
+fn validate_directory_metadata(path: &Path, metadata: &std::fs::Metadata) -> Result<(), String> {
+    if metadata.file_type().is_symlink() {
+        Err(format!(
+            "symbolic link is not allowed in managed path: {}",
+            path.display()
+        ))
+    } else if !metadata.is_dir() {
+        Err(format!(
+            "managed path is not a directory: {}",
+            path.display()
+        ))
+    } else {
+        Ok(())
     }
 }
 

--- a/web/src-tauri/src/local_engine/agent_changes.rs
+++ b/web/src-tauri/src/local_engine/agent_changes.rs
@@ -1,0 +1,546 @@
+use super::{safe_repo_path, text_file_diff, FileDiff, LocalEngine};
+use git2::{Oid, Repository, Signature, StatusOptions};
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+const BASE_REF_PREFIX: &str = "refs/cowiki/agent-bases/";
+const BRANCH_REF_PREFIX: &str = "refs/heads/cowiki/agent/";
+const CONFLICT_REF_PREFIX: &str = "refs/cowiki/agent-conflicts/";
+const MERGED_REF_PREFIX: &str = "refs/cowiki/agent-merged/";
+const DISCARDED_REF_PREFIX: &str = "refs/cowiki/agent-discarded/";
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentChange {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub created_at: i64,
+    pub worktree_path: PathBuf,
+    pub diffs: Vec<FileDiff>,
+}
+
+impl LocalEngine {
+    pub fn create_agent_change(
+        &self,
+        space_slug: &str,
+        agent_name: &str,
+    ) -> Result<AgentChange, String> {
+        let space = self.find_space(space_slug)?;
+        let repo = Repository::open(&space.local_path).map_err(|error| error.to_string())?;
+        let parent = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .map_err(|_| "the Space needs a Git checkpoint before running an Agent".to_string())?;
+        let tree_id = snapshot_worktree(&repo)?;
+        let tree = repo.find_tree(tree_id).map_err(|error| error.to_string())?;
+        let signature = Signature::now("CoWiki Agent", "agent@cowiki.app")
+            .map_err(|error| error.to_string())?;
+        let id = uuid::Uuid::new_v4().to_string();
+        let title = clean_agent_name(agent_name);
+        let base_ref = base_ref(&id);
+        let base_id = repo
+            .commit(
+                Some(&base_ref),
+                &signature,
+                &signature,
+                &format!("CoWiki Agent Change: {title}"),
+                &tree,
+                &[&parent],
+            )
+            .map_err(|error| error.to_string())?;
+        let branch_ref = branch_ref(&id);
+        if let Err(error) =
+            repo.reference(&branch_ref, base_id, false, "Create CoWiki Agent Change")
+        {
+            delete_reference_if_present(&repo, &base_ref);
+            return Err(error.to_string());
+        }
+
+        let worktree_path = self.change_worktree_path(&space.id, &id);
+        if let Some(parent) = worktree_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        let branch = repo
+            .find_reference(&branch_ref)
+            .map_err(|error| error.to_string())?;
+        let mut options = git2::WorktreeAddOptions::new();
+        options.reference(Some(&branch));
+        if let Err(error) = repo.worktree(&worktree_name(&id), &worktree_path, Some(&options)) {
+            delete_reference_if_present(&repo, &branch_ref);
+            delete_reference_if_present(&repo, &base_ref);
+            return Err(error.to_string());
+        }
+
+        self.agent_change(space_slug, &id)
+    }
+
+    pub fn list_agent_changes(&self, space_slug: &str) -> Result<Vec<AgentChange>, String> {
+        let repo = self.repo(space_slug)?;
+        let mut ids = Vec::new();
+        let references = repo
+            .references_glob(&format!("{BASE_REF_PREFIX}*"))
+            .map_err(|error| error.to_string())?;
+        for reference in references {
+            let reference = reference.map_err(|error| error.to_string())?;
+            if let Some(id) = reference
+                .name()
+                .and_then(|name| name.strip_prefix(BASE_REF_PREFIX))
+            {
+                if uuid::Uuid::parse_str(id).is_ok() {
+                    ids.push(id.to_string());
+                }
+            }
+        }
+        drop(repo);
+
+        let mut changes = ids
+            .iter()
+            .map(|id| self.agent_change(space_slug, id))
+            .collect::<Result<Vec<_>, _>>()?;
+        changes.sort_by(|left, right| {
+            right
+                .created_at
+                .cmp(&left.created_at)
+                .then_with(|| right.id.cmp(&left.id))
+        });
+        Ok(changes)
+    }
+
+    pub fn merge_agent_change(
+        &self,
+        space_slug: &str,
+        change_id: &str,
+    ) -> Result<AgentChange, String> {
+        validate_change_id(change_id)?;
+        let space = self.find_space(space_slug)?;
+        let repo = Repository::open(&space.local_path).map_err(|error| error.to_string())?;
+        ensure_active_change(&repo, change_id)?;
+        let result_id = self.capture_agent_result(&space.id, &repo, change_id)?;
+        let base_commit = reference_commit(&repo, &base_ref(change_id))?;
+        let result_commit = repo
+            .find_commit(result_id)
+            .map_err(|error| error.to_string())?;
+        let draft_tree_id = snapshot_worktree(&repo)?;
+        let draft_tree = repo
+            .find_tree(draft_tree_id)
+            .map_err(|error| error.to_string())?;
+        let base_tree = base_commit.tree().map_err(|error| error.to_string())?;
+        let result_tree = result_commit.tree().map_err(|error| error.to_string())?;
+        let mut merged_index = repo
+            .merge_trees(&base_tree, &draft_tree, &result_tree, None)
+            .map_err(|error| error.to_string())?;
+
+        if merged_index.has_conflicts() {
+            repo.reference(
+                &conflict_ref(change_id),
+                result_id,
+                true,
+                "CoWiki Agent Change needs resolution",
+            )
+            .map_err(|error| error.to_string())?;
+            drop(result_tree);
+            drop(base_tree);
+            drop(draft_tree);
+            drop(result_commit);
+            drop(base_commit);
+            drop(repo);
+            return self.agent_change(space_slug, change_id);
+        }
+
+        let merged_tree_id = merged_index
+            .write_tree_to(&repo)
+            .map_err(|error| error.to_string())?;
+        let merged_tree = repo
+            .find_tree(merged_tree_id)
+            .map_err(|error| error.to_string())?;
+        apply_tree_transition(&repo, &space.local_path, &draft_tree, &merged_tree)?;
+        repo.reference(
+            &merged_ref(change_id),
+            result_id,
+            true,
+            "Merge CoWiki Agent Change into Draft",
+        )
+        .map_err(|error| error.to_string())?;
+        delete_reference_if_present(&repo, &conflict_ref(change_id));
+        drop(merged_tree);
+        drop(result_tree);
+        drop(base_tree);
+        drop(draft_tree);
+        drop(result_commit);
+        drop(base_commit);
+        drop(repo);
+        self.agent_change(space_slug, change_id)
+    }
+
+    pub fn discard_agent_change(
+        &self,
+        space_slug: &str,
+        change_id: &str,
+    ) -> Result<AgentChange, String> {
+        validate_change_id(change_id)?;
+        let space = self.find_space(space_slug)?;
+        let repo = Repository::open(&space.local_path).map_err(|error| error.to_string())?;
+        ensure_active_change(&repo, change_id)?;
+        let result_id = self.capture_agent_result(&space.id, &repo, change_id)?;
+        repo.reference(
+            &discarded_ref(change_id),
+            result_id,
+            true,
+            "Discard CoWiki Agent Change",
+        )
+        .map_err(|error| error.to_string())?;
+        delete_reference_if_present(&repo, &conflict_ref(change_id));
+        drop(repo);
+        self.agent_change(space_slug, change_id)
+    }
+
+    pub fn agent_change_worktree(
+        &self,
+        space_slug: &str,
+        change_id: &str,
+    ) -> Result<PathBuf, String> {
+        validate_change_id(change_id)?;
+        let space = self.find_space(space_slug)?;
+        let repo = Repository::open(&space.local_path).map_err(|error| error.to_string())?;
+        reference_commit(&repo, &base_ref(change_id))?;
+        let worktree_path = self.change_worktree_path(&space.id, change_id);
+        worktree_path
+            .canonicalize()
+            .map_err(|error| format!("Agent Change worktree is unavailable: {error}"))
+    }
+
+    fn agent_change(&self, space_slug: &str, change_id: &str) -> Result<AgentChange, String> {
+        validate_change_id(change_id)?;
+        let space = self.find_space(space_slug)?;
+        let repo = Repository::open(&space.local_path).map_err(|error| error.to_string())?;
+        let status = change_status(&repo, change_id);
+        if status == "open" || status == "needsResolution" {
+            self.capture_agent_result(&space.id, &repo, change_id)?;
+        }
+        let base_commit = reference_commit(&repo, &base_ref(change_id))?;
+        let result_commit = reference_commit(&repo, &branch_ref(change_id))?;
+        let base_tree = base_commit.tree().map_err(|error| error.to_string())?;
+        let result_tree = result_commit.tree().map_err(|error| error.to_string())?;
+        let diffs = tree_diffs(&repo, &base_tree, &result_tree)?;
+        let title = base_commit
+            .summary()
+            .and_then(|summary| summary.strip_prefix("CoWiki Agent Change: "))
+            .unwrap_or("Agent Change")
+            .to_string();
+        Ok(AgentChange {
+            id: change_id.to_string(),
+            title,
+            status: change_status(&repo, change_id).to_string(),
+            created_at: base_commit.time().seconds(),
+            worktree_path: self.change_worktree_path(&space.id, change_id),
+            diffs,
+        })
+    }
+
+    fn capture_agent_result(
+        &self,
+        space_id: &str,
+        repo: &Repository,
+        change_id: &str,
+    ) -> Result<Oid, String> {
+        let branch_ref = branch_ref(change_id);
+        let current = reference_commit(repo, &branch_ref)?;
+        let worktree_path = self.change_worktree_path(space_id, change_id);
+        if !worktree_path.is_dir() {
+            return Ok(current.id());
+        }
+        let worktree_repo = Repository::open(&worktree_path).map_err(|error| error.to_string())?;
+        let head_name = worktree_repo
+            .head()
+            .ok()
+            .and_then(|head| head.name().map(ToOwned::to_owned));
+        if head_name.as_deref() != Some(branch_ref.as_str()) {
+            return Err("Agent Change left its managed Git branch".to_string());
+        }
+        let tree_id = snapshot_worktree(&worktree_repo)?;
+        if tree_id == current.tree_id() {
+            return Ok(current.id());
+        }
+        let tree = repo.find_tree(tree_id).map_err(|error| error.to_string())?;
+        let signature = Signature::now("CoWiki Agent", "agent@cowiki.app")
+            .map_err(|error| error.to_string())?;
+        repo.commit(
+            Some(&branch_ref),
+            &signature,
+            &signature,
+            "Capture CoWiki Agent result",
+            &tree,
+            &[&current],
+        )
+        .map_err(|error| error.to_string())
+    }
+
+    fn change_worktree_path(&self, space_id: &str, change_id: &str) -> PathBuf {
+        self.metadata_dir
+            .join("agent-worktrees")
+            .join(space_id)
+            .join(change_id)
+    }
+}
+
+fn snapshot_worktree(repo: &Repository) -> Result<Oid, String> {
+    let root = repo
+        .workdir()
+        .ok_or_else(|| "Git worktree has no working directory".to_string())?;
+    let head = repo
+        .head()
+        .and_then(|head| head.peel_to_commit())
+        .map_err(|error| error.to_string())?;
+    let head_tree = head.tree().map_err(|error| error.to_string())?;
+    // This is a detached in-memory view of the repository's index. It is
+    // deliberately never written, so staged user state remains byte-for-byte
+    // untouched while libgit2 writes only new blob/tree objects.
+    let mut index = repo.index().map_err(|error| error.to_string())?;
+    index
+        .read_tree(&head_tree)
+        .map_err(|error| error.to_string())?;
+    let mut options = StatusOptions::new();
+    options
+        .include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .include_ignored(false);
+    let statuses = repo
+        .statuses(Some(&mut options))
+        .map_err(|error| error.to_string())?;
+    for status in statuses.iter() {
+        let Some(relative) = status.path() else {
+            continue;
+        };
+        let relative = safe_repo_path(relative)?;
+        if std::fs::symlink_metadata(root.join(relative)).is_ok() {
+            index
+                .add_path(relative)
+                .map_err(|error| error.to_string())?;
+        } else {
+            let _ = index.remove_path(relative);
+        }
+    }
+    index.write_tree().map_err(|error| error.to_string())
+}
+
+fn tree_diffs(
+    repo: &Repository,
+    old_tree: &git2::Tree<'_>,
+    new_tree: &git2::Tree<'_>,
+) -> Result<Vec<FileDiff>, String> {
+    let diff = repo
+        .diff_tree_to_tree(Some(old_tree), Some(new_tree), None)
+        .map_err(|error| error.to_string())?;
+    let mut paths = BTreeSet::new();
+    for delta in diff.deltas() {
+        if let Some(path) = delta.old_file().path() {
+            paths.insert(path.to_path_buf());
+        }
+        if let Some(path) = delta.new_file().path() {
+            paths.insert(path.to_path_buf());
+        }
+    }
+    let mut result = Vec::new();
+    for path in paths {
+        let path_text = path
+            .to_str()
+            .ok_or_else(|| "Agent Change contains a non-UTF-8 path".to_string())?;
+        if safe_repo_path(path_text).is_err() {
+            continue;
+        }
+        let old_content = tree_text(repo, old_tree, &path)?;
+        let new_content = tree_text(repo, new_tree, &path)?;
+        if old_content.is_none() && new_content.is_none() {
+            continue;
+        }
+        result.push(text_file_diff(path_text, old_content, new_content));
+    }
+    Ok(result)
+}
+
+fn apply_tree_transition(
+    repo: &Repository,
+    root: &Path,
+    from_tree: &git2::Tree<'_>,
+    to_tree: &git2::Tree<'_>,
+) -> Result<(), String> {
+    let diff = repo
+        .diff_tree_to_tree(Some(from_tree), Some(to_tree), None)
+        .map_err(|error| error.to_string())?;
+    let mut paths = BTreeSet::new();
+    for delta in diff.deltas() {
+        if let Some(path) = delta.old_file().path() {
+            paths.insert(path.to_path_buf());
+        }
+        if let Some(path) = delta.new_file().path() {
+            paths.insert(path.to_path_buf());
+        }
+    }
+
+    let mut operations = Vec::new();
+    for relative in paths {
+        let relative_text = relative
+            .to_str()
+            .ok_or_else(|| "merged Agent Change contains a non-UTF-8 path".to_string())?;
+        safe_repo_path(relative_text)?;
+        let path = root.join(&relative);
+        let expected = tree_bytes(repo, from_tree, &relative)?;
+        let actual = read_optional_file(&path)?;
+        if actual != expected {
+            return Err(
+                "The current Draft changed while the Agent Change was merging. Retry the merge."
+                    .to_string(),
+            );
+        }
+        let target = tree_bytes(repo, to_tree, &relative)?;
+        operations.push((path, actual, target));
+    }
+
+    let mut applied = 0usize;
+    for (path, _, target) in &operations {
+        if let Err(error) = write_optional_file(path, target.as_deref()) {
+            for (rollback_path, previous, _) in operations[..applied].iter().rev() {
+                let _ = write_optional_file(rollback_path, previous.as_deref());
+            }
+            return Err(error);
+        }
+        applied += 1;
+    }
+    Ok(())
+}
+
+fn tree_text(
+    repo: &Repository,
+    tree: &git2::Tree<'_>,
+    path: &Path,
+) -> Result<Option<String>, String> {
+    Ok(tree_bytes(repo, tree, path)?.and_then(|bytes| String::from_utf8(bytes).ok()))
+}
+
+fn tree_bytes(
+    repo: &Repository,
+    tree: &git2::Tree<'_>,
+    path: &Path,
+) -> Result<Option<Vec<u8>>, String> {
+    let Ok(entry) = tree.get_path(path) else {
+        return Ok(None);
+    };
+    let blob = repo.find_blob(entry.id()).map_err(|error| {
+        format!(
+            "Agent Change path '{}' is not a regular file: {error}",
+            path.display()
+        )
+    })?;
+    Ok(Some(blob.content().to_vec()))
+}
+
+fn read_optional_file(path: &Path) -> Result<Option<Vec<u8>>, String> {
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn write_optional_file(path: &Path, content: Option<&[u8]>) -> Result<(), String> {
+    match content {
+        Some(content) => {
+            let parent = path
+                .parent()
+                .ok_or_else(|| "merged path has no parent directory".to_string())?;
+            std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+            let temporary = parent.join(format!(
+                ".cowiki-merge-{}.tmp",
+                uuid::Uuid::new_v4().simple()
+            ));
+            std::fs::write(&temporary, content).map_err(|error| error.to_string())?;
+            if let Err(error) = std::fs::rename(&temporary, path) {
+                let _ = std::fs::remove_file(&temporary);
+                return Err(error.to_string());
+            }
+            Ok(())
+        }
+        None => match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.to_string()),
+        },
+    }
+}
+
+fn reference_commit<'repo>(
+    repo: &'repo Repository,
+    reference_name: &str,
+) -> Result<git2::Commit<'repo>, String> {
+    repo.find_reference(reference_name)
+        .and_then(|reference| reference.peel_to_commit())
+        .map_err(|_| "Agent Change does not exist".to_string())
+}
+
+fn ensure_active_change(repo: &Repository, change_id: &str) -> Result<(), String> {
+    reference_commit(repo, &base_ref(change_id))?;
+    match change_status(repo, change_id) {
+        "merged" => Err("Agent Change is already merged".to_string()),
+        "discarded" => Err("Agent Change is already discarded".to_string()),
+        _ => Ok(()),
+    }
+}
+
+fn change_status(repo: &Repository, change_id: &str) -> &'static str {
+    if repo.find_reference(&discarded_ref(change_id)).is_ok() {
+        "discarded"
+    } else if repo.find_reference(&merged_ref(change_id)).is_ok() {
+        "merged"
+    } else if repo.find_reference(&conflict_ref(change_id)).is_ok() {
+        "needsResolution"
+    } else {
+        "open"
+    }
+}
+
+fn clean_agent_name(value: &str) -> String {
+    let value = value.lines().next().unwrap_or_default().trim();
+    if value.is_empty() {
+        "Agent Change".to_string()
+    } else {
+        value.chars().take(80).collect()
+    }
+}
+
+fn validate_change_id(change_id: &str) -> Result<(), String> {
+    uuid::Uuid::parse_str(change_id)
+        .map(|_| ())
+        .map_err(|_| "invalid Agent Change id".to_string())
+}
+
+fn base_ref(change_id: &str) -> String {
+    format!("{BASE_REF_PREFIX}{change_id}")
+}
+
+fn branch_ref(change_id: &str) -> String {
+    format!("{BRANCH_REF_PREFIX}{change_id}")
+}
+
+fn conflict_ref(change_id: &str) -> String {
+    format!("{CONFLICT_REF_PREFIX}{change_id}")
+}
+
+fn merged_ref(change_id: &str) -> String {
+    format!("{MERGED_REF_PREFIX}{change_id}")
+}
+
+fn discarded_ref(change_id: &str) -> String {
+    format!("{DISCARDED_REF_PREFIX}{change_id}")
+}
+
+fn worktree_name(change_id: &str) -> String {
+    format!("cowiki-agent-{change_id}")
+}
+
+fn delete_reference_if_present(repo: &Repository, name: &str) {
+    if let Ok(mut reference) = repo.find_reference(name) {
+        let _ = reference.delete();
+    }
+}

--- a/web/src-tauri/src/local_engine/agent_changes.rs
+++ b/web/src-tauri/src/local_engine/agent_changes.rs
@@ -82,6 +82,7 @@ impl LocalEngine {
     }
 
     pub fn list_agent_changes(&self, space_slug: &str) -> Result<Vec<AgentChange>, String> {
+        let space = self.find_space(space_slug)?;
         let repo = self.repo(space_slug)?;
         let mut ids = Vec::new();
         let references = repo
@@ -95,6 +96,13 @@ impl LocalEngine {
             {
                 if uuid::Uuid::parse_str(id).is_ok() {
                     ids.push(id.to_string());
+                }
+            }
+        }
+        for id in &ids {
+            if matches!(change_status(&repo, id), "merged" | "discarded") {
+                if let Err(error) = self.cleanup_agent_worktree(&repo, &space.id, id) {
+                    warn_cleanup_failure(id, &error);
                 }
             }
         }
@@ -118,7 +126,12 @@ impl LocalEngine {
         space_slug: &str,
         change_id: &str,
     ) -> Result<AgentChange, String> {
-        self.merge_agent_change_internal(space_slug, change_id, |_| Ok(()))
+        self.merge_agent_change_internal(
+            space_slug,
+            change_id,
+            |_| Ok(()),
+            |engine, repo, space_id, id| engine.cleanup_agent_worktree(repo, space_id, id),
+        )
     }
 
     #[cfg(test)]
@@ -131,17 +144,42 @@ impl LocalEngine {
     where
         F: FnMut(&Path) -> Result<(), String>,
     {
-        self.merge_agent_change_internal(space_slug, change_id, before_write)
+        self.merge_agent_change_internal(
+            space_slug,
+            change_id,
+            before_write,
+            |engine, repo, space_id, id| engine.cleanup_agent_worktree(repo, space_id, id),
+        )
     }
 
-    fn merge_agent_change_internal<F>(
+    #[cfg(test)]
+    pub fn merge_agent_change_with_cleanup_hook<C>(
+        &self,
+        space_slug: &str,
+        change_id: &str,
+        mut cleanup: C,
+    ) -> Result<AgentChange, String>
+    where
+        C: FnMut() -> Result<(), String>,
+    {
+        self.merge_agent_change_internal(
+            space_slug,
+            change_id,
+            |_| Ok(()),
+            move |_, _, _, _| cleanup(),
+        )
+    }
+
+    fn merge_agent_change_internal<F, C>(
         &self,
         space_slug: &str,
         change_id: &str,
         mut before_write: F,
+        mut cleanup: C,
     ) -> Result<AgentChange, String>
     where
         F: FnMut(&Path) -> Result<(), String>,
+        C: FnMut(&LocalEngine, &Repository, &str, &str) -> Result<(), String>,
     {
         validate_change_id(change_id)?;
         let space = self.find_space(space_slug)?;
@@ -200,7 +238,9 @@ impl LocalEngine {
         )
         .map_err(|error| error.to_string())?;
         delete_reference_if_present(&repo, &conflict_ref(change_id));
-        self.cleanup_agent_worktree(&repo, &space.id, change_id)?;
+        if let Err(error) = cleanup(self, &repo, &space.id, change_id) {
+            warn_cleanup_failure(change_id, &error);
+        }
         drop(merged_tree);
         drop(result_tree);
         drop(base_tree);
@@ -216,6 +256,33 @@ impl LocalEngine {
         space_slug: &str,
         change_id: &str,
     ) -> Result<AgentChange, String> {
+        self.discard_agent_change_internal(space_slug, change_id, |engine, repo, space_id, id| {
+            engine.cleanup_agent_worktree(repo, space_id, id)
+        })
+    }
+
+    #[cfg(test)]
+    pub fn discard_agent_change_with_cleanup_hook<C>(
+        &self,
+        space_slug: &str,
+        change_id: &str,
+        mut cleanup: C,
+    ) -> Result<AgentChange, String>
+    where
+        C: FnMut() -> Result<(), String>,
+    {
+        self.discard_agent_change_internal(space_slug, change_id, move |_, _, _, _| cleanup())
+    }
+
+    fn discard_agent_change_internal<C>(
+        &self,
+        space_slug: &str,
+        change_id: &str,
+        mut cleanup: C,
+    ) -> Result<AgentChange, String>
+    where
+        C: FnMut(&LocalEngine, &Repository, &str, &str) -> Result<(), String>,
+    {
         validate_change_id(change_id)?;
         let space = self.find_space(space_slug)?;
         let repo = Repository::open(&space.local_path).map_err(|error| error.to_string())?;
@@ -229,7 +296,9 @@ impl LocalEngine {
         )
         .map_err(|error| error.to_string())?;
         delete_reference_if_present(&repo, &conflict_ref(change_id));
-        self.cleanup_agent_worktree(&repo, &space.id, change_id)?;
+        if let Err(error) = cleanup(self, &repo, &space.id, change_id) {
+            warn_cleanup_failure(change_id, &error);
+        }
         drop(repo);
         self.agent_change(space_slug, change_id)
     }
@@ -368,13 +437,27 @@ impl LocalEngine {
         space_id: &str,
         change_id: &str,
     ) -> Result<(), String> {
-        let worktree_path = self.validate_managed_worktree_path(space_id, change_id)?;
-        std::fs::remove_dir_all(&worktree_path).map_err(|error| error.to_string())?;
-        let worktree = repo
-            .find_worktree(&worktree_name(change_id))
-            .map_err(|error| error.to_string())?;
-        worktree.prune(None).map_err(|error| error.to_string())
+        let worktree_path = self.change_worktree_path(space_id, change_id);
+        match std::fs::symlink_metadata(&worktree_path) {
+            Ok(_) => {
+                let worktree_path = self.validate_managed_worktree_path(space_id, change_id)?;
+                std::fs::remove_dir_all(&worktree_path).map_err(|error| error.to_string())?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.to_string()),
+        }
+        match repo.find_worktree(&worktree_name(change_id)) {
+            Ok(worktree) => worktree.prune(None).map_err(|error| error.to_string()),
+            Err(error) if error.code() == git2::ErrorCode::NotFound => Ok(()),
+            Err(error) => Err(error.to_string()),
+        }
     }
+}
+
+fn warn_cleanup_failure(change_id: &str, error: &str) {
+    eprintln!(
+        "CoWiki closed Agent Change '{change_id}' but could not clean its worktree; cleanup will retry when Reviews reload: {error}"
+    );
 }
 
 fn snapshot_worktree(repo: &Repository) -> Result<Oid, String> {

--- a/web/src-tauri/src/terminal.rs
+++ b/web/src-tauri/src/terminal.rs
@@ -7,7 +7,8 @@
 use crate::local_engine::LocalEngine;
 use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtySize};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -95,15 +96,205 @@ struct TerminalExitEvent {
 }
 
 struct TerminalSession {
+    identity: TerminalIdentity,
     // Keeping the master alive owns the PTY and enables resize.
     master: Box<dyn MasterPty + Send>,
     writer: Box<dyn Write + Send>,
     killer: Box<dyn ChildKiller + Send + Sync>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TerminalIdentity {
+    space_slug: String,
+    change_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AgentChangeIdentity {
+    space_slug: String,
+    change_id: String,
+}
+
+enum TerminalSlot {
+    Starting(TerminalIdentity),
+    Running(TerminalSession),
+}
+
+impl TerminalSlot {
+    fn identity(&self) -> &TerminalIdentity {
+        match self {
+            Self::Starting(identity) => identity,
+            Self::Running(session) => &session.identity,
+        }
+    }
+
+    fn running(&self) -> Option<&TerminalSession> {
+        match self {
+            Self::Running(session) => Some(session),
+            Self::Starting(_) => None,
+        }
+    }
+
+    fn running_mut(&mut self) -> Option<&mut TerminalSession> {
+        match self {
+            Self::Running(session) => Some(session),
+            Self::Starting(_) => None,
+        }
+    }
+}
+
+#[derive(Default)]
+struct TerminalRegistry {
+    sessions: HashMap<String, TerminalSlot>,
+    closing_changes: HashSet<AgentChangeIdentity>,
+}
+
 #[derive(Clone, Default)]
 pub struct TerminalState {
-    sessions: Arc<Mutex<HashMap<String, TerminalSession>>>,
+    registry: Arc<Mutex<TerminalRegistry>>,
+}
+
+pub(crate) struct TerminalChangeGuard {
+    registry: Arc<Mutex<TerminalRegistry>>,
+    identity: AgentChangeIdentity,
+}
+
+struct TerminalStartReservation {
+    state: TerminalState,
+    session_id: String,
+    active: bool,
+}
+
+impl TerminalStartReservation {
+    fn new(
+        state: TerminalState,
+        session_id: &str,
+        identity: TerminalIdentity,
+    ) -> Result<Self, String> {
+        state.reserve_session(session_id, identity)?;
+        Ok(Self {
+            state,
+            session_id: session_id.to_string(),
+            active: true,
+        })
+    }
+
+    fn finish(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for TerminalStartReservation {
+    fn drop(&mut self) {
+        if self.active {
+            self.state.release_session(&self.session_id);
+        }
+    }
+}
+
+impl fmt::Debug for TerminalChangeGuard {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TerminalChangeGuard")
+            .field("identity", &self.identity)
+            .finish()
+    }
+}
+
+impl Drop for TerminalChangeGuard {
+    fn drop(&mut self) {
+        if let Ok(mut registry) = self.registry.lock() {
+            registry.closing_changes.remove(&self.identity);
+        }
+    }
+}
+
+impl TerminalState {
+    fn reserve_session(&self, session_id: &str, identity: TerminalIdentity) -> Result<(), String> {
+        let mut registry = self
+            .registry
+            .lock()
+            .map_err(|_| "terminal state is unavailable".to_string())?;
+        if registry.sessions.contains_key(session_id) {
+            return Err("terminal session already exists".to_string());
+        }
+        if let Some(change_id) = identity.change_id.as_ref() {
+            let change = AgentChangeIdentity {
+                space_slug: identity.space_slug.clone(),
+                change_id: change_id.clone(),
+            };
+            if registry.closing_changes.contains(&change) {
+                return Err("Agent Change is being closed; its terminal cannot restart".to_string());
+            }
+        }
+        registry
+            .sessions
+            .insert(session_id.to_string(), TerminalSlot::Starting(identity));
+        Ok(())
+    }
+
+    fn install_session(&self, session_id: &str, session: TerminalSession) -> Result<(), String> {
+        let mut registry = self
+            .registry
+            .lock()
+            .map_err(|_| "terminal state is unavailable".to_string())?;
+        let Some(TerminalSlot::Starting(identity)) = registry.sessions.get(session_id) else {
+            return Err("terminal session reservation was lost".to_string());
+        };
+        if identity != &session.identity {
+            return Err("terminal session identity changed while starting".to_string());
+        }
+        registry
+            .sessions
+            .insert(session_id.to_string(), TerminalSlot::Running(session));
+        Ok(())
+    }
+
+    fn release_session(&self, session_id: &str) -> Option<TerminalSession> {
+        self.registry
+            .lock()
+            .ok()?
+            .sessions
+            .remove(session_id)
+            .and_then(|slot| match slot {
+                TerminalSlot::Running(session) => Some(session),
+                TerminalSlot::Starting(_) => None,
+            })
+    }
+
+    pub(crate) fn begin_change_close(
+        &self,
+        space_slug: &str,
+        change_id: &str,
+    ) -> Result<TerminalChangeGuard, String> {
+        let identity = AgentChangeIdentity {
+            space_slug: space_slug.to_string(),
+            change_id: change_id.to_string(),
+        };
+        let mut registry = self
+            .registry
+            .lock()
+            .map_err(|_| "terminal state is unavailable".to_string())?;
+        let has_active_terminal = registry.sessions.values().any(|slot| {
+            let terminal = slot.identity();
+            terminal.space_slug == identity.space_slug
+                && terminal.change_id.as_deref() == Some(identity.change_id.as_str())
+        });
+        if has_active_terminal {
+            return Err(
+                "Stop the active background terminal before merging or discarding this Agent Change."
+                    .to_string(),
+            );
+        }
+        if !registry.closing_changes.insert(identity.clone()) {
+            return Err("Agent Change is already being closed".to_string());
+        }
+        drop(registry);
+        Ok(TerminalChangeGuard {
+            registry: self.registry.clone(),
+            identity,
+        })
+    }
 }
 
 #[tauri::command]
@@ -124,6 +315,12 @@ pub fn terminal_create(
     let space = local_engine.find_space(&request.space_slug)?;
     validate_initial_command(request.agent, request.initial_command.as_deref())?;
     let size = normalized_pty_size(request.cols, request.rows);
+    let identity = TerminalIdentity {
+        space_slug: request.space_slug.clone(),
+        change_id: request.change_id.clone(),
+    };
+    let mut reservation =
+        TerminalStartReservation::new(state.inner().clone(), &session_id, identity.clone())?;
 
     let pair = native_pty_system()
         .openpty(size)
@@ -160,25 +357,19 @@ pub fn terminal_create(
         .and_then(|_| writer.flush())
         .map_err(|error| format!("failed to start {}: {error}", request.agent.command()))?;
 
-    let mut sessions = state
-        .sessions
-        .lock()
-        .map_err(|_| "terminal state is unavailable".to_string())?;
-    if sessions.contains_key(&session_id) {
-        return Err("terminal session already exists".to_string());
-    }
-    sessions.insert(
-        session_id.clone(),
+    state.install_session(
+        &session_id,
         TerminalSession {
+            identity,
             master: pair.master,
             writer,
             killer,
         },
-    );
-    drop(sessions);
+    )?;
+    reservation.finish();
 
     spawn_output_forwarder(app.clone(), session_id.clone(), reader);
-    spawn_exit_watcher(app, session_id.clone(), state.sessions.clone(), child);
+    spawn_exit_watcher(app, session_id.clone(), state.inner().clone(), child);
 
     Ok(TerminalCreated { session_id })
 }
@@ -261,12 +452,14 @@ pub fn terminal_write(
     session_id: String,
     data: String,
 ) -> Result<(), String> {
-    let mut sessions = state
-        .sessions
+    let mut registry = state
+        .registry
         .lock()
         .map_err(|_| "terminal state is unavailable".to_string())?;
-    let session = sessions
+    let session = registry
+        .sessions
         .get_mut(&session_id)
+        .and_then(TerminalSlot::running_mut)
         .ok_or_else(|| format!("unknown terminal session: {session_id}"))?;
     session
         .writer
@@ -282,12 +475,14 @@ pub fn terminal_resize(
     cols: u16,
     rows: u16,
 ) -> Result<(), String> {
-    let sessions = state
-        .sessions
+    let registry = state
+        .registry
         .lock()
         .map_err(|_| "terminal state is unavailable".to_string())?;
-    let session = sessions
+    let session = registry
+        .sessions
         .get(&session_id)
+        .and_then(TerminalSlot::running)
         .ok_or_else(|| format!("unknown terminal session: {session_id}"))?;
     session
         .master
@@ -297,17 +492,17 @@ pub fn terminal_resize(
 
 #[tauri::command]
 pub fn terminal_kill(state: State<'_, TerminalState>, session_id: String) -> Result<(), String> {
-    let session = state
-        .sessions
+    let mut registry = state
+        .registry
         .lock()
-        .map_err(|_| "terminal state is unavailable".to_string())?
-        .remove(&session_id);
-    if let Some(mut session) = session {
+        .map_err(|_| "terminal state is unavailable".to_string())?;
+    if let Some(TerminalSlot::Running(session)) = registry.sessions.get_mut(&session_id) {
         session
             .killer
             .kill()
             .map_err(|error| format!("failed to stop terminal: {error}"))?;
     }
+    registry.sessions.remove(&session_id);
     Ok(())
 }
 
@@ -335,14 +530,12 @@ fn spawn_output_forwarder(app: AppHandle, session_id: String, mut reader: Box<dy
 fn spawn_exit_watcher(
     app: AppHandle,
     session_id: String,
-    sessions: Arc<Mutex<HashMap<String, TerminalSession>>>,
+    state: TerminalState,
     mut child: Box<dyn portable_pty::Child + Send + Sync>,
 ) {
     std::thread::spawn(move || {
         let exit_code = child.wait().ok().map(|status| status.exit_code());
-        if let Ok(mut sessions) = sessions.lock() {
-            sessions.remove(&session_id);
-        }
+        state.release_session(&session_id);
         let _ = app.emit(
             "terminal:exit",
             TerminalExitEvent {
@@ -450,7 +643,7 @@ fn add_shell_args(command: &mut CommandBuilder, shell: &Path) {
 mod tests {
     use super::{
         build_agent_command, normalized_pty_size, resolve_terminal_cwd, validate_initial_command,
-        validate_session_id, AgentKind, TerminalMode,
+        validate_session_id, AgentKind, TerminalIdentity, TerminalMode, TerminalState,
     };
     use crate::local_engine::LocalEngine;
     use std::path::Path;
@@ -603,6 +796,53 @@ mod tests {
             &notes_space.slug,
             Some(&other_change.id),
             other_change.worktree_path.to_str().unwrap(),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn active_background_terminals_block_close_and_closing_blocks_restart() {
+        let state = TerminalState::default();
+        let identity = TerminalIdentity {
+            space_slug: "notes".to_string(),
+            change_id: Some("change-1".to_string()),
+        };
+        state
+            .reserve_session("terminal:active", identity.clone())
+            .unwrap();
+
+        let active_error = state.begin_change_close("notes", "change-1").unwrap_err();
+        assert!(active_error.contains("active background terminal"));
+
+        state.release_session("terminal:active");
+        let closing = state.begin_change_close("notes", "change-1").unwrap();
+        let restart_error = state
+            .reserve_session("terminal:restart", identity.clone())
+            .unwrap_err();
+        assert!(restart_error.contains("being closed"));
+
+        drop(closing);
+        state.reserve_session("terminal:restart", identity).unwrap();
+    }
+
+    #[test]
+    fn closed_agent_change_cannot_restart_a_background_terminal() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let notes = temp.path().join("notes");
+        std::fs::create_dir_all(&notes).unwrap();
+        let space = engine.add_space("Notes", "notes", &notes).unwrap();
+        let change = engine.create_agent_change(&space.slug, "Codex").unwrap();
+        engine
+            .discard_agent_change(&space.slug, &change.id)
+            .unwrap();
+
+        assert!(resolve_terminal_cwd(
+            &engine,
+            TerminalMode::Background,
+            &space.slug,
+            Some(&change.id),
+            change.worktree_path.to_str().unwrap(),
         )
         .is_err());
     }

--- a/web/src-tauri/src/terminal.rs
+++ b/web/src-tauri/src/terminal.rs
@@ -31,6 +31,22 @@ pub enum AgentKind {
     Hermes,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TerminalMode {
+    Live,
+    Background,
+}
+
+impl TerminalMode {
+    fn prompt(self) -> &'static str {
+        match self {
+            Self::Live => "You are editing the current Draft working tree directly. Re-read files immediately before every edit and never overwrite concurrent human or Agent changes.",
+            Self::Background => "You are in a CoWiki-managed background worktree captured from the Draft at dispatch time. Only edit files in this worktree. Do not checkout, merge, commit, or push; CoWiki collects the result and merges it into the latest Draft after review.",
+        }
+    }
+}
+
 impl AgentKind {
     fn command(self) -> &'static str {
         match self {
@@ -49,6 +65,9 @@ impl AgentKind {
 pub struct TerminalCreateRequest {
     session_id: String,
     cwd: String,
+    mode: TerminalMode,
+    space_slug: String,
+    change_id: Option<String>,
     agent: AgentKind,
     initial_command: Option<String>,
     cols: Option<u16>,
@@ -95,8 +114,14 @@ pub fn terminal_create(
     request: TerminalCreateRequest,
 ) -> Result<TerminalCreated, String> {
     let session_id = validate_session_id(&request.session_id)?;
-    let cwd = canonical_space_path(&request.cwd)?;
-    let space = local_engine.find_space_by_path(&cwd)?;
+    let cwd = resolve_terminal_cwd(
+        &local_engine,
+        request.mode,
+        &request.space_slug,
+        request.change_id.as_deref(),
+        &request.cwd,
+    )?;
+    let space = local_engine.find_space(&request.space_slug)?;
     validate_initial_command(request.agent, request.initial_command.as_deref())?;
     let size = normalized_pty_size(request.cols, request.rows);
 
@@ -129,7 +154,7 @@ pub fn terminal_create(
     // renderer cannot provide arbitrary flags or commands.
     let executable = std::env::current_exe()
         .map_err(|error| format!("cannot locate CoWiki MCP executable: {error}"))?;
-    let agent_command = build_agent_command(request.agent, &space.slug, &executable);
+    let agent_command = build_agent_command(request.agent, request.mode, &space.slug, &executable);
     writer
         .write_all(format!("{agent_command}\r").as_bytes())
         .and_then(|_| writer.flush())
@@ -168,9 +193,15 @@ fn validate_session_id(value: &str) -> Result<String, String> {
 
 const SPACE_PROTOCOL: &str = "You are maintaining a CoWiki knowledge Space. Markdown files are the source of truth. Follow the Open Knowledge Format and the Space's own rules. Before answering about the Space, use the cowiki MCP search tools and read the relevant pages; cite their relative paths. Before claiming that knowledge is absent, search and list evidence first. Raw sources are immutable. Integrate durable knowledge into the maintained wiki, reconcile contradictions, keep links/index/log consistent, and make every change reversible. Re-read a file immediately before editing it; never silently overwrite concurrent human changes. Do not commit, checkout, merge, push, or edit CoWiki SQLite metadata unless the user explicitly asks.";
 
-fn build_agent_command(agent: AgentKind, space_slug: &str, executable: &Path) -> String {
+fn build_agent_command(
+    agent: AgentKind,
+    mode: TerminalMode,
+    space_slug: &str,
+    executable: &Path,
+) -> String {
     let executable_text = executable.to_string_lossy();
     let mcp_args = vec!["--mcp", "--space", space_slug];
+    let prompt = format!("{SPACE_PROTOCOL} {}", mode.prompt());
     match agent {
         AgentKind::Claude => {
             let config = serde_json::json!({
@@ -185,7 +216,7 @@ fn build_agent_command(agent: AgentKind, space_slug: &str, executable: &Path) ->
             format!(
                 "claude --mcp-config {} --append-system-prompt {}",
                 shell_quote(&config.to_string()),
-                shell_quote(SPACE_PROTOCOL),
+                shell_quote(&prompt),
             )
         }
         AgentKind::Codex => {
@@ -202,16 +233,13 @@ fn build_agent_command(agent: AgentKind, space_slug: &str, executable: &Path) ->
                 "codex -c {} -c {} {}",
                 shell_quote(&format!("mcp_servers.cowiki.command={command_toml}")),
                 shell_quote(&format!("mcp_servers.cowiki.args={args_toml}")),
-                shell_quote(SPACE_PROTOCOL),
+                shell_quote(&prompt),
             )
         }
-        AgentKind::Grok => format!("grok --rules {}", shell_quote(SPACE_PROTOCOL)),
-        AgentKind::Gemini => format!(
-            "gemini --prompt-interactive {}",
-            shell_quote(SPACE_PROTOCOL)
-        ),
+        AgentKind::Grok => format!("grok --rules {}", shell_quote(&prompt)),
+        AgentKind::Gemini => format!("gemini --prompt-interactive {}", shell_quote(&prompt)),
         AgentKind::OpenCode => {
-            format!("opencode --prompt {}", shell_quote(SPACE_PROTOCOL))
+            format!("opencode --prompt {}", shell_quote(&prompt))
         }
         // Hermes discovers the Space's AGENTS.md and skills from its working
         // directory. Its interactive command has no system-prompt override.
@@ -336,6 +364,37 @@ fn canonical_space_path(raw_path: &str) -> Result<PathBuf, String> {
     Ok(canonical)
 }
 
+fn resolve_terminal_cwd(
+    local_engine: &LocalEngine,
+    mode: TerminalMode,
+    space_slug: &str,
+    change_id: Option<&str>,
+    raw_cwd: &str,
+) -> Result<PathBuf, String> {
+    let requested = canonical_space_path(raw_cwd)?;
+    let space = local_engine.find_space(space_slug)?;
+    let expected = match mode {
+        TerminalMode::Live => {
+            if change_id.is_some() {
+                return Err("a Live terminal cannot claim an Agent Change".to_string());
+            }
+            space
+                .local_path
+                .canonicalize()
+                .map_err(|error| error.to_string())?
+        }
+        TerminalMode::Background => {
+            let change_id = change_id
+                .ok_or_else(|| "a background terminal requires an Agent Change".to_string())?;
+            local_engine.agent_change_worktree(space_slug, change_id)?
+        }
+    };
+    if requested != expected {
+        return Err("terminal directory does not match its Space and Agent Change".to_string());
+    }
+    Ok(requested)
+}
+
 fn validate_initial_command(agent: AgentKind, initial_command: Option<&str>) -> Result<(), String> {
     if initial_command.is_some_and(|command| command != agent.command()) {
         return Err("terminal initial command must match the selected agent".to_string());
@@ -390,9 +449,10 @@ fn add_shell_args(command: &mut CommandBuilder, shell: &Path) {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_agent_command, normalized_pty_size, validate_initial_command, validate_session_id,
-        AgentKind,
+        build_agent_command, normalized_pty_size, resolve_terminal_cwd, validate_initial_command,
+        validate_session_id, AgentKind, TerminalMode,
     };
+    use crate::local_engine::LocalEngine;
     use std::path::Path;
 
     #[test]
@@ -424,21 +484,54 @@ mod tests {
     #[test]
     fn launches_agents_with_read_only_cowiki_mcp_and_maintenance_protocol() {
         let executable = Path::new("/Applications/CoWiki.app/Contents/MacOS/cowiki-desktop");
-        let codex = build_agent_command(AgentKind::Codex, "research-space", executable);
-        let claude = build_agent_command(AgentKind::Claude, "research-space", executable);
+        let codex = build_agent_command(
+            AgentKind::Codex,
+            TerminalMode::Live,
+            "research-space",
+            executable,
+        );
+        let claude = build_agent_command(
+            AgentKind::Claude,
+            TerminalMode::Background,
+            "research-space",
+            executable,
+        );
 
         assert!(codex.contains("mcp_servers.cowiki.command"));
         assert!(codex.contains("--space"));
         assert!(codex.contains("research-space"));
         assert!(codex.contains("Before claiming that knowledge is absent"));
+        assert!(codex.contains("current Draft working tree"));
         assert!(claude.contains("--mcp-config"));
         assert!(claude.contains("cowiki"));
         assert!(claude.contains("--append-system-prompt"));
+        assert!(claude.contains("managed background worktree"));
+        assert!(claude.contains("Do not checkout, merge, commit, or push"));
 
-        let grok = build_agent_command(AgentKind::Grok, "research-space", executable);
-        let gemini = build_agent_command(AgentKind::Gemini, "research-space", executable);
-        let opencode = build_agent_command(AgentKind::OpenCode, "research-space", executable);
-        let hermes = build_agent_command(AgentKind::Hermes, "research-space", executable);
+        let grok = build_agent_command(
+            AgentKind::Grok,
+            TerminalMode::Live,
+            "research-space",
+            executable,
+        );
+        let gemini = build_agent_command(
+            AgentKind::Gemini,
+            TerminalMode::Live,
+            "research-space",
+            executable,
+        );
+        let opencode = build_agent_command(
+            AgentKind::OpenCode,
+            TerminalMode::Live,
+            "research-space",
+            executable,
+        );
+        let hermes = build_agent_command(
+            AgentKind::Hermes,
+            TerminalMode::Live,
+            "research-space",
+            executable,
+        );
 
         assert!(grok.starts_with("grok --rules "));
         assert!(grok.contains("Before claiming that knowledge is absent"));
@@ -447,5 +540,70 @@ mod tests {
         assert!(opencode.starts_with("opencode --prompt "));
         assert!(opencode.contains("Before claiming that knowledge is absent"));
         assert_eq!(hermes, "hermes chat");
+    }
+
+    #[test]
+    fn terminal_mode_and_identity_control_the_only_allowed_cwd() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let notes = temp.path().join("notes");
+        let other = temp.path().join("other");
+        std::fs::create_dir_all(&notes).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+        let notes_space = engine.add_space("Notes", "notes", &notes).unwrap();
+        let other_space = engine.add_space("Other", "other", &other).unwrap();
+        let notes_change = engine
+            .create_agent_change(&notes_space.slug, "Codex")
+            .unwrap();
+        let other_change = engine
+            .create_agent_change(&other_space.slug, "Claude Code")
+            .unwrap();
+
+        assert_eq!(
+            resolve_terminal_cwd(
+                &engine,
+                TerminalMode::Live,
+                &notes_space.slug,
+                None,
+                notes.to_str().unwrap(),
+            )
+            .unwrap(),
+            notes.canonicalize().unwrap()
+        );
+        assert!(resolve_terminal_cwd(
+            &engine,
+            TerminalMode::Live,
+            &notes_space.slug,
+            None,
+            other.to_str().unwrap(),
+        )
+        .is_err());
+        assert_eq!(
+            resolve_terminal_cwd(
+                &engine,
+                TerminalMode::Background,
+                &notes_space.slug,
+                Some(&notes_change.id),
+                notes_change.worktree_path.to_str().unwrap(),
+            )
+            .unwrap(),
+            notes_change.worktree_path.canonicalize().unwrap()
+        );
+        assert!(resolve_terminal_cwd(
+            &engine,
+            TerminalMode::Background,
+            &notes_space.slug,
+            Some(&notes_change.id),
+            notes.to_str().unwrap(),
+        )
+        .is_err());
+        assert!(resolve_terminal_cwd(
+            &engine,
+            TerminalMode::Background,
+            &notes_space.slug,
+            Some(&other_change.id),
+            other_change.worktree_path.to_str().unwrap(),
+        )
+        .is_err());
     }
 }

--- a/web/src-tauri/src/terminal.rs
+++ b/web/src-tauri/src/terminal.rs
@@ -115,30 +115,45 @@ struct AgentChangeIdentity {
     change_id: String,
 }
 
-enum TerminalSlot {
-    Starting(TerminalIdentity),
-    Running(TerminalSession),
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalPhase {
+    Starting,
+    Running,
+    Stopping,
+}
+
+struct TerminalSlot {
+    identity: TerminalIdentity,
+    phase: TerminalPhase,
+    session: Option<TerminalSession>,
 }
 
 impl TerminalSlot {
-    fn identity(&self) -> &TerminalIdentity {
-        match self {
-            Self::Starting(identity) => identity,
-            Self::Running(session) => &session.identity,
+    fn starting(identity: TerminalIdentity) -> Self {
+        Self {
+            identity,
+            phase: TerminalPhase::Starting,
+            session: None,
         }
     }
 
+    fn identity(&self) -> &TerminalIdentity {
+        &self.identity
+    }
+
     fn running(&self) -> Option<&TerminalSession> {
-        match self {
-            Self::Running(session) => Some(session),
-            Self::Starting(_) => None,
+        if self.phase == TerminalPhase::Running {
+            self.session.as_ref()
+        } else {
+            None
         }
     }
 
     fn running_mut(&mut self) -> Option<&mut TerminalSession> {
-        match self {
-            Self::Running(session) => Some(session),
-            Self::Starting(_) => None,
+        if self.phase == TerminalPhase::Running {
+            self.session.as_mut()
+        } else {
+            None
         }
     }
 }
@@ -147,6 +162,23 @@ impl TerminalSlot {
 struct TerminalRegistry {
     sessions: HashMap<String, TerminalSlot>,
     closing_changes: HashSet<AgentChangeIdentity>,
+}
+
+impl TerminalRegistry {
+    fn mark_stopping(&mut self, session_id: &str) -> Result<(), String> {
+        let slot = self
+            .sessions
+            .get_mut(session_id)
+            .ok_or_else(|| format!("unknown terminal session: {session_id}"))?;
+        match slot.phase {
+            TerminalPhase::Starting => Err("terminal session is still starting".to_string()),
+            TerminalPhase::Running => {
+                slot.phase = TerminalPhase::Stopping;
+                Ok(())
+            }
+            TerminalPhase::Stopping => Ok(()),
+        }
+    }
 }
 
 #[derive(Clone, Default)]
@@ -226,10 +258,19 @@ impl TerminalState {
             if registry.closing_changes.contains(&change) {
                 return Err("Agent Change is being closed; its terminal cannot restart".to_string());
             }
+        } else if registry
+            .closing_changes
+            .iter()
+            .any(|change| change.space_slug == identity.space_slug)
+        {
+            return Err(
+                "Agent Change in this Space is being closed; a Live terminal cannot start"
+                    .to_string(),
+            );
         }
         registry
             .sessions
-            .insert(session_id.to_string(), TerminalSlot::Starting(identity));
+            .insert(session_id.to_string(), TerminalSlot::starting(identity));
         Ok(())
     }
 
@@ -238,15 +279,17 @@ impl TerminalState {
             .registry
             .lock()
             .map_err(|_| "terminal state is unavailable".to_string())?;
-        let Some(TerminalSlot::Starting(identity)) = registry.sessions.get(session_id) else {
+        let Some(slot) = registry.sessions.get_mut(session_id) else {
             return Err("terminal session reservation was lost".to_string());
         };
-        if identity != &session.identity {
+        if slot.phase != TerminalPhase::Starting {
+            return Err("terminal session reservation is no longer starting".to_string());
+        }
+        if slot.identity != session.identity {
             return Err("terminal session identity changed while starting".to_string());
         }
-        registry
-            .sessions
-            .insert(session_id.to_string(), TerminalSlot::Running(session));
+        slot.phase = TerminalPhase::Running;
+        slot.session = Some(session);
         Ok(())
     }
 
@@ -256,10 +299,25 @@ impl TerminalState {
             .ok()?
             .sessions
             .remove(session_id)
-            .and_then(|slot| match slot {
-                TerminalSlot::Running(session) => Some(session),
-                TerminalSlot::Starting(_) => None,
-            })
+            .and_then(|slot| slot.session)
+    }
+
+    fn request_stop(&self, session_id: &str) -> Result<(), String> {
+        let mut registry = self
+            .registry
+            .lock()
+            .map_err(|_| "terminal state is unavailable".to_string())?;
+        let Some(slot) = registry.sessions.get_mut(session_id) else {
+            return Ok(());
+        };
+        if slot.phase == TerminalPhase::Stopping {
+            return Ok(());
+        }
+        let session = slot
+            .running_mut()
+            .ok_or_else(|| "terminal session is still starting".to_string())?;
+        stop_terminal_processes(session)?;
+        registry.mark_stopping(session_id)
     }
 
     pub(crate) fn begin_change_close(
@@ -275,12 +333,19 @@ impl TerminalState {
             .registry
             .lock()
             .map_err(|_| "terminal state is unavailable".to_string())?;
-        let has_active_terminal = registry.sessions.values().any(|slot| {
+        let blocking_terminal = registry.sessions.values().find(|slot| {
             let terminal = slot.identity();
             terminal.space_slug == identity.space_slug
-                && terminal.change_id.as_deref() == Some(identity.change_id.as_str())
+                && (terminal.change_id.is_none()
+                    || terminal.change_id.as_deref() == Some(identity.change_id.as_str()))
         });
-        if has_active_terminal {
+        if let Some(slot) = blocking_terminal {
+            if slot.identity().change_id.is_none() {
+                return Err(
+                    "Stop the active Live terminal before merging or discarding an Agent Change in this Space."
+                        .to_string(),
+                );
+            }
             return Err(
                 "Stop the active background terminal before merging or discarding this Agent Change."
                     .to_string(),
@@ -492,18 +557,31 @@ pub fn terminal_resize(
 
 #[tauri::command]
 pub fn terminal_kill(state: State<'_, TerminalState>, session_id: String) -> Result<(), String> {
-    let mut registry = state
-        .registry
-        .lock()
-        .map_err(|_| "terminal state is unavailable".to_string())?;
-    if let Some(TerminalSlot::Running(session)) = registry.sessions.get_mut(&session_id) {
-        session
-            .killer
-            .kill()
-            .map_err(|error| format!("failed to stop terminal: {error}"))?;
+    state.request_stop(&session_id)
+}
+
+fn stop_terminal_processes(session: &mut TerminalSession) -> Result<(), String> {
+    #[cfg(unix)]
+    if let Some(process_group) = session.master.process_group_leader() {
+        // portable-pty makes the shell a session leader, but its cloned killer
+        // signals only the shell PID. Signal the current foreground process
+        // group as well so an interactive Agent CLI is asked to stop before
+        // the shell. The registry remains Stopping until child.wait confirms
+        // that the PTY child has actually exited.
+        let result = unsafe { libc::kill(-process_group, libc::SIGHUP) };
+        if result != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(format!("failed to stop terminal process group: {error}"));
+            }
+        }
     }
-    registry.sessions.remove(&session_id);
-    Ok(())
+    match session.killer.kill() {
+        Ok(()) => Ok(()),
+        #[cfg(unix)]
+        Err(error) if error.raw_os_error() == Some(libc::ESRCH) => Ok(()),
+        Err(error) => Err(format!("failed to stop terminal: {error}")),
+    }
 }
 
 fn spawn_output_forwarder(app: AppHandle, session_id: String, mut reader: Box<dyn Read + Send>) {
@@ -645,6 +723,8 @@ mod tests {
         build_agent_command, normalized_pty_size, resolve_terminal_cwd, validate_initial_command,
         validate_session_id, AgentKind, TerminalIdentity, TerminalMode, TerminalState,
     };
+    #[cfg(unix)]
+    use super::{TerminalPhase, TerminalSession};
     use crate::local_engine::LocalEngine;
     use std::path::Path;
 
@@ -823,6 +903,97 @@ mod tests {
 
         drop(closing);
         state.reserve_session("terminal:restart", identity).unwrap();
+    }
+
+    #[test]
+    fn live_terminals_share_the_space_close_gate() {
+        let state = TerminalState::default();
+        let live = TerminalIdentity {
+            space_slug: "notes".to_string(),
+            change_id: None,
+        };
+        state
+            .reserve_session("terminal:live", live.clone())
+            .unwrap();
+
+        let active_error = state.begin_change_close("notes", "change-1").unwrap_err();
+        assert!(active_error.contains("active Live terminal"));
+
+        state.release_session("terminal:live");
+        let closing = state.begin_change_close("notes", "change-1").unwrap();
+        let restart_error = state
+            .reserve_session("terminal:live-restart", live)
+            .unwrap_err();
+        assert!(restart_error.contains("being closed"));
+        assert!(state
+            .reserve_session(
+                "terminal:other-space",
+                TerminalIdentity {
+                    space_slug: "other".to_string(),
+                    change_id: None,
+                },
+            )
+            .is_ok());
+        drop(closing);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stopping_terminal_blocks_close_until_exit_releases_its_slot() {
+        let state = TerminalState::default();
+        let pair = portable_pty::native_pty_system()
+            .openpty(normalized_pty_size(None, None))
+            .unwrap();
+        let mut command = portable_pty::CommandBuilder::new("/bin/sh");
+        command.arg("-c");
+        command.arg("sleep 10");
+        let mut child = pair.slave.spawn_command(command).unwrap();
+        drop(pair.slave);
+        let writer = pair.master.take_writer().unwrap();
+        let killer = child.clone_killer();
+        let identity = TerminalIdentity {
+            space_slug: "notes".to_string(),
+            change_id: Some("change-1".to_string()),
+        };
+        state
+            .reserve_session("terminal:stopping", identity.clone())
+            .unwrap();
+        state
+            .install_session(
+                "terminal:stopping",
+                TerminalSession {
+                    identity,
+                    master: pair.master,
+                    writer,
+                    killer,
+                },
+            )
+            .unwrap();
+
+        state.request_stop("terminal:stopping").unwrap();
+        {
+            let registry = state.registry.lock().unwrap();
+            assert_eq!(
+                registry.sessions["terminal:stopping"].phase,
+                TerminalPhase::Stopping
+            );
+        }
+
+        let stopping_error = state.begin_change_close("notes", "change-1").unwrap_err();
+        assert!(stopping_error.contains("active background terminal"));
+
+        let exited = (0..100).any(|_| {
+            if child.try_wait().unwrap().is_some() {
+                true
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                false
+            }
+        });
+        assert!(exited, "terminal child did not exit after Stop");
+        // This is the exit watcher's only release point after child.wait().
+        state.release_session("terminal:stopping");
+        assert!(state.begin_change_close("notes", "change-1").is_ok());
     }
 
     #[test]

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -60,6 +60,9 @@ export interface FileDiff {
   path: string;
   old_content: string | null;
   new_content: string | null;
+  is_binary?: boolean;
+  old_binary_hash?: string | null;
+  new_binary_hash?: string | null;
   hunks: DiffHunk[];
   additions: number;
   deletions: number;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -65,6 +65,17 @@ export interface FileDiff {
   deletions: number;
 }
 
+export type AgentChangeStatus = 'open' | 'needsResolution' | 'merged' | 'discarded';
+
+export interface AgentChange {
+  id: string;
+  title: string;
+  status: AgentChangeStatus;
+  createdAt: number;
+  worktreePath: string;
+  diffs: FileDiff[];
+}
+
 export interface ReviewComment {
   id: string;
   submission_id: string;
@@ -398,9 +409,22 @@ export async function submit(branch: string, paths: string[], skipReview: boolea
 }
 
 export async function listReviews(workspaceSlug: string): Promise<Submission[]> {
-  // Local Agent Changes will populate this from Git. Until one exists, the
-  // desktop review inbox is intentionally empty and never calls cloud HTTP.
-  if (isDesktopClient()) return [];
+  if (isDesktopClient()) {
+    const changes = await localApi.listAgentChanges(workspaceSlug);
+    return changes.map((change) => ({
+      id: change.id,
+      user_id: 'local-agent',
+      status: change.status === 'merged' ? 'merged' : change.status === 'discarded' ? 'rejected' : 'pending',
+      summary: change.title,
+      paths: change.diffs.map((diff) => diff.path),
+      source_branch: `cowiki/agent/${change.id}`,
+      created_at: new Date(change.createdAt * 1000).toISOString(),
+      reviewed_by: null,
+      reviewed_at: null,
+      author_name: change.title,
+      reviewer_name: null,
+    }));
+  }
   const res = await fetch(`${BASE}/workspaces/${workspaceSlug}/reviews`, { headers: h() });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
@@ -419,6 +443,35 @@ export async function getLocalWorkingDiff(workspaceSlug: string): Promise<FileDi
 export async function keepLocalWorkingDiff(workspaceSlug: string, expected: FileDiff[]): Promise<void> {
   if (!isDesktopClient()) throw new Error('Local Review is available only in the desktop app');
   await localApi.keepWorkingDiff(workspaceSlug, expected);
+}
+
+export async function createLocalAgentChange(
+  workspaceSlug: string,
+  agentName: string,
+): Promise<AgentChange> {
+  if (!isDesktopClient()) throw new Error('Local Agent Changes are available only in the desktop app');
+  return localApi.createAgentChange(workspaceSlug, agentName);
+}
+
+export async function listLocalAgentChanges(workspaceSlug: string): Promise<AgentChange[]> {
+  if (!isDesktopClient()) return [];
+  return localApi.listAgentChanges(workspaceSlug);
+}
+
+export async function mergeLocalAgentChange(
+  workspaceSlug: string,
+  changeId: string,
+): Promise<AgentChange> {
+  if (!isDesktopClient()) throw new Error('Local Agent Changes are available only in the desktop app');
+  return localApi.mergeAgentChange(workspaceSlug, changeId);
+}
+
+export async function discardLocalAgentChange(
+  workspaceSlug: string,
+  changeId: string,
+): Promise<AgentChange> {
+  if (!isDesktopClient()) throw new Error('Local Agent Changes are available only in the desktop app');
+  return localApi.discardAgentChange(workspaceSlug, changeId);
 }
 
 export async function getReview(workspaceSlug: string, id: string): Promise<ReviewDetail> {

--- a/web/src/components/review/DiffView.tsx
+++ b/web/src/components/review/DiffView.tsx
@@ -7,8 +7,10 @@ import { timeAgo } from '../../lib/time';
 const mono = fonts.mono;
 
 function fileStatus(f: FileDiff): 'added' | 'deleted' | 'modified' {
-  if (f.old_content == null) return 'added';
-  if (f.new_content == null) return 'deleted';
+  const hasOldContent = f.old_content != null || f.old_binary_hash != null;
+  const hasNewContent = f.new_content != null || f.new_binary_hash != null;
+  if (!hasOldContent) return 'added';
+  if (!hasNewContent) return 'deleted';
   return 'modified';
 }
 

--- a/web/src/components/review/LocalReviewInbox.tsx
+++ b/web/src/components/review/LocalReviewInbox.tsx
@@ -12,14 +12,19 @@ import {
 } from '@/api';
 import { C } from '@/lib/design';
 import { DiffView } from './DiffView';
-import { orderedLocalReviewRows } from './local-review-model';
+import {
+  localReviewActionRefreshesDraft,
+  orderedLocalReviewRows,
+  type LocalReviewAction,
+} from './local-review-model';
 
 type LocalReviewInboxProps = {
   workspaceSlug: string;
   refreshKey?: number;
+  onDraftChanged?: () => void;
 };
 
-export function LocalReviewInbox({ workspaceSlug, refreshKey }: LocalReviewInboxProps) {
+export function LocalReviewInbox({ workspaceSlug, refreshKey, onDraftChanged }: LocalReviewInboxProps) {
   const [draftDiffs, setDraftDiffs] = useState<FileDiff[] | null>(null);
   const [changes, setChanges] = useState<AgentChange[] | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(['current-draft']));
@@ -60,13 +65,18 @@ export function LocalReviewInbox({ workspaceSlug, refreshKey }: LocalReviewInbox
     });
   };
 
-  const runAction = async (id: string, action: () => Promise<unknown>) => {
+  const runAction = async (
+    id: string,
+    actionKind: LocalReviewAction,
+    action: () => Promise<unknown>,
+  ) => {
     if (pendingAction) return;
     setPendingAction(id);
     setError(null);
     try {
       await action();
       await reload();
+      if (localReviewActionRefreshesDraft(actionKind)) onDraftChanged?.();
     } catch (cause) {
       setError(errorMessage(cause));
     } finally {
@@ -103,7 +113,11 @@ export function LocalReviewInbox({ workspaceSlug, refreshKey }: LocalReviewInbox
                   actions={(
                     <ActionButton
                       disabled={!draftDiffs.length || pendingAction != null}
-                      onClick={() => runAction(row.id, () => keepLocalWorkingDiff(workspaceSlug, draftDiffs))}
+                      onClick={() => runAction(
+                        row.id,
+                        'commit',
+                        () => keepLocalWorkingDiff(workspaceSlug, draftDiffs),
+                      )}
                     >
                       {pendingAction === row.id ? 'Committing…' : 'Commit Draft'}
                     </ActionButton>
@@ -128,14 +142,22 @@ export function LocalReviewInbox({ workspaceSlug, refreshKey }: LocalReviewInbox
                   <>
                     <ActionButton
                       disabled={pendingAction != null}
-                      onClick={() => runAction(row.id, () => mergeLocalAgentChange(workspaceSlug, change.id))}
+                      onClick={() => runAction(
+                        row.id,
+                        'merge',
+                        () => mergeLocalAgentChange(workspaceSlug, change.id),
+                      )}
                     >
                       {pendingAction === row.id ? 'Working…' : 'Merge into Draft'}
                     </ActionButton>
                     <ActionButton
                       subtle
                       disabled={pendingAction != null}
-                      onClick={() => runAction(row.id, () => discardLocalAgentChange(workspaceSlug, change.id))}
+                      onClick={() => runAction(
+                        row.id,
+                        'discard',
+                        () => discardLocalAgentChange(workspaceSlug, change.id),
+                      )}
                     >
                       Discard
                     </ActionButton>

--- a/web/src/components/review/LocalReviewInbox.tsx
+++ b/web/src/components/review/LocalReviewInbox.tsx
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight, GitBranch, GitCommitHorizontal } from 'lucide-react';
+
+import {
+  discardLocalAgentChange,
+  getLocalWorkingDiff,
+  keepLocalWorkingDiff,
+  listLocalAgentChanges,
+  mergeLocalAgentChange,
+  type AgentChange,
+  type FileDiff,
+} from '@/api';
+import { C } from '@/lib/design';
+import { DiffView } from './DiffView';
+import { orderedLocalReviewRows } from './local-review-model';
+
+type LocalReviewInboxProps = {
+  workspaceSlug: string;
+  refreshKey?: number;
+};
+
+export function LocalReviewInbox({ workspaceSlug, refreshKey }: LocalReviewInboxProps) {
+  const [draftDiffs, setDraftDiffs] = useState<FileDiff[] | null>(null);
+  const [changes, setChanges] = useState<AgentChange[] | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(['current-draft']));
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    const [nextDraft, nextChanges] = await Promise.all([
+      getLocalWorkingDiff(workspaceSlug),
+      listLocalAgentChanges(workspaceSlug),
+    ]);
+    setDraftDiffs(nextDraft);
+    setChanges(nextChanges);
+  }, [workspaceSlug]);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([getLocalWorkingDiff(workspaceSlug), listLocalAgentChanges(workspaceSlug)])
+      .then(([nextDraft, nextChanges]) => {
+        if (cancelled) return;
+        setError(null);
+        setDraftDiffs(nextDraft);
+        setChanges(nextChanges);
+      })
+      .catch((cause) => {
+        if (!cancelled) setError(errorMessage(cause));
+      });
+    return () => { cancelled = true; };
+  }, [refreshKey, workspaceSlug]);
+
+  const rows = useMemo(() => orderedLocalReviewRows(changes ?? []), [changes]);
+  const toggle = (id: string) => {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const runAction = async (id: string, action: () => Promise<unknown>) => {
+    if (pendingAction) return;
+    setPendingAction(id);
+    setError(null);
+    try {
+      await action();
+      await reload();
+    } catch (cause) {
+      setError(errorMessage(cause));
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ marginBottom: 20 }}>
+        <h1 className="page-title" style={{ marginBottom: 5 }}>Reviews</h1>
+        <p style={{ color: C.muted, fontSize: 13, margin: 0 }}>
+          Review and commit the Current Draft, or merge isolated Agent Changes into its working tree.
+        </p>
+      </div>
+      {error && <p style={{ color: C.red, fontSize: 13 }}>{error}</p>}
+      {draftDiffs == null || changes == null ? (
+        <p style={{ color: C.muted, fontSize: 14 }}>Loading Reviews…</p>
+      ) : (
+        <div style={{ display: 'grid', gap: 10 }}>
+          {rows.map((row) => {
+            if (row.kind === 'draft') {
+              return (
+                <ReviewRow
+                  key={row.id}
+                  id={row.id}
+                  title="Current Draft"
+                  subtitle="Local working tree · relative to HEAD"
+                  status={draftDiffs.length ? 'Uncommitted' : 'Clean'}
+                  diffs={draftDiffs}
+                  expanded={expanded.has(row.id)}
+                  onToggle={() => toggle(row.id)}
+                  icon={<GitCommitHorizontal size={17} color={C.faint} />}
+                  actions={(
+                    <ActionButton
+                      disabled={!draftDiffs.length || pendingAction != null}
+                      onClick={() => runAction(row.id, () => keepLocalWorkingDiff(workspaceSlug, draftDiffs))}
+                    >
+                      {pendingAction === row.id ? 'Committing…' : 'Commit Draft'}
+                    </ActionButton>
+                  )}
+                />
+              );
+            }
+            const change = row.change;
+            const active = change.status === 'open' || change.status === 'needsResolution';
+            return (
+              <ReviewRow
+                key={row.id}
+                id={row.id}
+                title={change.title}
+                subtitle={`Agent Change · ${new Date(change.createdAt * 1000).toLocaleString()}`}
+                status={statusLabel(change.status)}
+                diffs={change.diffs}
+                expanded={expanded.has(row.id)}
+                onToggle={() => toggle(row.id)}
+                icon={<GitBranch size={17} color={C.faint} />}
+                actions={active ? (
+                  <>
+                    <ActionButton
+                      disabled={pendingAction != null}
+                      onClick={() => runAction(row.id, () => mergeLocalAgentChange(workspaceSlug, change.id))}
+                    >
+                      {pendingAction === row.id ? 'Working…' : 'Merge into Draft'}
+                    </ActionButton>
+                    <ActionButton
+                      subtle
+                      disabled={pendingAction != null}
+                      onClick={() => runAction(row.id, () => discardLocalAgentChange(workspaceSlug, change.id))}
+                    >
+                      Discard
+                    </ActionButton>
+                  </>
+                ) : undefined}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReviewRow({
+  actions,
+  diffs,
+  expanded,
+  icon,
+  id,
+  onToggle,
+  status,
+  subtitle,
+  title,
+}: {
+  actions?: React.ReactNode;
+  diffs: FileDiff[];
+  expanded: boolean;
+  icon: React.ReactNode;
+  id: string;
+  onToggle: () => void;
+  status: string;
+  subtitle: string;
+  title: string;
+}) {
+  const additions = diffs.reduce((total, diff) => total + diff.additions, 0);
+  const deletions = diffs.reduce((total, diff) => total + diff.deletions, 0);
+  return (
+    <section style={{ border: `1px solid ${C.line}`, borderRadius: 10, overflow: 'hidden', background: C.panel }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 16px' }}>
+        <button
+          type="button"
+          aria-controls={`${id}-diff`}
+          aria-expanded={expanded}
+          onClick={onToggle}
+          style={{ display: 'flex', flex: 1, minWidth: 0, alignItems: 'center', gap: 12, border: 0, padding: 0, background: 'transparent', textAlign: 'left', cursor: 'pointer' }}
+        >
+          {expanded ? <ChevronDown size={15} color={C.faint} /> : <ChevronRight size={15} color={C.faint} />}
+          {icon}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 14.5, fontWeight: 650, color: C.ink }}>{title}</div>
+            <div style={{ marginTop: 3, fontSize: 12.5, color: C.muted }}>{subtitle}</div>
+          </div>
+          <DiffSummary diffs={diffs} additions={additions} deletions={deletions} />
+          <span style={{ fontSize: 11.5, fontWeight: 650, color: status === 'Needs resolution' ? C.red : C.muted }}>
+            {status}
+          </span>
+        </button>
+        {actions && <div style={{ display: 'flex', gap: 7 }}>{actions}</div>}
+      </div>
+      {expanded && (
+        <div id={`${id}-diff`} style={{ borderTop: `1px solid ${C.line}`, padding: diffs.length ? 14 : 20 }}>
+          {diffs.length ? (
+            <DiffView diffs={diffs} />
+          ) : (
+            <div style={{ color: C.muted, fontSize: 13, textAlign: 'center' }}>No file changes.</div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DiffSummary({
+  additions,
+  deletions,
+  diffs,
+}: {
+  additions: number;
+  deletions: number;
+  diffs: FileDiff[];
+}) {
+  return (
+    <span style={{ color: C.muted, fontSize: 12, whiteSpace: 'nowrap' }}>
+      {diffs.length} file{diffs.length === 1 ? '' : 's'} · <span style={{ color: C.green }}>+{additions}</span> · <span style={{ color: C.red }}>−{deletions}</span>
+    </span>
+  );
+}
+
+function ActionButton({
+  children,
+  disabled,
+  onClick,
+  subtle = false,
+}: {
+  children: React.ReactNode;
+  disabled?: boolean;
+  onClick: () => void;
+  subtle?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      style={{
+        border: subtle ? `1px solid ${C.line}` : 'none',
+        borderRadius: 7,
+        padding: '7px 10px',
+        background: subtle ? C.panel : C.ink,
+        color: subtle ? C.muted : '#fff',
+        cursor: disabled ? 'default' : 'pointer',
+        fontSize: 12,
+        fontWeight: 650,
+        opacity: disabled ? 0.55 : 1,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function statusLabel(status: AgentChange['status']): string {
+  switch (status) {
+    case 'needsResolution': return 'Needs resolution';
+    case 'merged': return 'Merged';
+    case 'discarded': return 'Discarded';
+    default: return 'Open';
+  }
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}

--- a/web/src/components/review/ReviewList.tsx
+++ b/web/src/components/review/ReviewList.tsx
@@ -13,12 +13,19 @@ type Filter = 'open' | 'merged' | 'all';
 type ReviewListProps = {
   workspaceSlug: string;
   onOpen: (id: string) => void;
+  onLocalDraftChanged?: () => void;
   refreshKey?: number;
 };
 
 export function ReviewList(props: ReviewListProps) {
   return isDesktopClient()
-    ? <LocalReviewInbox workspaceSlug={props.workspaceSlug} refreshKey={props.refreshKey} />
+    ? (
+      <LocalReviewInbox
+        workspaceSlug={props.workspaceSlug}
+        refreshKey={props.refreshKey}
+        onDraftChanged={props.onLocalDraftChanged}
+      />
+    )
     : <CloudReviewList {...props} />;
 }
 

--- a/web/src/components/review/ReviewList.tsx
+++ b/web/src/components/review/ReviewList.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { GitBranch, MessageSquare } from 'lucide-react';
-import { getLocalWorkingDiff, keepLocalWorkingDiff, listReviews, type FileDiff, type Submission } from '../../api';
+import { listReviews, type Submission } from '../../api';
 import { C } from '@/lib/design';
 import { timeAgo } from '../../lib/time';
 import { AvatarBadge } from '@/components/ui/avatar-badge';
 import { statusBadge } from '@/lib/review';
 import { isDesktopClient } from '@/runtime';
-import { DiffView } from './DiffView';
+import { LocalReviewInbox } from './LocalReviewInbox';
 
 type Filter = 'open' | 'merged' | 'all';
 
@@ -33,10 +33,12 @@ function CloudReviewList({
 
   useEffect(() => {
     let cancelled = false;
-    setSubs(null);
-    setError(null);
     listReviews(workspaceSlug)
-      .then((s) => !cancelled && setSubs(s))
+      .then((s) => {
+        if (cancelled) return;
+        setError(null);
+        setSubs(s);
+      })
       .catch((e) => !cancelled && setError(e.message || 'Failed to load reviews'));
     return () => { cancelled = true; };
   }, [workspaceSlug, refreshKey]);
@@ -150,78 +152,6 @@ function CloudReviewList({
             );
           })}
         </div>
-      )}
-    </div>
-  );
-}
-
-function LocalReviewInbox({ workspaceSlug, refreshKey }: { workspaceSlug: string; refreshKey?: number }) {
-  const [diffs, setDiffs] = useState<FileDiff[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [keeping, setKeeping] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    getLocalWorkingDiff(workspaceSlug)
-      .then((nextDiffs) => { if (!cancelled) setDiffs(nextDiffs); })
-      .catch((cause) => {
-        if (!cancelled) setError(cause instanceof Error ? cause.message : String(cause));
-      });
-    return () => { cancelled = true; };
-  }, [workspaceSlug, refreshKey]);
-
-  const keep = async () => {
-    if (!diffs?.length || keeping) return;
-    setKeeping(true);
-    setError(null);
-    try {
-      await keepLocalWorkingDiff(workspaceSlug, diffs);
-      await getLocalWorkingDiff(workspaceSlug).then(setDiffs);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setKeeping(false);
-    }
-  };
-
-  const additions = diffs?.reduce((total, diff) => total + diff.additions, 0) ?? 0;
-  const deletions = diffs?.reduce((total, diff) => total + diff.deletions, 0) ?? 0;
-  return (
-    <div>
-      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16, marginBottom: 20 }}>
-        <div>
-          <h1 className="page-title" style={{ marginBottom: 5 }}>Review local changes</h1>
-          <p style={{ color: C.muted, fontSize: 13, margin: 0 }}>
-            Review edits made by you and local agents before recording one Git checkpoint.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={keep}
-          disabled={!diffs?.length || keeping}
-          style={{
-            border: 'none', borderRadius: 8, padding: '9px 15px', fontSize: 13, fontWeight: 650,
-            background: diffs?.length ? C.ink : C.rail, color: diffs?.length ? '#fff' : C.faint,
-            cursor: diffs?.length && !keeping ? 'pointer' : 'default', whiteSpace: 'nowrap',
-          }}
-        >
-          {keeping ? 'Keeping…' : 'Keep changes'}
-        </button>
-      </div>
-      {error && <p style={{ color: C.red, fontSize: 13 }}>{error}</p>}
-      {diffs == null ? (
-        <p style={{ color: C.muted, fontSize: 14 }}>Loading local changes…</p>
-      ) : diffs.length === 0 ? (
-        <div style={{ padding: 32, textAlign: 'center', color: C.muted, fontSize: 14, border: `1px solid ${C.line}`, borderRadius: 10 }}>
-          Everything is kept. New human or agent edits will appear here automatically when you reopen Reviews.
-        </div>
-      ) : (
-        <>
-          <div style={{ marginBottom: 12, color: C.muted, fontSize: 12.5 }}>
-            {diffs.length} file{diffs.length === 1 ? '' : 's'} · <span style={{ color: C.green }}>+{additions}</span> · <span style={{ color: C.red }}>−{deletions}</span>
-          </div>
-          <DiffView diffs={diffs} />
-        </>
       )}
     </div>
   );

--- a/web/src/components/review/local-review-model.ts
+++ b/web/src/components/review/local-review-model.ts
@@ -1,0 +1,20 @@
+export type LocalReviewChangeIdentity = {
+  id: string;
+  createdAt: number;
+};
+
+export type LocalReviewRow<T extends LocalReviewChangeIdentity> =
+  | { kind: 'draft'; id: 'current-draft' }
+  | { kind: 'agent'; id: string; change: T };
+
+export function orderedLocalReviewRows<T extends LocalReviewChangeIdentity>(
+  changes: T[],
+): LocalReviewRow<T>[] {
+  const newestFirst = [...changes].sort((left, right) => (
+    right.createdAt - left.createdAt || right.id.localeCompare(left.id)
+  ));
+  return [
+    { kind: 'draft', id: 'current-draft' },
+    ...newestFirst.map((change) => ({ kind: 'agent' as const, id: change.id, change })),
+  ];
+}

--- a/web/src/components/review/local-review-model.ts
+++ b/web/src/components/review/local-review-model.ts
@@ -18,3 +18,9 @@ export function orderedLocalReviewRows<T extends LocalReviewChangeIdentity>(
     ...newestFirst.map((change) => ({ kind: 'agent' as const, id: change.id, change })),
   ];
 }
+
+export type LocalReviewAction = 'commit' | 'merge' | 'discard';
+
+export function localReviewActionRefreshesDraft(action: LocalReviewAction): boolean {
+  return action === 'merge';
+}

--- a/web/src/components/terminal/AgentTerminalPanel.tsx
+++ b/web/src/components/terminal/AgentTerminalPanel.tsx
@@ -1,7 +1,7 @@
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
-import { Bot, FileText, History, PanelRightClose, Plus, RotateCcw, SquareTerminal, X } from 'lucide-react';
+import { Bot, FileText, GitBranch, History, PanelRightClose, Plus, RotateCcw, SquareTerminal, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -15,8 +15,13 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 import { SUPPORTED_AGENTS } from '@/lib/agents';
+import { createLocalAgentChange } from '@/api';
 
-import { agentDisplayName, type AgentKind } from './terminal-contract';
+import {
+  agentDisplayName,
+  type AgentKind,
+  type AgentTerminalMode,
+} from './terminal-contract';
 import {
   addAgentTab,
   closeAgentTab,
@@ -28,6 +33,7 @@ import { useAgentTerminal } from './useAgentTerminal';
 
 type AgentTerminalPanelProps = {
   spacePath: string;
+  spaceSlug: string;
   defaultAgent: AgentKind;
   onClose?: () => void;
   className?: string;
@@ -42,6 +48,7 @@ function nextTerminalTabId(agent: AgentKind): string {
 
 export function AgentTerminalPanel({
   spacePath,
+  spaceSlug,
   defaultAgent,
   onClose,
   className,
@@ -50,9 +57,26 @@ export function AgentTerminalPanel({
     activeTabId: null,
     tabs: [],
   });
+  const [launchError, setLaunchError] = useState<string | null>(null);
 
-  const openAgent = (agent: AgentKind) => {
-    setTabState((state) => addAgentTab(state, agent, nextTerminalTabId(agent)));
+  const openAgent = async (agent: AgentKind, mode: AgentTerminalMode = 'live') => {
+    setLaunchError(null);
+    try {
+      if (mode === 'live') {
+        setTabState((state) => addAgentTab(state, agent, nextTerminalTabId(agent), mode));
+        return;
+      }
+      const change = await createLocalAgentChange(spaceSlug, agentDisplayName(agent));
+      setTabState((state) => addAgentTab(
+        state,
+        agent,
+        nextTerminalTabId(agent),
+        mode,
+        { changeId: change.id, worktreePath: change.worktreePath },
+      ));
+    } catch (cause) {
+      setLaunchError(cause instanceof Error ? cause.message : String(cause));
+    }
   };
 
   const closeTab = (tabId: string) => {
@@ -114,6 +138,11 @@ export function AgentTerminalPanel({
       </header>
 
       <div className="relative min-h-0 flex-1">
+        {launchError && (
+          <div className="absolute inset-x-0 top-0 z-10 bg-red-950 px-3 py-2 text-xs text-red-200">
+            {launchError}
+          </div>
+        )}
         {tabState.tabs.length === 0 ? (
           <AgentLaunchPage defaultAgent={defaultAgent} onOpenAgent={openAgent} />
         ) : (
@@ -122,6 +151,7 @@ export function AgentTerminalPanel({
               key={tab.id}
               tab={tab}
               spacePath={spacePath}
+              spaceSlug={spaceSlug}
               active={tab.id === tabState.activeTabId}
             />
           ))
@@ -136,7 +166,7 @@ function AgentLaunchPage({
   onOpenAgent,
 }: {
   defaultAgent: AgentKind;
-  onOpenAgent: (agent: AgentKind) => void;
+  onOpenAgent: (agent: AgentKind, mode?: AgentTerminalMode) => void;
 }) {
   return (
     <div className="flex h-full flex-col items-center justify-center px-7 text-center">
@@ -145,10 +175,17 @@ function AgentLaunchPage({
       </div>
       <h2 className="text-base font-semibold text-text">Work with an agent</h2>
       <p className="mt-1.5 max-w-64 text-xs leading-relaxed text-text-tertiary">
-        Run your preferred local coding agent in this Space. Each agent gets its own terminal tab and edits the same files you see here.
+        Work live in the Current Draft, or isolate a background Agent Change for review.
       </p>
-      <Button className="mt-5 min-w-36 bg-[#e2590b] text-white hover:bg-[#c94b08]" onClick={() => onOpenAgent(defaultAgent)}>
-        Start {agentDisplayName(defaultAgent)}
+      <Button className="mt-5 min-w-44 bg-[#e2590b] text-white hover:bg-[#c94b08]" onClick={() => onOpenAgent(defaultAgent, 'live')}>
+        Start {agentDisplayName(defaultAgent)} live
+      </Button>
+      <Button
+        variant="outline"
+        className="mt-2 min-w-44"
+        onClick={() => onOpenAgent(defaultAgent, 'background')}
+      >
+        Run in background
       </Button>
       <AgentPicker defaultAgent={defaultAgent} onOpenAgent={onOpenAgent} />
     </div>
@@ -160,7 +197,7 @@ function AgentPicker({
   onOpenAgent,
 }: {
   defaultAgent: AgentKind;
-  onOpenAgent: (agent: AgentKind) => void;
+  onOpenAgent: (agent: AgentKind, mode?: AgentTerminalMode) => void;
 }) {
   return (
     <DropdownMenu>
@@ -173,9 +210,17 @@ function AgentPicker({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="center" className="w-52">
+        <DropdownMenuLabel className="text-xs text-text-tertiary">Live in Current Draft</DropdownMenuLabel>
         {SUPPORTED_AGENTS.filter((agent) => agent !== defaultAgent).map((agent) => (
-          <DropdownMenuItem key={agent} onSelect={() => onOpenAgent(agent)}>
+          <DropdownMenuItem key={`live-${agent}`} onSelect={() => onOpenAgent(agent, 'live')}>
             <Bot /> {agentDisplayName(agent)}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs text-text-tertiary">Run in background</DropdownMenuLabel>
+        {SUPPORTED_AGENTS.filter((agent) => agent !== defaultAgent).map((agent) => (
+          <DropdownMenuItem key={`background-${agent}`} onSelect={() => onOpenAgent(agent, 'background')}>
+            <GitBranch /> {agentDisplayName(agent)}
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>
@@ -183,7 +228,11 @@ function AgentPicker({
   );
 }
 
-function NewViewMenu({ onOpenAgent }: { onOpenAgent: (agent: AgentKind) => void }) {
+function NewViewMenu({
+  onOpenAgent,
+}: {
+  onOpenAgent: (agent: AgentKind, mode?: AgentTerminalMode) => void;
+}) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -198,10 +247,17 @@ function NewViewMenu({ onOpenAgent }: { onOpenAgent: (agent: AgentKind) => void 
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-48">
-        <DropdownMenuLabel className="text-xs text-text-tertiary">New agent</DropdownMenuLabel>
+        <DropdownMenuLabel className="text-xs text-text-tertiary">Live in Current Draft</DropdownMenuLabel>
         {SUPPORTED_AGENTS.map((agent) => (
-          <DropdownMenuItem key={agent} onSelect={() => onOpenAgent(agent)}>
+          <DropdownMenuItem key={`live-${agent}`} onSelect={() => onOpenAgent(agent, 'live')}>
             <Bot /> {agentDisplayName(agent)}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs text-text-tertiary">Run in background</DropdownMenuLabel>
+        {SUPPORTED_AGENTS.map((agent) => (
+          <DropdownMenuItem key={`background-${agent}`} onSelect={() => onOpenAgent(agent, 'background')}>
+            <GitBranch /> {agentDisplayName(agent)}
           </DropdownMenuItem>
         ))}
         <DropdownMenuSeparator />
@@ -217,12 +273,15 @@ function NewViewMenu({ onOpenAgent }: { onOpenAgent: (agent: AgentKind) => void 
 function AgentTerminalInstance({
   tab,
   spacePath,
+  spaceSlug,
   active,
 }: {
   tab: AgentTerminalTab;
   spacePath: string;
+  spaceSlug: string;
   active: boolean;
 }) {
+  const cwd = tab.mode === 'background' ? tab.worktreePath! : spacePath;
   const containerRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -237,7 +296,10 @@ function AgentTerminalInstance({
   }, []);
 
   const { error, resize, start, status, write } = useAgentTerminal({
-    cwd: spacePath,
+    cwd,
+    mode: tab.mode,
+    spaceSlug,
+    changeId: tab.changeId,
     agent: tab.agent,
     onData: handleData,
     onExit: (exitCode) => {
@@ -293,10 +355,10 @@ function AgentTerminalInstance({
   useEffect(() => {
     const terminal = terminalRef.current;
     if (!terminal) return;
-    terminal.writeln(`Starting ${agentDisplayName(tab.agent)} in ${spacePath}…`);
+    terminal.writeln(`Starting ${agentDisplayName(tab.agent)} in ${cwd}…`);
     fitAddonRef.current?.fit();
     void start({ cols: terminal.cols, rows: terminal.rows });
-  }, [spacePath, start, tab.agent]);
+  }, [cwd, start, tab.agent]);
 
   useEffect(() => {
     if (!active) return;
@@ -313,7 +375,10 @@ function AgentTerminalInstance({
     >
       <div className="flex h-7 shrink-0 items-center border-b border-white/8 px-2.5 text-[10px] text-white/35">
         <span>{status}</span>
-        <span className="ml-2 truncate">{spacePath}</span>
+        <span className="ml-2 shrink-0 text-white/55">
+          {tab.mode === 'background' ? 'Background Change' : 'Current Draft'}
+        </span>
+        <span className="ml-2 truncate">{cwd}</span>
         <Button
           type="button"
           variant="ghost"

--- a/web/src/components/terminal/terminal-contract.ts
+++ b/web/src/components/terminal/terminal-contract.ts
@@ -2,6 +2,8 @@ import { agentDefinition, type AgentKind } from '../../lib/agents.ts';
 
 export type { AgentKind } from '../../lib/agents.ts';
 
+export type AgentTerminalMode = 'live' | 'background';
+
 export type TerminalSize = {
   cols: number;
   rows: number;

--- a/web/src/components/terminal/terminal-tabs.ts
+++ b/web/src/components/terminal/terminal-tabs.ts
@@ -1,8 +1,15 @@
-import { agentDisplayName, type AgentKind } from './terminal-contract.ts';
+import {
+  agentDisplayName,
+  type AgentKind,
+  type AgentTerminalMode,
+} from './terminal-contract.ts';
 
 export type AgentTerminalTab = {
   id: string;
   agent: AgentKind;
+  mode: AgentTerminalMode;
+  changeId?: string;
+  worktreePath?: string;
 };
 
 export type AgentTerminalTabsState = {
@@ -14,10 +21,23 @@ export function addAgentTab(
   state: AgentTerminalTabsState,
   agent: AgentKind,
   id: string,
+  mode: AgentTerminalMode = 'live',
+  background?: { changeId: string; worktreePath: string },
 ): AgentTerminalTabsState {
+  if (mode === 'background' && !background) {
+    throw new Error('background Agent tabs require a managed Change');
+  }
   return {
     activeTabId: id,
-    tabs: [...state.tabs, { id, agent }],
+    tabs: [
+      ...state.tabs,
+      {
+        id,
+        agent,
+        mode,
+        ...(background ?? {}),
+      },
+    ],
   };
 }
 
@@ -41,5 +61,6 @@ export function terminalTabLabel(tabs: AgentTerminalTab[], tab: AgentTerminalTab
   const matchingTabs = tabs.filter((candidate) => candidate.agent === tab.agent);
   const position = matchingTabs.findIndex((candidate) => candidate.id === tab.id);
   const label = agentDisplayName(tab.agent);
-  return matchingTabs.length > 1 ? `${label} ${position + 1}` : label;
+  const numbered = matchingTabs.length > 1 ? `${label} ${position + 1}` : label;
+  return tab.mode === 'background' ? `${numbered} · Background` : numbered;
 }

--- a/web/src/components/terminal/useAgentTerminal.ts
+++ b/web/src/components/terminal/useAgentTerminal.ts
@@ -7,6 +7,7 @@ import {
   belongsToTerminalSession,
   normalizeTerminalSize,
   type AgentKind,
+  type AgentTerminalMode,
   type TerminalDataEvent,
   type TerminalExitEvent,
   type TerminalSize,
@@ -17,11 +18,22 @@ type TerminalStatus = 'idle' | 'starting' | 'running' | 'exited' | 'error';
 type UseAgentTerminalOptions = {
   cwd: string;
   agent: AgentKind;
+  mode: AgentTerminalMode;
+  spaceSlug: string;
+  changeId?: string;
   onData: (data: string) => void;
   onExit?: (exitCode: number | null) => void;
 };
 
-export function useAgentTerminal({ cwd, agent, onData, onExit }: UseAgentTerminalOptions) {
+export function useAgentTerminal({
+  agent,
+  changeId,
+  cwd,
+  mode,
+  onData,
+  onExit,
+  spaceSlug,
+}: UseAgentTerminalOptions) {
   const sessionIdRef = useRef<string | null>(null);
   const generationRef = useRef(0);
   const listenersReadyRef = useRef<Promise<void> | null>(null);
@@ -66,6 +78,9 @@ export function useAgentTerminal({ cwd, agent, onData, onExit }: UseAgentTermina
         request: {
           sessionId: requestedSessionId,
           cwd,
+          mode,
+          spaceSlug,
+          changeId,
           agent,
           initialCommand: agentInitialCommand(agent),
           ...normalized,
@@ -91,7 +106,7 @@ export function useAgentTerminal({ cwd, agent, onData, onExit }: UseAgentTermina
       setStatus('error');
       setError(cause instanceof Error ? cause.message : String(cause));
     }
-  }, [agent, cwd]);
+  }, [agent, changeId, cwd, mode, spaceSlug]);
 
   const write = useCallback(async (data: string) => {
     const sessionId = sessionIdRef.current;

--- a/web/src/local-api.ts
+++ b/web/src/local-api.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import type {
+  AgentChange,
   PageFull,
   PageMeta,
   FileDiff,
@@ -76,6 +77,22 @@ export function workingDiff(spaceSlug: string): Promise<FileDiff[]> {
 
 export function keepWorkingDiff(spaceSlug: string, expected: FileDiff[]): Promise<unknown> {
   return invoke('local_keep_working_diff', { spaceSlug, expected });
+}
+
+export function createAgentChange(spaceSlug: string, agentName: string): Promise<AgentChange> {
+  return invoke('local_create_agent_change', { spaceSlug, agentName });
+}
+
+export function listAgentChanges(spaceSlug: string): Promise<AgentChange[]> {
+  return invoke('local_list_agent_changes', { spaceSlug });
+}
+
+export function mergeAgentChange(spaceSlug: string, changeId: string): Promise<AgentChange> {
+  return invoke('local_merge_agent_change', { spaceSlug, changeId });
+}
+
+export function discardAgentChange(spaceSlug: string, changeId: string): Promise<AgentChange> {
+  return invoke('local_discard_agent_change', { spaceSlug, changeId });
 }
 
 export function search(spaceSlug: string, query: string, limit: number): Promise<SearchResponse> {

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -1201,7 +1201,9 @@ export function MainLayout() {
                 }}
               />
               <AgentTerminalPanel
+                key={activeWorkspace.id}
                 spacePath={activeWorkspace.localPath}
+                spaceSlug={activeWorkspace.slug}
                 defaultAgent={clientSettings.defaultAgent}
                 onClose={() => setAgentPanelOpen(false)}
               />

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -1065,6 +1065,11 @@ export function MainLayout() {
                 <ReviewList
                   workspaceSlug={activeView.workspaceSlug}
                   onOpen={openReviewDetail}
+                  onLocalDraftChanged={() => {
+                    if (!activeWorkspace || activeWorkspace.slug !== activeView.workspaceSlug) return;
+                    void loadSpacePages(activeWorkspace);
+                    void loadSpaceSources(activeWorkspace);
+                  }}
                   refreshKey={reviewRefreshKey}
                 />
 

--- a/web/tests/agent-terminal.test.ts
+++ b/web/tests/agent-terminal.test.ts
@@ -13,6 +13,7 @@ import {
   terminalTabLabel,
   type AgentTerminalTabsState,
 } from '../src/components/terminal/terminal-tabs.ts';
+import { orderedLocalReviewRows } from '../src/components/review/local-review-model.ts';
 
 test('maps the supported agents to their local CLI command', () => {
   assert.equal(agentInitialCommand('codex'), 'codex');
@@ -52,8 +53,8 @@ test('opens multiple independent tabs for the same agent', () => {
   assert.deepEqual(second, {
     activeTabId: 'codex-2',
     tabs: [
-      { id: 'codex-1', agent: 'codex' },
-      { id: 'codex-2', agent: 'codex' },
+      { id: 'codex-1', agent: 'codex', mode: 'live' },
+      { id: 'codex-2', agent: 'codex', mode: 'live' },
     ],
   });
   assert.equal(terminalTabLabel(second.tabs, second.tabs[0]), 'Codex 1');
@@ -64,24 +65,64 @@ test('closing the active tab selects its nearest remaining neighbor', () => {
   const state: AgentTerminalTabsState = {
     activeTabId: 'claude-2',
     tabs: [
-      { id: 'codex-1', agent: 'codex' },
-      { id: 'claude-2', agent: 'claude' },
-      { id: 'codex-3', agent: 'codex' },
+      { id: 'codex-1', agent: 'codex', mode: 'live' },
+      { id: 'claude-2', agent: 'claude', mode: 'live' },
+      { id: 'codex-3', agent: 'codex', mode: 'live' },
     ],
   };
 
   assert.deepEqual(closeAgentTab(state, 'claude-2'), {
     activeTabId: 'codex-3',
     tabs: [
-      { id: 'codex-1', agent: 'codex' },
-      { id: 'codex-3', agent: 'codex' },
+      { id: 'codex-1', agent: 'codex', mode: 'live' },
+      { id: 'codex-3', agent: 'codex', mode: 'live' },
     ],
   });
 });
 
 test('closing the final tab returns to the agent launch page', () => {
   assert.deepEqual(
-    closeAgentTab({ activeTabId: 'codex-1', tabs: [{ id: 'codex-1', agent: 'codex' }] }, 'codex-1'),
+    closeAgentTab({
+      activeTabId: 'codex-1',
+      tabs: [{ id: 'codex-1', agent: 'codex', mode: 'live' }],
+    }, 'codex-1'),
     { activeTabId: null, tabs: [] },
+  );
+});
+
+test('agent tabs keep live and background execution identities separate', () => {
+  const empty: AgentTerminalTabsState = { activeTabId: null, tabs: [] };
+  const live = addAgentTab(empty, 'codex', 'live-1', 'live');
+  const background = addAgentTab(live, 'codex', 'background-1', 'background', {
+    changeId: 'change-1',
+    worktreePath: '/managed/change-1',
+  });
+
+  assert.deepEqual(background.tabs, [
+    { id: 'live-1', agent: 'codex', mode: 'live' },
+    {
+      id: 'background-1',
+      agent: 'codex',
+      mode: 'background',
+      changeId: 'change-1',
+      worktreePath: '/managed/change-1',
+    },
+  ]);
+  assert.equal(terminalTabLabel(background.tabs, background.tabs[0]), 'Codex 1');
+  assert.equal(terminalTabLabel(background.tabs, background.tabs[1]), 'Codex 2 · Background');
+});
+
+test('local Reviews always order Current Draft before Agent Changes', () => {
+  assert.deepEqual(orderedLocalReviewRows([]), [{ kind: 'draft', id: 'current-draft' }]);
+  assert.deepEqual(
+    orderedLocalReviewRows([
+      { id: 'older', createdAt: 10 },
+      { id: 'newer', createdAt: 20 },
+    ]),
+    [
+      { kind: 'draft', id: 'current-draft' },
+      { kind: 'agent', id: 'newer', change: { id: 'newer', createdAt: 20 } },
+      { kind: 'agent', id: 'older', change: { id: 'older', createdAt: 10 } },
+    ],
   );
 });

--- a/web/tests/agent-terminal.test.ts
+++ b/web/tests/agent-terminal.test.ts
@@ -13,7 +13,10 @@ import {
   terminalTabLabel,
   type AgentTerminalTabsState,
 } from '../src/components/terminal/terminal-tabs.ts';
-import { orderedLocalReviewRows } from '../src/components/review/local-review-model.ts';
+import {
+  localReviewActionRefreshesDraft,
+  orderedLocalReviewRows,
+} from '../src/components/review/local-review-model.ts';
 
 test('maps the supported agents to their local CLI command', () => {
   assert.equal(agentInitialCommand('codex'), 'codex');
@@ -125,4 +128,10 @@ test('local Reviews always order Current Draft before Agent Changes', () => {
       { kind: 'agent', id: 'older', change: { id: 'older', createdAt: 10 } },
     ],
   );
+});
+
+test('only merging an Agent Change refreshes the Draft navigation trees', () => {
+  assert.equal(localReviewActionRefreshesDraft('merge'), true);
+  assert.equal(localReviewActionRefreshesDraft('discard'), false);
+  assert.equal(localReviewActionRefreshesDraft('commit'), false);
 });


### PR DESCRIPTION
## Summary

- foreground Agent tabs edit the current local Draft directly
- background Agent runs create isolated local Changes backed by Git branches/worktrees
- Reviews shows **Current Draft** first, followed by Agent Changes
- Current Draft can be committed explicitly; Auto Save continues to write only local files
- merging an Agent Change performs a three-way merge onto the latest Draft without moving HEAD or creating a commit
- conflicts leave the Draft untouched and mark the Change as needing resolution
- discard and cleanup are idempotent, and active Agent terminals cannot be merged or discarded

## Product model

- **Live edit:** Agent and user share the current Draft.
- **Background change:** Agent works on an isolated branch and appears in Reviews.
- **Merge:** replay the Agent result onto the latest Draft; the user keeps editing and decides later when to commit.

This PR is local-only. Cloud PRs, History, and release CI are intentionally handled separately.

## Verification

- Rust: 79 tests passed
- Web: 40 tests passed
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- npm run build
- targeted ESLint: 0 errors
- independent correctness/security review: no blocking findings

## Related

- #125 — History and explicit checkpoints
- #126 — macOS DMG CI and GitHub download artifacts

## Known platform boundary

CoWiki is macOS-first for this release. Unix PTY process groups are stopped and awaited. Windows builds retain the portable-pty fallback, but robust descendant lifecycle management will require Windows Job Objects before Windows becomes a supported release target.