### PR TITLE
feat(desktop): add local version navigation

### DIFF
--- a/web/src/components/layout/SpaceRail.tsx
+++ b/web/src/components/layout/SpaceRail.tsx
@@ -111,15 +111,15 @@ export function SpaceRail({
       {/* Notification bell */}
       {showBell && <NotificationBell unread={notifUnread} onOpen={onShowNotifications} />}
 
-      {/* User avatar + menu. The trigger carries the Cloud accent while the
-          menu itself stays neutral so it does not resemble selected state. */}
+      {/* Account menu follows the desktop shell: a compact rounded-square
+          trigger, explicit connection status, then the available actions. */}
       <DropdownMenu>
         <Tooltip>
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
               <button
                 style={{
-                  width: 34, height: 34, borderRadius: '50%',
+                  width: 34, height: 34, borderRadius: 10,
                   background: showCloudActions ? C.sidebar : C.accentSoft,
                   border: showCloudActions ? `1px solid ${C.line}` : '1px solid rgba(226, 89, 11, 0.25)',
                   cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -143,7 +143,7 @@ export function SpaceRail({
           </TooltipTrigger>
           {!showCloudActions && <TooltipContent side="right">Sign up / Sign in</TooltipContent>}
         </Tooltip>
-        <DropdownMenuContent side="right" align="end" className="w-48">
+        <DropdownMenuContent side="right" align="end" sideOffset={10} className="w-[210px] rounded-xl p-1.5">
           {showCloudActions ? (
             <>
               <div className="px-2 py-1.5 text-xs text-gray-500">{userName}</div>
@@ -151,17 +151,22 @@ export function SpaceRail({
             </>
           ) : (
             <>
+              <div className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground">
+                <span
+                  aria-hidden
+                  style={{ width: 8, height: 8, borderRadius: '50%', background: C.amber, boxShadow: `0 0 0 3px ${C.amberSoft}` }}
+                />
+                Not signed in
+              </div>
+              <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={onConnectCloud}
-                className="mx-1 my-1 w-[calc(100%-8px)] items-start gap-2.5 rounded-md py-2.5 focus:bg-[#f5f4f1] focus:text-inherit"
+                className="rounded-lg px-2.5 py-2 font-semibold focus:bg-[#fbeadd] focus:text-[#e2590b]"
+                style={{ color: C.accent }}
               >
-                <Cloud size={16} className="mt-0.5 shrink-0" style={{ color: C.accent }} />
-                <span>
-                  <span className="block font-medium" style={{ color: C.accent }}>Sign up / Sign in</span>
-                  <span className="block text-xs text-muted-foreground">Connect to CoWiki Cloud</span>
-                </span>
+                <Cloud size={16} />
+                Sign in
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
             </>
           )}
           {/* Settings is not a Cloud feature — local-only Spaces need it too.

--- a/web/src/components/layout/VersionSwitcher.tsx
+++ b/web/src/components/layout/VersionSwitcher.tsx
@@ -1,0 +1,148 @@
+import { Check, GitBranch, Rows3 } from 'lucide-react';
+
+import type { AgentChange } from '@/api';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { C } from '@/lib/design';
+
+export type VersionSelection =
+  | { kind: 'working' }
+  | { kind: 'upstream' }
+  | { kind: 'agent'; changeId: string };
+
+type VersionSwitcherProps = {
+  agentChanges: AgentChange[];
+  selection: VersionSelection;
+  onSelect: (selection: VersionSelection) => void;
+  onSeeReviews: () => void;
+};
+
+export function VersionSwitcher({
+  agentChanges,
+  selection,
+  onSelect,
+  onSeeReviews,
+}: VersionSwitcherProps) {
+  const selectedAgent = selection.kind === 'agent'
+    ? agentChanges.find((change) => change.id === selection.changeId)
+    : undefined;
+  const label = selection.kind === 'working'
+    ? 'Current Draft'
+    : selection.kind === 'upstream'
+      ? 'main'
+      : selectedAgent?.title ?? 'Agent Change';
+  const dot = selection.kind === 'working'
+    ? C.accent
+    : selection.kind === 'upstream'
+      ? C.purple
+      : C.blue;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Switch version"
+          title="Switch version"
+          style={triggerStyle}
+        >
+          <GitBranch size={14} />
+          <span aria-hidden style={{ width: 7, height: 7, borderRadius: '50%', background: dot }} />
+          <span style={{ maxWidth: 150, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{label}</span>
+          <span aria-hidden style={{ color: C.faint, fontSize: 10 }}>⌄</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-72" sideOffset={6}>
+        <DropdownMenuLabel className="px-2 pb-1 pt-2 text-[10px] font-bold tracking-[0.09em] text-text-tertiary">
+          WORKING
+        </DropdownMenuLabel>
+        <VersionItem
+          label="Current Draft"
+          meta="Local working tree"
+          color={C.accent}
+          selected={selection.kind === 'working'}
+          onSelect={() => onSelect({ kind: 'working' })}
+        />
+
+        <DropdownMenuLabel className="px-2 pb-1 pt-3 text-[10px] font-bold tracking-[0.09em] text-text-tertiary">
+          UPSTREAM
+        </DropdownMenuLabel>
+        <VersionItem
+          label="main"
+          meta="Latest local checkpoint · read-only"
+          color={C.purple}
+          selected={selection.kind === 'upstream'}
+          onSelect={() => onSelect({ kind: 'upstream' })}
+        />
+
+        <DropdownMenuLabel className="px-2 pb-1 pt-3 text-[10px] font-bold tracking-[0.09em] text-text-tertiary">
+          AGENT CHANGES
+        </DropdownMenuLabel>
+        {agentChanges.length ? agentChanges.map((change) => (
+          <VersionItem
+            key={change.id}
+            label={change.title}
+            meta={`${change.diffs.length} changed ${change.diffs.length === 1 ? 'file' : 'files'} · Open`}
+            color={C.blue}
+            selected={selection.kind === 'agent' && selection.changeId === change.id}
+            onSelect={() => onSelect({ kind: 'agent', changeId: change.id })}
+          />
+        )) : (
+          <div className="px-2 py-2 text-xs text-text-tertiary">No open Agent Changes</div>
+        )}
+
+        <DropdownMenuSeparator className="my-1" />
+        <DropdownMenuItem onSelect={onSeeReviews} className="text-xs text-text-secondary">
+          <Rows3 />
+          See All in Reviews
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function VersionItem({
+  color,
+  label,
+  meta,
+  onSelect,
+  selected,
+}: {
+  color: string;
+  label: string;
+  meta: string;
+  onSelect: () => void;
+  selected: boolean;
+}) {
+  return (
+    <DropdownMenuItem onSelect={onSelect} className="gap-2.5 px-2 py-2">
+      <span aria-hidden style={{ width: 8, height: 8, borderRadius: '50%', flexShrink: 0, background: color }} />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[13px] font-semibold text-text">{label}</span>
+        <span className="block truncate font-mono text-[10.5px] text-text-tertiary">{meta}</span>
+      </span>
+      {selected ? <Check size={14} style={{ color: C.accent }} /> : <span style={{ width: 14 }} />}
+    </DropdownMenuItem>
+  );
+}
+
+const triggerStyle: React.CSSProperties = {
+  height: 28,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 7,
+  padding: '0 10px',
+  border: `1px solid ${C.line}`,
+  borderRadius: 7,
+  background: C.panel,
+  color: C.ink2,
+  fontSize: 12,
+  fontWeight: 550,
+  cursor: 'pointer',
+};

--- a/web/src/components/review/LocalReviewDetail.tsx
+++ b/web/src/components/review/LocalReviewDetail.tsx
@@ -19,12 +19,14 @@ export function LocalReviewDetail({
   target,
   onBack,
   onDraftChanged,
+  onReviewsChanged,
   onContinueAgent,
 }: {
   workspaceSlug: string;
   target: LocalReviewSelection;
   onBack: () => void;
   onDraftChanged?: () => void;
+  onReviewsChanged?: () => void;
   onContinueAgent?: (change: AgentChange) => void;
 }) {
   const [draftDiffs, setDraftDiffs] = useState<FileDiff[] | null>(null);
@@ -69,6 +71,7 @@ export function LocalReviewDetail({
     try {
       const result = await operation();
       await reload();
+      onReviewsChanged?.();
       if (action === 'merge') {
         const merge = agentMergeResult(
           (result as AgentChange).status === 'needsResolution' ? 'needsResolution' : 'merged',

--- a/web/src/components/views/HistoryView.tsx
+++ b/web/src/components/views/HistoryView.tsx
@@ -65,7 +65,7 @@ export function HistoryView({ workspaceSlug, local }: HistoryViewProps) {
   };
 
   return (
-    <section style={{ width: 'min(760px, 100%)', margin: '0 auto' }}>
+    <section style={{ width: 'min(860px, 100%)' }}>
       <header style={{ marginBottom: 30 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
           <History size={20} color={C.accent} strokeWidth={1.8} />
@@ -147,12 +147,11 @@ export function HistoryView({ workspaceSlug, local }: HistoryViewProps) {
             {loading ? (
               <div style={emptyStyle}><LoaderCircle size={17} className="animate-spin" /> Loading history…</div>
             ) : spaceHistory?.checkpoints.length ? (
-              <ol style={{ margin: 0, padding: 0, listStyle: 'none' }}>
-                {spaceHistory.checkpoints.map((checkpoint, index) => (
-                  <li key={checkpoint.id} style={{ position: 'relative', display: 'grid', gridTemplateColumns: '34px 1fr', gap: 12, paddingBottom: 18 }}>
-                    {index < spaceHistory.checkpoints.length - 1 && <span aria-hidden style={timelineStyle} />}
-                    <span style={commitIconStyle}><GitCommitHorizontal size={16} /></span>
+              <ol style={{ display: 'grid', gap: 10, margin: 0, padding: 0, listStyle: 'none' }}>
+                {spaceHistory.checkpoints.map((checkpoint) => (
+                  <li key={checkpoint.id}>
                     <div style={checkpointCardStyle}>
+                      <span style={commitIconStyle}><GitCommitHorizontal size={16} /></span>
                       <div style={{ minWidth: 0 }}>
                         <strong style={{ display: 'block', color: C.ink2, fontSize: 13.5, fontWeight: 620, overflow: 'hidden', textOverflow: 'ellipsis' }}>
                           {checkpoint.name}
@@ -236,8 +235,6 @@ const checkpointCardStyle: React.CSSProperties = {
 };
 
 const commitIconStyle: React.CSSProperties = {
-  position: 'relative',
-  zIndex: 1,
   width: 34,
   height: 34,
   display: 'grid',
@@ -245,16 +242,8 @@ const commitIconStyle: React.CSSProperties = {
   borderRadius: 999,
   color: C.green,
   background: C.greenSoft,
-  border: '3px solid #faf9f7',
-};
-
-const timelineStyle: React.CSSProperties = {
-  position: 'absolute',
-  top: 31,
-  bottom: -3,
-  left: 16,
-  width: 1,
-  background: C.line,
+  border: `1px solid ${C.line}`,
+  flexShrink: 0,
 };
 
 const commitCodeStyle: React.CSSProperties = {

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -4,6 +4,7 @@ import { getStoredAuth, storeAuth } from '../auth';
 import { buildWebGithubLoginUrl } from '../auth-flow';
 import { startDesktopGithubOAuth } from '../desktop-auth';
 import { apiBase, isDesktopClient } from '../runtime';
+import { C } from '@/lib/design';
 
 export function LoginPage() {
   const navigate = useNavigate();
@@ -24,43 +25,125 @@ export function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg)] flex items-center justify-center">
-      <div className="text-center max-w-md px-6">
-        <div className="flex items-center justify-center gap-2.5 mb-3">
-          <span className="text-3xl font-bold text-[var(--color-text)]" style={{ fontFamily: 'var(--font-serif)' }}>
-            CoWiki<span className="text-[var(--color-accent)]">.</span>
-          </span>
+    <main
+      data-tauri-drag-region="deep"
+      style={{ minHeight: '100vh', display: 'grid', placeItems: 'center', padding: 32, background: C.rail }}
+    >
+      <section style={shellStyle}>
+        <div style={brandPanelStyle}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 11 }}>
+            <img src="/cowiki-logo.svg" alt="CoWiki" width={34} height={34} />
+            <span style={{ color: C.ink, fontFamily: 'var(--font-serif)', fontSize: 25, fontWeight: 700 }}>
+              CoWiki
+            </span>
+          </div>
+          <div>
+            <p style={{ margin: '0 0 12px', color: C.accent, fontSize: 12, fontWeight: 700, letterSpacing: '0.08em' }}>
+              LOCAL FIRST
+            </p>
+            <h1 style={{ maxWidth: 380, margin: 0, color: C.ink, fontFamily: 'var(--font-serif)', fontSize: 38, lineHeight: 1.12, letterSpacing: '-0.025em' }}>
+              Your knowledge stays yours.
+            </h1>
+            <p style={{ maxWidth: 390, margin: '18px 0 0', color: C.muted, fontSize: 14, lineHeight: 1.7 }}>
+              Work in local Spaces without an account. Connect only when you want to publish or collaborate.
+            </p>
+          </div>
+          <p style={{ margin: 0, color: C.faint, fontSize: 11.5 }}>人与 AI 共建的知识空间</p>
         </div>
-        <p className="text-[var(--color-text-secondary)] text-base mb-10">
-          人与 AI 共建的团队知识库
-        </p>
 
-        <a
-          href={buildWebGithubLoginUrl(apiBase())}
-          onClick={signInWithGitHub}
-          className="inline-flex items-center gap-2.5 bg-[var(--color-text)] text-[var(--color-bg)] px-6 py-3 text-sm font-medium hover:opacity-90 transition-opacity"
-          style={{ borderRadius: 'var(--radius)' }}
-        >
-          <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-          </svg>
-          {desktop ? 'Connect to CoWiki Cloud' : 'Sign in with GitHub'}
-        </a>
+        <div style={formPanelStyle}>
+          <div style={{ width: 'min(340px, 100%)' }}>
+            <div style={{ width: 42, height: 42, display: 'grid', placeItems: 'center', marginBottom: 22, borderRadius: 12, background: C.accentSoft, color: C.accent }}>
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M7 18a4 4 0 0 1 0-8 5 5 0 0 1 9.6-1.3A3.5 3.5 0 0 1 17.5 18Z" />
+              </svg>
+            </div>
+            <h2 style={{ margin: 0, color: C.ink, fontFamily: 'var(--font-serif)', fontSize: 30, lineHeight: 1.2 }}>
+              Sign in
+            </h2>
+            <p style={{ margin: '9px 0 26px', color: C.muted, fontSize: 13.5, lineHeight: 1.6 }}>
+              Connect to CoWiki Cloud to publish or join a shared Space.
+            </p>
 
-        {desktop ? (
-          <button
-            type="button"
-            onClick={() => navigate('/', { replace: true })}
-            className="block mx-auto mt-4 text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
-          >
-            Continue locally
-          </button>
-        ) : null}
+            <a
+              href={buildWebGithubLoginUrl(apiBase())}
+              onClick={signInWithGitHub}
+              style={githubButtonStyle}
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              {desktop ? 'Continue with GitHub' : 'Sign in with GitHub'}
+            </a>
 
-        <p className="mt-12 text-xs text-[var(--color-text-tertiary)]">
-          {desktop ? 'Use local Spaces without an account. Sign in only to publish or join a shared Space.' : 'A team wiki that builds itself.'}
-        </p>
-      </div>
-    </div>
+            {desktop && (
+              <button type="button" onClick={() => navigate('/', { replace: true })} style={localButtonStyle}>
+                Continue locally
+              </button>
+            )}
+
+            <p style={{ margin: '22px 0 0', color: C.faint, fontSize: 11.5, lineHeight: 1.55 }}>
+              Signing in does not upload a local Space. Publishing remains an explicit action.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
   );
 }
+
+const shellStyle: React.CSSProperties = {
+  width: 'min(980px, 100%)',
+  minHeight: 590,
+  display: 'grid',
+  gridTemplateColumns: '1.05fr 0.95fr',
+  overflow: 'hidden',
+  border: `1px solid ${C.line}`,
+  borderRadius: 16,
+  background: C.panel,
+  boxShadow: '0 24px 70px rgba(29, 28, 26, 0.16), 0 2px 8px rgba(29, 28, 26, 0.08)',
+};
+
+const brandPanelStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  padding: '52px 54px 42px',
+  borderRight: `1px solid ${C.line}`,
+  background: C.sidebar,
+};
+
+const formPanelStyle: React.CSSProperties = {
+  display: 'grid',
+  placeItems: 'center',
+  padding: 48,
+  background: C.panel,
+};
+
+const githubButtonStyle: React.CSSProperties = {
+  width: '100%',
+  height: 44,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 10,
+  borderRadius: 9,
+  background: C.ink,
+  color: '#fff',
+  fontSize: 13.5,
+  fontWeight: 650,
+  textDecoration: 'none',
+};
+
+const localButtonStyle: React.CSSProperties = {
+  width: '100%',
+  height: 42,
+  marginTop: 10,
+  border: `1px solid ${C.line}`,
+  borderRadius: 9,
+  background: C.panel,
+  color: C.ink2,
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: 'pointer',
+};

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -19,13 +19,16 @@ import {
   deleteWorkspace,
   listPublicWorkspaces, joinWorkspace,
   listSources, getSource, listReviews, renamePath, deletePath,
-  type Workspace, type PageMeta, type PageFull, type SourceItem, type SourceContent, type AgentChange,
+  getLocalWorkingDiff, listLocalAgentChanges,
+  type Workspace, type PageMeta, type PageFull, type SourceItem, type SourceContent,
+  type AgentChange, type FileDiff,
 } from '../api';
 import { AddSourceDialog } from '@/components/AddSourceDialog';
 import { SettingsDialog } from '../components/SettingsDialog';
 import { getCurrentAuth, clearAuth, isRemoteAuth, hasAuth } from '../auth';
 import { SpaceRail } from '../components/layout/SpaceRail';
 import { SpacePanel, type NavTab } from '../components/layout/SpacePanel';
+import { VersionSwitcher, type VersionSelection } from '../components/layout/VersionSwitcher';
 type CreateSpaceMode = 'choose' | 'local' | 'import';
 import { ReviewList } from '../components/review/ReviewList';
 import { ReviewDetail } from '../components/review/ReviewDetail';
@@ -108,6 +111,9 @@ export function MainLayout() {
   const [reviewRefreshKey, setReviewRefreshKey] = useState(0);
   const [activeTab, setActiveTab] = useState<NavTab>('wiki');
   const [reviewCount, setReviewCount] = useState(0);
+  const [versionSelection, setVersionSelection] = useState<VersionSelection>({ kind: 'working' });
+  const [openAgentChanges, setOpenAgentChanges] = useState<AgentChange[]>([]);
+  const [workingDiffs, setWorkingDiffs] = useState<FileDiff[]>([]);
   const [sidebarLayout, setSidebarLayout] = useState(() => loadSidebarLayout(window.localStorage));
   const [resizingSidebar, setResizingSidebar] = useState(false);
   const sidebarResizeStart = useRef({ pointerX: 0, width: sidebarLayout.width });
@@ -328,6 +334,40 @@ export function MainLayout() {
       .catch(() => !cancelled && setReviewCount(0));
     return () => { cancelled = true; };
   }, [activeWorkspace, reviewRefreshKey]);
+
+  // The desktop version switcher is a local Git view: Working, HEAD
+  // (Upstream), and currently-open isolated Agent Changes only.
+  useEffect(() => {
+    if (!desktop || !activeWorkspace?.localPath) {
+      const task = window.setTimeout(() => {
+        setOpenAgentChanges([]);
+        setWorkingDiffs([]);
+        setVersionSelection({ kind: 'working' });
+      }, 0);
+      return () => window.clearTimeout(task);
+    }
+    let cancelled = false;
+    Promise.all([
+      listLocalAgentChanges(activeWorkspace.slug),
+      getLocalWorkingDiff(activeWorkspace.slug),
+    ]).then(([changes, diffs]) => {
+      if (cancelled) return;
+      const openChanges = changes.filter((change) => change.status === 'open');
+      setOpenAgentChanges(openChanges);
+      setWorkingDiffs(diffs);
+      setVersionSelection((current) => (
+        current.kind === 'agent' && !openChanges.some((change) => change.id === current.changeId)
+          ? { kind: 'working' }
+          : current
+      ));
+    }).catch(() => {
+      if (cancelled) return;
+      setOpenAgentChanges([]);
+      setWorkingDiffs([]);
+      setVersionSelection({ kind: 'working' });
+    });
+    return () => { cancelled = true; };
+  }, [activeWorkspace?.localPath, activeWorkspace?.slug, desktop, reviewRefreshKey]);
 
   function isPersonalSpace(ws: Workspace): boolean {
     return ws.visibility === 'private' && ws.role === 'owner';
@@ -802,6 +842,33 @@ export function MainLayout() {
   // Determine active page/source for panel highlight
   const currentActivePage = activeView?.kind === 'page' ? activeView.slug : null;
   const currentActiveSource = activeView?.kind === 'source' ? activeView.filename : null;
+  const selectedAgentChange = versionSelection.kind === 'agent'
+    ? openAgentChanges.find((change) => change.id === versionSelection.changeId)
+    : undefined;
+  const activePagePath = activeView?.kind === 'page'
+    ? (activeView.path || conceptPath(activeView.slug))
+    : null;
+  const workingPageDiff = activePagePath ? findDiffForPath(workingDiffs, activePagePath) : undefined;
+  const agentPageDiff = activePagePath && selectedAgentChange
+    ? findDiffForPath(selectedAgentChange.diffs, activePagePath)
+    : undefined;
+  const viewedPageBody = activeView?.kind === 'page' && activeView.content
+    ? versionSelection.kind === 'upstream'
+      ? (workingPageDiff?.old_content ?? activeView.content.body)
+      : versionSelection.kind === 'agent'
+        ? (agentPageDiff?.new_content ?? activeView.content.body)
+        : activeView.content.body
+    : '';
+  const viewedPageMissing = versionSelection.kind === 'upstream'
+    ? workingPageDiff?.old_content === null
+    : versionSelection.kind === 'agent'
+      ? agentPageDiff?.new_content === null
+      : false;
+  const readonlyVersionLabel = versionSelection.kind === 'upstream'
+    ? 'Viewing upstream “main”'
+    : versionSelection.kind === 'agent'
+      ? `Viewing ${selectedAgentChange?.title ?? 'Agent Change'} changes`
+      : '';
 
   if (desktop && workspacesLoaded && workspaces.length === 0) {
     return (
@@ -1017,6 +1084,15 @@ export function MainLayout() {
               {/* Right: actions */}
               <div className="app-header-actions" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
 
+                {desktop && activeWorkspace?.localPath && !editingPage && (
+                  <VersionSwitcher
+                    selection={versionSelection}
+                    agentChanges={openAgentChanges}
+                    onSelect={setVersionSelection}
+                    onSeeReviews={() => handleTabChange('reviews')}
+                  />
+                )}
+
                 {desktop && activeWorkspace?.localPath && (
                   <button
                     type="button"
@@ -1033,7 +1109,7 @@ export function MainLayout() {
                 )}
 
                 {/* Wiki-specific actions */}
-                {activeTab === 'wiki' && (activeView?.kind === 'page' || activeView?.kind === 'source') && (
+                {versionSelection.kind === 'working' && activeTab === 'wiki' && (activeView?.kind === 'page' || activeView?.kind === 'source') && (
                   <>
                     {activeView?.kind === 'page' && activeView.content && !editingPage && (
                       <button
@@ -1114,11 +1190,11 @@ export function MainLayout() {
                     target={activeView.target}
                     onBack={() => handleTabChange('reviews')}
                     onDraftChanged={() => {
-                      setReviewRefreshKey((key) => key + 1);
                       if (!activeWorkspace || activeWorkspace.slug !== activeView.workspaceSlug) return;
                       void loadSpacePages(activeWorkspace);
                       void loadSpaceSources(activeWorkspace);
                     }}
+                    onReviewsChanged={() => setReviewRefreshKey((key) => key + 1)}
                     onContinueAgent={(change: AgentChange) => {
                       setAgentPanelOpen(true);
                       setAgentOpenRequest({
@@ -1215,10 +1291,30 @@ export function MainLayout() {
                   // scroll. Opening it shrinks the doc from the right only.
                   <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'stretch' }}>
                     <article ref={articleRef} className="prose" style={{ flex: 1, minWidth: 0, overflow: 'auto', padding: '36px 48px 56px 56px' }}>
-                      <PageByline name={activeView.content.edited_by} editedAt={activeView.content.edited_at} />
-                      <ReactMarkdown remarkPlugins={[remarkGfm]} components={commentMarkdownComponents}>
-                        {renderBody(activeView.content.body)}
-                      </ReactMarkdown>
+                      {versionSelection.kind !== 'working' && (
+                        <div style={readonlyVersionBannerStyle}>
+                          <span aria-hidden style={{
+                            width: 8,
+                            height: 8,
+                            borderRadius: '50%',
+                            background: versionSelection.kind === 'upstream' ? C.purple : C.blue,
+                            flexShrink: 0,
+                          }} />
+                          <span>{readonlyVersionLabel} · <span style={{ color: C.muted }}>read-only</span></span>
+                        </div>
+                      )}
+                      {viewedPageMissing ? (
+                        <div style={missingVersionStyle}>This page does not exist in the selected version.</div>
+                      ) : (
+                        <>
+                          {versionSelection.kind === 'working' && (
+                            <PageByline name={activeView.content.edited_by} editedAt={activeView.content.edited_at} />
+                          )}
+                          <ReactMarkdown remarkPlugins={[remarkGfm]} components={commentMarkdownComponents}>
+                            {renderBody(viewedPageBody)}
+                          </ReactMarkdown>
+                        </>
+                      )}
                     </article>
                     <CommentsPanel />
                   </div>
@@ -1626,6 +1722,34 @@ const headerBtnStyle: React.CSSProperties = {
   background: 'transparent', color: C.muted, fontSize: 12,
   transition: 'background 0.1s',
 };
+
+const readonlyVersionBannerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 9,
+  marginBottom: 24,
+  padding: '10px 14px',
+  border: `1px solid ${C.line}`,
+  borderRadius: 9,
+  background: C.sidebar,
+  color: C.ink2,
+  fontSize: 12.5,
+};
+
+const missingVersionStyle: React.CSSProperties = {
+  padding: '34px 18px',
+  border: `1px dashed ${C.line}`,
+  borderRadius: 10,
+  background: C.panel,
+  color: C.muted,
+  textAlign: 'center',
+  fontSize: 13,
+};
+
+function findDiffForPath(diffs: FileDiff[], path: string): FileDiff | undefined {
+  const normalized = path.replace(/^\.\//, '');
+  return diffs.find((diff) => diff.path.replace(/^\.\//, '') === normalized);
+}
 
 function isMissingLocalPageError(error: unknown): boolean {
   const message = String(error).toLowerCase();

--- a/web/tests/auth-flow.test.ts
+++ b/web/tests/auth-flow.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import {
@@ -6,6 +7,9 @@ import {
   buildWebGithubLoginUrl,
   parseDesktopOAuthCallback,
 } from '../src/auth-flow.ts';
+
+const loginPage = readFileSync(new URL('../src/pages/LoginPage.tsx', import.meta.url), 'utf8');
+const spaceRail = readFileSync(new URL('../src/components/layout/SpaceRail.tsx', import.meta.url), 'utf8');
 
 test('web GitHub login keeps the existing browser URL', () => {
   assert.equal(
@@ -31,4 +35,12 @@ test('desktop callback accepts credential query params from the loopback listene
     ),
     { apiKey: 'cw_123', userName: 'octo-cat', userId: 'user-1' },
   );
+});
+
+test('desktop sign in follows the local-first shell design', () => {
+  assert.match(loginPage, /LOCAL FIRST/);
+  assert.match(loginPage, /Continue locally/);
+  assert.match(loginPage, /Signing in does not upload a local Space/);
+  assert.match(spaceRail, /Not signed in/);
+  assert.match(spaceRail, />\s*Sign in\s*</);
 });

--- a/web/tests/history.test.ts
+++ b/web/tests/history.test.ts
@@ -10,6 +10,7 @@ import {
 
 const mainLayout = readFileSync(new URL('../src/pages/MainLayout.tsx', import.meta.url), 'utf8');
 const spacePanel = readFileSync(new URL('../src/components/layout/SpacePanel.tsx', import.meta.url), 'utf8');
+const historyView = readFileSync(new URL('../src/components/views/HistoryView.tsx', import.meta.url), 'utf8');
 
 test('checkpoint names use the user local date and time', () => {
   const localTime = new Date(2026, 6, 15, 23, 5);
@@ -35,4 +36,9 @@ test('space navigation replaces Activity with History', () => {
   assert.match(spacePanel, /label: 'History'/);
   assert.doesNotMatch(mainLayout, /kind: 'activity'/);
   assert.match(mainLayout, /kind: 'history'/);
+});
+
+test('History shares the left-aligned content grid', () => {
+  assert.match(historyView, /width: 'min\(860px, 100%\)'/);
+  assert.doesNotMatch(historyView, /margin: '0 auto'/);
 });

--- a/web/tests/page-header.test.ts
+++ b/web/tests/page-header.test.ts
@@ -12,6 +12,10 @@ const spacePanel = readFileSync(
   new URL('../src/components/layout/SpacePanel.tsx', import.meta.url),
   'utf8',
 );
+const versionSwitcher = readFileSync(
+  new URL('../src/components/layout/VersionSwitcher.tsx', import.meta.url),
+  'utf8',
+);
 
 test('the page header has no unused overflow actions menu', () => {
   assert.equal(mainLayout.includes('aria-label="More actions"'), false);
@@ -53,4 +57,14 @@ test('long breadcrumbs cannot shrink or wrap the header actions', () => {
 
 test('Source titles use a dedicated overflow-safe presentation class', () => {
   assert.match(mainLayout, /className="page-title page-title--compact source-title"/);
+});
+
+test('the desktop header exposes the focused local version switcher', () => {
+  assert.match(mainLayout, /desktop && activeWorkspace\?\.localPath/);
+  assert.match(mainLayout, /change\.status === 'open'/);
+  assert.match(versionSwitcher, />\s*WORKING\s*</);
+  assert.match(versionSwitcher, />\s*UPSTREAM\s*</);
+  assert.match(versionSwitcher, />\s*AGENT CHANGES\s*</);
+  assert.match(versionSwitcher, /See All in Reviews/);
+  assert.doesNotMatch(versionSwitcher, /CHECKPOINTS|Discarded|Merged/);
 });


### PR DESCRIPTION
## Summary

- add a desktop-wide version switcher for Working, Upstream, and open Agent Changes
- preview upstream HEAD and Agent Change content read-only on the current page
- link the switcher to Reviews and refresh it after checkpoint, merge, or discard actions
- align History with the shared left content grid
- bring the account popover and Sign In page in line with the desktop design language

## Desktop behavior

Working is the editable Current Draft. Upstream is the latest local Git checkpoint represented by HEAD. Agent Changes lists only entries whose status is open. Non-working views are read-only.

## Verification

- npm run build
- npm test (68 passed)
- ESLint on changed files (0 errors; existing MainLayout hook warnings remain)
- restarted the Tauri desktop client against the rebased branch

## Stack

This PR is intentionally based on #132 because both changes touch the local Reviews navigation and MainLayout. After #132 merges, this PR can be retargeted to dev.

## Visual check

The Tauri client was verified locally after a clean restart. A screenshot is not attached because macOS screen capture is unavailable in the agent session.