### PR TITLE
fix(desktop): preserve Agent sessions when collapsed

### DIFF
--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -1382,8 +1382,8 @@ export function MainLayout() {
             </CommentsProvider>
           </main>
 
-          {desktop && agentPanelOpen && activeWorkspace?.localPath && (
-            <div style={{
+          {desktop && activeWorkspace?.localPath && (
+            <div hidden={!agentPanelOpen} style={{
               width: agentPanelWidth, minWidth: agentPanelWidth, height: '100vh',
               position: 'relative', flexShrink: 0,
             }}>

--- a/web/tests/agent-terminal.test.ts
+++ b/web/tests/agent-terminal.test.ts
@@ -57,6 +57,22 @@ test('routes terminal events only to their owning session', () => {
   assert.equal(belongsToTerminalSession(null, 'terminal-a'), false);
 });
 
+test('collapsing the Agent panel hides it without unmounting terminal sessions', () => {
+  const mainLayout = readFileSync(
+    new URL('../src/pages/MainLayout.tsx', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    mainLayout,
+    /\{desktop && activeWorkspace\?\.localPath && \(\s*<div hidden=\{!agentPanelOpen\}/,
+  );
+  assert.match(mainLayout, /hidden=\{!agentPanelOpen\}[\s\S]*<AgentTerminalPanel/);
+  assert.doesNotMatch(
+    mainLayout,
+    /desktop && agentPanelOpen && activeWorkspace\?\.localPath/,
+  );
+});
+
 test('opens multiple independent tabs for the same agent', () => {
   const empty: AgentTerminalTabsState = { activeTabId: null, tabs: [] };
   const first = addAgentTab(empty, 'codex', 'codex-1');


### PR DESCRIPTION
## Summary
- keep the current Space's Agent panel mounted while it is collapsed
- preserve Agent tabs, xterm scrollback, and running PTY sessions across collapse/reopen
- retain the existing cleanup behavior for explicit tab close, Space changes, and app exit

## Root cause
The Agent panel was conditionally mounted with `agentPanelOpen`. Collapsing it unmounted every terminal instance, whose hook cleanup invokes `terminal_kill`.

## Test plan
- `cd web && npm run test:agent-terminal`
- `cd web && npm test`
- `cd web && npm run build`
- `git diff --check`
