### PR TITLE
feat: add competition Cloud submission workflow

### DIFF
--- a/.env.cloud.local.example
+++ b/.env.cloud.local.example
@@ -1,0 +1,12 @@
+# Copy to .env.cloud.local. Register a GitHub OAuth app whose callback is:
+# http://localhost:5173/api/auth/github/callback
+POSTGRES_DB=cowiki
+POSTGRES_USER=cowiki
+POSTGRES_PASSWORD=cowiki-local
+DATABASE_URL=postgres://cowiki:cowiki-local@postgres:5432/cowiki
+COWIKI_TOKEN_PEPPER=replace-with-at-least-32-random-bytes
+GITHUB_CLIENT_ID=replace-with-local-github-oauth-client-id
+GITHUB_CLIENT_SECRET=replace-with-local-github-oauth-client-secret
+COWIKI_PUBLIC_ORIGIN=http://localhost:5173
+COWIKI_BIND_ADDR=0.0.0.0:8787
+RUST_LOG=cowiki_cloud=info,tower_http=info

--- a/cloud/migrations/002_space_invitations.sql
+++ b/cloud/migrations/002_space_invitations.sql
@@ -1,0 +1,15 @@
+CREATE TABLE space_invitations (
+    id UUID PRIMARY KEY,
+    space_id UUID NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+    created_by UUID NOT NULL REFERENCES users(id),
+    role member_role NOT NULL CHECK (role <> 'owner'),
+    token_hash BYTEA NOT NULL UNIQUE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked_at TIMESTAMPTZ,
+    accepted_count INTEGER NOT NULL DEFAULT 0 CHECK (accepted_count >= 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX space_invitations_active_space_idx
+    ON space_invitations(space_id, created_at DESC)
+    WHERE revoked_at IS NULL;

--- a/cloud/src/auth.rs
+++ b/cloud/src/auth.rs
@@ -241,15 +241,14 @@ async fn exchange_request(
         "cli" => "CoWiki CLI",
         _ => return Err(AppError::BadRequest("unsupported OAuth client".into())),
     };
-    let issued =
-        db::exchange_code(
-            &state.pool,
-            request.code.trim(),
-            &state.config.token_pepper,
-            label,
-        )
-            .await?
-            .ok_or_else(|| AppError::BadRequest("OAuth code is invalid or expired".into()))?;
+    let issued = db::exchange_code(
+        &state.pool,
+        request.code.trim(),
+        &state.config.token_pepper,
+        label,
+    )
+    .await?
+    .ok_or_else(|| AppError::BadRequest("OAuth code is invalid or expired".into()))?;
     Ok(no_store_json(DesktopExchangeResponse {
         api_key: issued.api_key,
         user_name: issued.user.display_name,

--- a/cloud/src/auth.rs
+++ b/cloud/src/auth.rs
@@ -49,6 +49,7 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/auth/github", get(github_start))
         .route("/api/auth/github/callback", get(github_callback))
+        .route("/api/auth/exchange", post(exchange))
         .route("/api/auth/desktop/exchange", post(desktop_exchange))
         .route("/api/me", get(me))
         .route("/api/auth/logout", post(logout))
@@ -65,12 +66,12 @@ async fn github_start(
     Query(query): Query<GithubStartQuery>,
 ) -> AppResult<Redirect> {
     let callback = match query.client.as_deref() {
-        Some("desktop") => Some(
-            validate_desktop_callback(
+        Some("desktop" | "cli") => Some(
+            validate_loopback_callback(
                 query
                     .callback
                     .as_deref()
-                    .ok_or_else(|| AppError::BadRequest("desktop callback is required".into()))?,
+                    .ok_or_else(|| AppError::BadRequest("loopback callback is required".into()))?,
             )
             .map_err(AppError::BadRequest)?,
         ),
@@ -204,6 +205,7 @@ async fn github_callback(
 #[serde(rename_all = "camelCase")]
 struct DesktopExchangeRequest {
     code: String,
+    client: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -216,12 +218,38 @@ struct DesktopExchangeResponse {
 
 async fn desktop_exchange(
     State(state): State<AppState>,
+    Json(mut request): Json<DesktopExchangeRequest>,
+) -> AppResult<Response> {
+    request.client = Some("desktop".into());
+    exchange_request(&state, request).await
+}
+
+async fn exchange(
+    State(state): State<AppState>,
     Json(request): Json<DesktopExchangeRequest>,
 ) -> AppResult<Response> {
+    exchange_request(&state, request).await
+}
+
+async fn exchange_request(
+    state: &AppState,
+    request: DesktopExchangeRequest,
+) -> AppResult<Response> {
+    let label = match request.client.as_deref().unwrap_or("desktop") {
+        "web" => "CoWiki Web",
+        "desktop" => "CoWiki Desktop",
+        "cli" => "CoWiki CLI",
+        _ => return Err(AppError::BadRequest("unsupported OAuth client".into())),
+    };
     let issued =
-        db::exchange_desktop_code(&state.pool, request.code.trim(), &state.config.token_pepper)
+        db::exchange_code(
+            &state.pool,
+            request.code.trim(),
+            &state.config.token_pepper,
+            label,
+        )
             .await?
-            .ok_or_else(|| AppError::BadRequest("desktop code is invalid or expired".into()))?;
+            .ok_or_else(|| AppError::BadRequest("OAuth code is invalid or expired".into()))?;
     Ok(no_store_json(DesktopExchangeResponse {
         api_key: issued.api_key,
         user_name: issued.user.display_name,
@@ -258,8 +286,8 @@ fn bearer_token(headers: &HeaderMap) -> AppResult<&str> {
         .ok_or(AppError::Unauthorized)
 }
 
-pub fn validate_desktop_callback(value: &str) -> Result<Url, String> {
-    let url = Url::parse(value).map_err(|error| format!("invalid desktop callback: {error}"))?;
+pub fn validate_loopback_callback(value: &str) -> Result<Url, String> {
+    let url = Url::parse(value).map_err(|error| format!("invalid loopback callback: {error}"))?;
     let valid = url.scheme() == "http"
         && url.host_str() == Some("127.0.0.1")
         && url.port().is_some()
@@ -270,7 +298,11 @@ pub fn validate_desktop_callback(value: &str) -> Result<Url, String> {
         && url.fragment().is_none();
     valid
         .then_some(url)
-        .ok_or_else(|| "desktop callback must be http://127.0.0.1:<port>/auth/callback".into())
+        .ok_or_else(|| "callback must be http://127.0.0.1:<port>/auth/callback".into())
+}
+
+pub fn validate_desktop_callback(value: &str) -> Result<Url, String> {
+    validate_loopback_callback(value)
 }
 
 pub fn random_secret(prefix: &str) -> String {

--- a/cloud/src/db.rs
+++ b/cloud/src/db.rs
@@ -5,7 +5,9 @@ use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 
 use crate::auth::{api_key_hash, random_secret};
-use crate::model::{MemberRole, PullRequestStatus, User};
+use crate::model::{
+    MemberRole, PullRequestStatus, SpaceInvitation, SpaceInvitationPreview, User,
+};
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct SpaceMembership {
@@ -45,6 +47,9 @@ pub struct IssuedApiKey {
     pub api_key: String,
     pub user: User,
 }
+
+const INVITATION_COLUMNS: &str =
+    "id, space_id, created_by, role, expires_at, revoked_at, accepted_count, created_at";
 
 pub async fn connect_and_migrate(database_url: &str) -> Result<PgPool, sqlx::Error> {
     let options = PgConnectOptions::from_str(database_url)?.disable_statement_logging();
@@ -334,6 +339,185 @@ pub async fn remove_space_member(
         .bind(space_id)
         .bind(actor_id)
         .bind(member_id.to_string())
+        .execute(&mut *transaction)
+        .await?;
+    }
+    transaction.commit().await?;
+    Ok(result.rows_affected() == 1)
+}
+
+pub async fn create_space_invitation(
+    pool: &PgPool,
+    invitation_id: Uuid,
+    space_id: Uuid,
+    actor_id: Uuid,
+    role: MemberRole,
+    token_hash: &[u8],
+    expires_at: OffsetDateTime,
+) -> Result<SpaceInvitation, sqlx::Error> {
+    let mut transaction = pool.begin().await?;
+    let invitation = sqlx::query_as::<_, SpaceInvitation>(&format!(
+        "INSERT INTO space_invitations
+            (id, space_id, created_by, role, token_hash, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING {INVITATION_COLUMNS}"
+    ))
+    .bind(invitation_id)
+    .bind(space_id)
+    .bind(actor_id)
+    .bind(role)
+    .bind(token_hash)
+    .bind(expires_at)
+    .fetch_one(&mut *transaction)
+    .await?;
+    sqlx::query(
+        "INSERT INTO audit_events
+            (space_id, actor_id, action, subject_type, subject_id, metadata)
+         VALUES ($1, $2, 'space_invitation.created', 'space_invitation', $3,
+                 jsonb_build_object('role', $4::text, 'expires_at', $5::text))",
+    )
+    .bind(space_id)
+    .bind(actor_id)
+    .bind(invitation_id.to_string())
+    .bind(role.as_str())
+    .bind(expires_at.to_string())
+    .execute(&mut *transaction)
+    .await?;
+    transaction.commit().await?;
+    Ok(invitation)
+}
+
+pub async fn list_space_invitations(
+    pool: &PgPool,
+    space_id: Uuid,
+) -> Result<Vec<SpaceInvitation>, sqlx::Error> {
+    sqlx::query_as::<_, SpaceInvitation>(&format!(
+        "SELECT {INVITATION_COLUMNS}
+         FROM space_invitations
+         WHERE space_id = $1 AND revoked_at IS NULL AND expires_at > now()
+         ORDER BY created_at DESC"
+    ))
+    .bind(space_id)
+    .fetch_all(pool)
+    .await
+}
+
+pub async fn preview_space_invitation(
+    pool: &PgPool,
+    token_hash: &[u8],
+) -> Result<Option<SpaceInvitationPreview>, sqlx::Error> {
+    sqlx::query_as::<_, SpaceInvitationPreview>(
+        "SELECT space_invitations.id, spaces.id AS space_id, spaces.name AS space_name,
+                spaces.slug AS space_slug, space_invitations.role,
+                space_invitations.expires_at
+         FROM space_invitations
+         JOIN spaces ON spaces.id = space_invitations.space_id
+         WHERE token_hash = $1
+           AND revoked_at IS NULL
+           AND expires_at > now()",
+    )
+    .bind(token_hash)
+    .fetch_optional(pool)
+    .await
+}
+
+pub async fn accept_space_invitation(
+    pool: &PgPool,
+    token_hash: &[u8],
+    user_id: Uuid,
+) -> Result<Option<SpaceMembership>, sqlx::Error> {
+    let mut transaction = pool.begin().await?;
+    let invitation = sqlx::query_as::<_, SpaceInvitationPreview>(
+        "SELECT space_invitations.id, spaces.id AS space_id, spaces.name AS space_name,
+                spaces.slug AS space_slug, space_invitations.role,
+                space_invitations.expires_at
+         FROM space_invitations
+         JOIN spaces ON spaces.id = space_invitations.space_id
+         WHERE token_hash = $1
+           AND revoked_at IS NULL
+           AND expires_at > now()
+         FOR UPDATE OF space_invitations",
+    )
+    .bind(token_hash)
+    .fetch_optional(&mut *transaction)
+    .await?;
+    let Some(invitation) = invitation else {
+        transaction.rollback().await?;
+        return Ok(None);
+    };
+    let existing = sqlx::query_scalar::<_, MemberRole>(
+        "SELECT role FROM space_members WHERE space_id = $1 AND user_id = $2",
+    )
+    .bind(invitation.space_id)
+    .bind(user_id)
+    .fetch_optional(&mut *transaction)
+    .await?;
+    let role = if let Some(existing) = existing {
+        existing
+    } else {
+        sqlx::query(
+            "INSERT INTO space_members (space_id, user_id, role)
+             VALUES ($1, $2, $3)",
+        )
+        .bind(invitation.space_id)
+        .bind(user_id)
+        .bind(invitation.role)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            "UPDATE space_invitations SET accepted_count = accepted_count + 1
+             WHERE id = $1",
+        )
+        .bind(invitation.id)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            "INSERT INTO audit_events
+                (space_id, actor_id, action, subject_type, subject_id, metadata)
+             VALUES ($1, $2, 'space_invitation.accepted', 'space_invitation', $3,
+                     jsonb_build_object('role', $4::text))",
+        )
+        .bind(invitation.space_id)
+        .bind(user_id)
+        .bind(invitation.id.to_string())
+        .bind(invitation.role.as_str())
+        .execute(&mut *transaction)
+        .await?;
+        invitation.role
+    };
+    transaction.commit().await?;
+    Ok(Some(SpaceMembership {
+        id: invitation.space_id,
+        name: invitation.space_name,
+        slug: invitation.space_slug,
+        role,
+    }))
+}
+
+pub async fn revoke_space_invitation(
+    pool: &PgPool,
+    space_id: Uuid,
+    invitation_id: Uuid,
+    actor_id: Uuid,
+) -> Result<bool, sqlx::Error> {
+    let mut transaction = pool.begin().await?;
+    let result = sqlx::query(
+        "UPDATE space_invitations SET revoked_at = now()
+         WHERE id = $1 AND space_id = $2 AND revoked_at IS NULL",
+    )
+    .bind(invitation_id)
+    .bind(space_id)
+    .execute(&mut *transaction)
+    .await?;
+    if result.rows_affected() == 1 {
+        sqlx::query(
+            "INSERT INTO audit_events
+                (space_id, actor_id, action, subject_type, subject_id)
+             VALUES ($1, $2, 'space_invitation.revoked', 'space_invitation', $3)",
+        )
+        .bind(space_id)
+        .bind(actor_id)
+        .bind(invitation_id.to_string())
         .execute(&mut *transaction)
         .await?;
     }

--- a/cloud/src/db.rs
+++ b/cloud/src/db.rs
@@ -137,10 +137,11 @@ pub async fn create_desktop_exchange_code(
     Ok(code)
 }
 
-pub async fn exchange_desktop_code(
+pub async fn exchange_code(
     pool: &PgPool,
     raw_code: &str,
     pepper: &str,
+    label: &str,
 ) -> Result<Option<IssuedApiKey>, sqlx::Error> {
     let mut transaction = pool.begin().await?;
     let code_hash = api_key_hash(raw_code, pepper);
@@ -161,11 +162,12 @@ pub async fn exchange_desktop_code(
     let token_hash = api_key_hash(&api_key, pepper);
     sqlx::query(
         "INSERT INTO api_keys (id, user_id, token_hash, label)
-         VALUES ($1, $2, $3, 'CoWiki Desktop')",
+         VALUES ($1, $2, $3, $4)",
     )
     .bind(Uuid::new_v4())
     .bind(user_id)
     .bind(token_hash.as_slice())
+    .bind(label)
     .execute(&mut *transaction)
     .await?;
     let user = sqlx::query_as::<_, User>(

--- a/cloud/src/db.rs
+++ b/cloud/src/db.rs
@@ -5,9 +5,7 @@ use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 
 use crate::auth::{api_key_hash, random_secret};
-use crate::model::{
-    MemberRole, PullRequestStatus, SpaceInvitation, SpaceInvitationPreview, User,
-};
+use crate::model::{MemberRole, PullRequestStatus, SpaceInvitation, SpaceInvitationPreview, User};
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct SpaceMembership {
@@ -273,6 +271,16 @@ pub async fn user_by_handle(pool: &PgPool, handle: &str) -> Result<Option<User>,
          FROM users WHERE lower(handle) = lower($1)",
     )
     .bind(handle)
+    .fetch_optional(pool)
+    .await
+}
+
+pub async fn user_by_id(pool: &PgPool, user_id: Uuid) -> Result<Option<User>, sqlx::Error> {
+    sqlx::query_as::<_, User>(
+        "SELECT id, github_id, handle, display_name, avatar_url
+         FROM users WHERE id = $1",
+    )
+    .bind(user_id)
     .fetch_optional(pool)
     .await
 }
@@ -774,6 +782,7 @@ pub async fn approve_pull_request(
     record: &PullRequestRecord,
     user_id: Uuid,
 ) -> Result<(), sqlx::Error> {
+    let mut transaction = pool.begin().await?;
     sqlx::query(
         "INSERT INTO pull_request_approvals (pull_request_id, user_id, head_oid)
          VALUES ($1, $2, $3)
@@ -783,8 +792,22 @@ pub async fn approve_pull_request(
     .bind(record.id)
     .bind(user_id)
     .bind(&record.head_oid)
-    .execute(pool)
+    .execute(&mut *transaction)
     .await?;
+    sqlx::query(
+        "INSERT INTO audit_events
+            (space_id, actor_id, action, subject_type, subject_id, metadata)
+         VALUES ($1, $2, 'pull_request.approved', 'pull_request', $3,
+                 jsonb_build_object('number', $4::bigint, 'head_oid', $5::text))",
+    )
+    .bind(record.space_id)
+    .bind(user_id)
+    .bind(record.id.to_string())
+    .bind(record.number)
+    .bind(&record.head_oid)
+    .execute(&mut *transaction)
+    .await?;
+    transaction.commit().await?;
     Ok(())
 }
 

--- a/cloud/src/db.rs
+++ b/cloud/src/db.rs
@@ -453,25 +453,18 @@ pub async fn accept_space_invitation(
         transaction.rollback().await?;
         return Ok(None);
     };
-    let existing = sqlx::query_scalar::<_, MemberRole>(
-        "SELECT role FROM space_members WHERE space_id = $1 AND user_id = $2",
+    let inserted_role = sqlx::query_scalar::<_, MemberRole>(
+        "INSERT INTO space_members (space_id, user_id, role)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (space_id, user_id) DO NOTHING
+         RETURNING role",
     )
     .bind(invitation.space_id)
     .bind(user_id)
+    .bind(invitation.role)
     .fetch_optional(&mut *transaction)
     .await?;
-    let role = if let Some(existing) = existing {
-        existing
-    } else {
-        sqlx::query(
-            "INSERT INTO space_members (space_id, user_id, role)
-             VALUES ($1, $2, $3)",
-        )
-        .bind(invitation.space_id)
-        .bind(user_id)
-        .bind(invitation.role)
-        .execute(&mut *transaction)
-        .await?;
+    let role = if let Some(role) = inserted_role {
         sqlx::query(
             "UPDATE space_invitations SET accepted_count = accepted_count + 1
              WHERE id = $1",
@@ -491,7 +484,15 @@ pub async fn accept_space_invitation(
         .bind(invitation.role.as_str())
         .execute(&mut *transaction)
         .await?;
-        invitation.role
+        role
+    } else {
+        sqlx::query_scalar::<_, MemberRole>(
+            "SELECT role FROM space_members WHERE space_id = $1 AND user_id = $2",
+        )
+        .bind(invitation.space_id)
+        .bind(user_id)
+        .fetch_one(&mut *transaction)
+        .await?
     };
     transaction.commit().await?;
     Ok(Some(SpaceMembership {

--- a/cloud/src/git_repo.rs
+++ b/cloud/src/git_repo.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -32,6 +33,8 @@ pub enum GitRepoError {
     ObjectNotFound(String),
     #[error("repository lock registry is unavailable")]
     LockPoisoned,
+    #[error("pull request diff exceeds the {0} byte size limit")]
+    DiffTooLarge(usize),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,6 +74,24 @@ pub struct ContentBlob {
     pub oid: String,
     pub path: String,
     pub bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangedMarkdownFile {
+    pub path: String,
+    pub status: String,
+    pub additions: u64,
+    pub deletions: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PullRequestDiff {
+    pub base_oid: String,
+    pub head_oid: String,
+    pub files: Vec<ChangedMarkdownFile>,
+    pub patch: String,
 }
 
 #[derive(Clone)]
@@ -241,6 +262,108 @@ impl GitRepoStore {
         })
     }
 
+    pub fn markdown_diff(
+        &self,
+        space_id: Uuid,
+        base_oid: &str,
+        head_oid: &str,
+        max_bytes: usize,
+    ) -> Result<PullRequestDiff, GitRepoError> {
+        validate_oid(base_oid)?;
+        validate_oid(head_oid)?;
+        let repository = self.repo_path(space_id);
+        let status_output = self.git_output(
+            &repository,
+            &[
+                "diff",
+                "--name-status",
+                "--no-renames",
+                "-z",
+                base_oid,
+                head_oid,
+                "--",
+                ":(glob)**/*.md",
+            ],
+        )?;
+        let mut statuses = HashMap::new();
+        let status_parts = status_output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>();
+        for pair in status_parts.chunks_exact(2) {
+            let status = std::str::from_utf8(pair[0])
+                .map_err(|_| GitRepoError::Git("diff status is not UTF-8".into()))?;
+            let path = std::str::from_utf8(pair[1])
+                .map_err(|_| GitRepoError::Git("diff path is not UTF-8".into()))?;
+            statuses.insert(path.to_string(), diff_status_label(status).to_string());
+        }
+
+        let stat_output = self.git_output(
+            &repository,
+            &[
+                "diff",
+                "--numstat",
+                "--no-renames",
+                "-z",
+                base_oid,
+                head_oid,
+                "--",
+                ":(glob)**/*.md",
+            ],
+        )?;
+        let mut files = Vec::new();
+        for entry in stat_output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|part| !part.is_empty())
+        {
+            let entry = std::str::from_utf8(entry)
+                .map_err(|_| GitRepoError::Git("diff statistics are not UTF-8".into()))?;
+            let mut fields = entry.splitn(3, '\t');
+            let additions = parse_diff_count(fields.next())?;
+            let deletions = parse_diff_count(fields.next())?;
+            let path = fields
+                .next()
+                .ok_or_else(|| GitRepoError::Git("invalid diff statistics".into()))?;
+            files.push(ChangedMarkdownFile {
+                path: path.to_string(),
+                status: statuses
+                    .remove(path)
+                    .unwrap_or_else(|| "modified".to_string()),
+                additions,
+                deletions,
+            });
+        }
+
+        let patch_output = self.git_output(
+            &repository,
+            &[
+                "diff",
+                "--patch",
+                "--no-ext-diff",
+                "--no-color",
+                "--no-renames",
+                "--unified=3",
+                base_oid,
+                head_oid,
+                "--",
+                ":(glob)**/*.md",
+            ],
+        )?;
+        if patch_output.stdout.len() > max_bytes {
+            return Err(GitRepoError::DiffTooLarge(max_bytes));
+        }
+        let patch = String::from_utf8(patch_output.stdout)
+            .map_err(|_| GitRepoError::Git("Markdown diff is not UTF-8".into()))?;
+        Ok(PullRequestDiff {
+            base_oid: base_oid.to_string(),
+            head_oid: head_oid.to_string(),
+            files,
+            patch,
+        })
+    }
+
     pub fn fast_forward_main(
         &self,
         space_id: Uuid,
@@ -310,6 +433,25 @@ impl GitRepoStore {
             .stdin(Stdio::null())
             .output()?;
         ensure_success(output)
+    }
+}
+
+fn diff_status_label(value: &str) -> &'static str {
+    match value.chars().next() {
+        Some('A') => "added",
+        Some('D') => "deleted",
+        Some('T') => "type-changed",
+        _ => "modified",
+    }
+}
+
+fn parse_diff_count(value: Option<&str>) -> Result<u64, GitRepoError> {
+    match value {
+        Some("-") => Ok(0),
+        Some(value) => value
+            .parse()
+            .map_err(|_| GitRepoError::Git("invalid diff line count".into())),
+        None => Err(GitRepoError::Git("invalid diff statistics".into())),
     }
 }
 

--- a/cloud/src/git_repo.rs
+++ b/cloud/src/git_repo.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::{Arc, Mutex};
@@ -336,7 +337,7 @@ impl GitRepoStore {
             });
         }
 
-        let patch_output = self.git_output(
+        let patch_output = self.git_output_limited(
             &repository,
             &[
                 "diff",
@@ -350,10 +351,8 @@ impl GitRepoStore {
                 "--",
                 ":(glob)**/*.md",
             ],
+            max_bytes,
         )?;
-        if patch_output.stdout.len() > max_bytes {
-            return Err(GitRepoError::DiffTooLarge(max_bytes));
-        }
         let patch = String::from_utf8(patch_output.stdout)
             .map_err(|_| GitRepoError::Git("Markdown diff is not UTF-8".into()))?;
         Ok(PullRequestDiff {
@@ -434,6 +433,71 @@ impl GitRepoStore {
             .output()?;
         ensure_success(output)
     }
+
+    fn git_output_limited(
+        &self,
+        path: &Path,
+        arguments: &[&str],
+        max_bytes: usize,
+    ) -> Result<Output, GitRepoError> {
+        let mut child = Command::new("git")
+            .args(["--git-dir"])
+            .arg(path)
+            .args(arguments)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        let mut stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| GitRepoError::Git("Git stdout pipe is unavailable".into()))?;
+        let mut stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| GitRepoError::Git("Git stderr pipe is unavailable".into()))?;
+        let stderr_reader = std::thread::spawn(move || {
+            let mut bytes = Vec::new();
+            stderr.read_to_end(&mut bytes)?;
+            Ok::<_, std::io::Error>(bytes)
+        });
+
+        let stdout_result = read_limited_output(&mut stdout, max_bytes);
+        let too_large = stdout_result
+            .as_ref()
+            .is_ok_and(|bytes| bytes.len() > max_bytes);
+        if too_large || stdout_result.is_err() {
+            let _ = child.kill();
+        }
+        let status_result = child.wait();
+        let stderr_result = stderr_reader
+            .join()
+            .map_err(|_| GitRepoError::Git("Git stderr reader stopped unexpectedly".into()))?;
+
+        let status = status_result?;
+        let stderr = stderr_result?;
+        let stdout = stdout_result?;
+        if too_large {
+            return Err(GitRepoError::DiffTooLarge(max_bytes));
+        }
+        ensure_success(Output {
+            status,
+            stdout,
+            stderr,
+        })
+    }
+}
+
+fn read_limited_output(
+    reader: &mut impl Read,
+    max_bytes: usize,
+) -> Result<Vec<u8>, std::io::Error> {
+    let limit = u64::try_from(max_bytes)
+        .unwrap_or(u64::MAX)
+        .saturating_add(1);
+    let mut bytes = Vec::with_capacity(max_bytes.saturating_add(1).min(64 * 1024));
+    reader.take(limit).read_to_end(&mut bytes)?;
+    Ok(bytes)
 }
 
 fn diff_status_label(value: &str) -> &'static str {
@@ -648,3 +712,37 @@ while read -r _old new ref; do
   [ "$new" != "$zero" ] || { echo "CoWiki: user branches cannot be deleted" >&2; exit 1; }
 done < "$updates"
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::read_limited_output;
+    use std::io::{self, Read};
+
+    struct CountingReader {
+        remaining: usize,
+        bytes_read: usize,
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            let count = buffer.len().min(self.remaining);
+            buffer[..count].fill(b'x');
+            self.remaining -= count;
+            self.bytes_read += count;
+            Ok(count)
+        }
+    }
+
+    #[test]
+    fn limited_output_reader_stops_after_the_sentinel_byte() {
+        let mut reader = CountingReader {
+            remaining: 4096,
+            bytes_read: 0,
+        };
+
+        let output = read_limited_output(&mut reader, 32).unwrap();
+
+        assert_eq!(output.len(), 33);
+        assert_eq!(reader.bytes_read, 33);
+    }
+}

--- a/cloud/src/invitations.rs
+++ b/cloud/src/invitations.rs
@@ -58,10 +58,7 @@ struct InvitationPreviewResponse {
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/invitations/{token}", get(preview_invitation))
-        .route(
-            "/api/invitations/{token}/accept",
-            post(accept_invitation),
-        )
+        .route("/api/invitations/{token}/accept", post(accept_invitation))
         .route(
             "/api/spaces/{space_id}/invitations",
             get(list_invitations).post(create_invitation),
@@ -126,8 +123,7 @@ async fn create_invitation(
     Json(input): Json<CreateInvitationRequest>,
 ) -> AppResult<(StatusCode, Json<CreatedInvitationResponse>)> {
     require_manager(&state, space_id, user.user.id).await?;
-    validate_invitation_input(input.role, input.expires_in_hours)
-        .map_err(AppError::BadRequest)?;
+    validate_invitation_input(input.role, input.expires_in_hours).map_err(AppError::BadRequest)?;
     let invitation_id = Uuid::new_v4();
     let token = random_secret("cw_invite_");
     let token_hash = api_key_hash(&token, &state.config.token_pepper);

--- a/cloud/src/invitations.rs
+++ b/cloud/src/invitations.rs
@@ -1,0 +1,223 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{delete, get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+use uuid::Uuid;
+
+use crate::AppState;
+use crate::auth::{AuthenticatedUser, api_key_hash, random_secret};
+use crate::db;
+use crate::error::{AppError, AppResult};
+use crate::model::{MemberRole, SpaceInvitation, SpaceInvitationPreview};
+use crate::spaces::{CloudSpace, space_response};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateInvitationRequest {
+    role: MemberRole,
+    expires_in_hours: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InvitationResponse {
+    id: Uuid,
+    space_id: Uuid,
+    role: MemberRole,
+    expires_at: String,
+    accepted_count: i32,
+    created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreatedInvitationResponse {
+    id: Uuid,
+    space_id: Uuid,
+    role: MemberRole,
+    expires_at: String,
+    accepted_count: i32,
+    created_at: String,
+    token: String,
+    invite_url: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InvitationPreviewResponse {
+    space_id: Uuid,
+    space_name: String,
+    space_slug: String,
+    role: MemberRole,
+    expires_at: String,
+}
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/invitations/{token}", get(preview_invitation))
+        .route(
+            "/api/invitations/{token}/accept",
+            post(accept_invitation),
+        )
+        .route(
+            "/api/spaces/{space_id}/invitations",
+            get(list_invitations).post(create_invitation),
+        )
+        .route(
+            "/api/spaces/{space_id}/invitations/{invitation_id}",
+            delete(revoke_invitation),
+        )
+}
+
+pub fn validate_invitation_input(role: MemberRole, expires_in_hours: i64) -> Result<(), String> {
+    if role == MemberRole::Owner {
+        return Err("invitation cannot grant the owner role".into());
+    }
+    if !(1..=720).contains(&expires_in_hours) {
+        return Err("invitation expiry must be between 1 and 720 hours".into());
+    }
+    Ok(())
+}
+
+async fn preview_invitation(
+    State(state): State<AppState>,
+    Path(token): Path<String>,
+) -> AppResult<Json<InvitationPreviewResponse>> {
+    let token_hash = invitation_hash(&state, &token)?;
+    let invitation = db::preview_space_invitation(&state.pool, &token_hash)
+        .await?
+        .ok_or(AppError::NotFound)?;
+    Ok(Json(preview_response(invitation)?))
+}
+
+async fn accept_invitation(
+    State(state): State<AppState>,
+    user: AuthenticatedUser,
+    Path(token): Path<String>,
+) -> AppResult<Json<CloudSpace>> {
+    let token_hash = invitation_hash(&state, &token)?;
+    let membership = db::accept_space_invitation(&state.pool, &token_hash, user.user.id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+    Ok(Json(space_response(&state, membership, user.user.id)?))
+}
+
+async fn list_invitations(
+    State(state): State<AppState>,
+    user: AuthenticatedUser,
+    Path(space_id): Path<Uuid>,
+) -> AppResult<Json<Vec<InvitationResponse>>> {
+    require_manager(&state, space_id, user.user.id).await?;
+    let invitations = db::list_space_invitations(&state.pool, space_id)
+        .await?
+        .into_iter()
+        .map(invitation_response)
+        .collect::<AppResult<Vec<_>>>()?;
+    Ok(Json(invitations))
+}
+
+async fn create_invitation(
+    State(state): State<AppState>,
+    user: AuthenticatedUser,
+    Path(space_id): Path<Uuid>,
+    Json(input): Json<CreateInvitationRequest>,
+) -> AppResult<(StatusCode, Json<CreatedInvitationResponse>)> {
+    require_manager(&state, space_id, user.user.id).await?;
+    validate_invitation_input(input.role, input.expires_in_hours)
+        .map_err(AppError::BadRequest)?;
+    let invitation_id = Uuid::new_v4();
+    let token = random_secret("cw_invite_");
+    let token_hash = api_key_hash(&token, &state.config.token_pepper);
+    let expires_at = OffsetDateTime::now_utc() + time::Duration::hours(input.expires_in_hours);
+    let invitation = db::create_space_invitation(
+        &state.pool,
+        invitation_id,
+        space_id,
+        user.user.id,
+        input.role,
+        &token_hash,
+        expires_at,
+    )
+    .await?;
+    let invite_url = state
+        .config
+        .public_origin
+        .join(&format!("/invite/{token}"))
+        .map_err(|error| AppError::Internal(error.to_string()))?
+        .to_string();
+    Ok((
+        StatusCode::CREATED,
+        Json(CreatedInvitationResponse {
+            id: invitation.id,
+            space_id: invitation.space_id,
+            role: invitation.role,
+            expires_at: format_time(invitation.expires_at)?,
+            accepted_count: invitation.accepted_count,
+            created_at: format_time(invitation.created_at)?,
+            token,
+            invite_url,
+        }),
+    ))
+}
+
+async fn revoke_invitation(
+    State(state): State<AppState>,
+    user: AuthenticatedUser,
+    Path((space_id, invitation_id)): Path<(Uuid, Uuid)>,
+) -> AppResult<StatusCode> {
+    require_manager(&state, space_id, user.user.id).await?;
+    if db::revoke_space_invitation(&state.pool, space_id, invitation_id, user.user.id).await? {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(AppError::NotFound)
+    }
+}
+
+async fn require_manager(state: &AppState, space_id: Uuid, user_id: Uuid) -> AppResult<()> {
+    let role = db::member_role(&state.pool, space_id, user_id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+    if role.can_merge() {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden)
+    }
+}
+
+fn invitation_hash(state: &AppState, token: &str) -> AppResult<[u8; 32]> {
+    let token = token.trim();
+    if !token.starts_with("cw_invite_") || token.len() > 128 {
+        return Err(AppError::NotFound);
+    }
+    Ok(api_key_hash(token, &state.config.token_pepper))
+}
+
+fn invitation_response(invitation: SpaceInvitation) -> AppResult<InvitationResponse> {
+    Ok(InvitationResponse {
+        id: invitation.id,
+        space_id: invitation.space_id,
+        role: invitation.role,
+        expires_at: format_time(invitation.expires_at)?,
+        accepted_count: invitation.accepted_count,
+        created_at: format_time(invitation.created_at)?,
+    })
+}
+
+fn preview_response(invitation: SpaceInvitationPreview) -> AppResult<InvitationPreviewResponse> {
+    Ok(InvitationPreviewResponse {
+        space_id: invitation.space_id,
+        space_name: invitation.space_name,
+        space_slug: invitation.space_slug,
+        role: invitation.role,
+        expires_at: format_time(invitation.expires_at)?,
+    })
+}
+
+fn format_time(value: OffsetDateTime) -> AppResult<String> {
+    value
+        .format(&Rfc3339)
+        .map_err(|error| AppError::Internal(error.to_string()))
+}

--- a/cloud/src/lib.rs
+++ b/cloud/src/lib.rs
@@ -5,6 +5,7 @@ pub mod db;
 pub mod error;
 pub mod git_http;
 pub mod git_repo;
+pub mod invitations;
 pub mod model;
 pub mod pull_requests;
 pub mod spaces;
@@ -46,6 +47,7 @@ pub fn build_router(config: Config, pool: PgPool) -> Result<Router, git_repo::Gi
         .merge(auth::routes())
         .merge(spaces::routes())
         .merge(content::routes())
+        .merge(invitations::routes())
         .merge(pull_requests::routes())
         .layer(DefaultBodyLimit::max(MAX_API_REQUEST_BYTES))
         .layer(TimeoutLayer::with_status_code(

--- a/cloud/src/model.rs
+++ b/cloud/src/model.rs
@@ -30,6 +30,28 @@ pub enum PullRequestStatus {
     Closed,
 }
 
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct SpaceInvitation {
+    pub id: Uuid,
+    pub space_id: Uuid,
+    pub created_by: Uuid,
+    pub role: MemberRole,
+    pub expires_at: time::OffsetDateTime,
+    pub revoked_at: Option<time::OffsetDateTime>,
+    pub accepted_count: i32,
+    pub created_at: time::OffsetDateTime,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct SpaceInvitationPreview {
+    pub id: Uuid,
+    pub space_id: Uuid,
+    pub space_name: String,
+    pub space_slug: String,
+    pub role: MemberRole,
+    pub expires_at: time::OffsetDateTime,
+}
+
 impl MemberRole {
     pub const fn as_str(self) -> &'static str {
         match self {

--- a/cloud/src/pull_requests.rs
+++ b/cloud/src/pull_requests.rs
@@ -9,7 +9,7 @@ use crate::AppState;
 use crate::auth::AuthenticatedUser;
 use crate::db::{self, PullRequestRecord};
 use crate::error::{AppError, AppResult};
-use crate::git_repo::GitRepoError;
+use crate::git_repo::{GitRepoError, PullRequestDiff};
 use crate::model::{MemberRole, PullRequestStatus};
 
 #[derive(Debug, Deserialize)]
@@ -42,7 +42,12 @@ pub struct PullRequestResponse {
     pub status: PullRequestStatus,
     pub merged_by: Option<Uuid>,
     pub approval_count: i64,
+    pub author_handle: String,
+    pub author_name: String,
+    pub author_avatar_url: Option<String>,
 }
+
+const MAX_DIFF_BYTES: usize = 2 * 1024 * 1024;
 
 pub fn routes() -> Router<AppState> {
     Router::new()
@@ -53,6 +58,10 @@ pub fn routes() -> Router<AppState> {
         .route(
             "/api/spaces/{space_id}/pull-requests/{pull_request_id}",
             get(get_pull_request),
+        )
+        .route(
+            "/api/spaces/{space_id}/pull-requests/{pull_request_id}/diff",
+            get(get_pull_request_diff),
         )
         .route(
             "/api/spaces/{space_id}/pull-requests/{pull_request_id}/approve",
@@ -143,7 +152,7 @@ async fn approve_pull_request(
     Path((space_id, pull_request_id)): Path<(Uuid, Uuid)>,
 ) -> AppResult<Json<PullRequestResponse>> {
     let role = require_member(&state, space_id, user.user.id).await?;
-    if !role.can_push() {
+    if !role.can_merge() {
         return Err(AppError::Forbidden);
     }
     let lock = state.repos.space_lock(space_id).map_err(git_error)?;
@@ -157,6 +166,23 @@ async fn approve_pull_request(
     }
     db::approve_pull_request(&state.pool, &record, user.user.id).await?;
     Ok(Json(response(&state, record).await?))
+}
+
+async fn get_pull_request_diff(
+    State(state): State<AppState>,
+    user: AuthenticatedUser,
+    Path((space_id, pull_request_id)): Path<(Uuid, Uuid)>,
+) -> AppResult<Json<PullRequestDiff>> {
+    require_member(&state, space_id, user.user.id).await?;
+    let record = db::get_pull_request(&state.pool, space_id, pull_request_id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+    let record = reconcile_live_head(&state, record).await?;
+    let diff = state
+        .repos
+        .markdown_diff(space_id, &record.base_oid, &record.head_oid, MAX_DIFF_BYTES)
+        .map_err(git_error)?;
+    Ok(Json(diff))
 }
 
 async fn merge_pull_request(
@@ -252,6 +278,9 @@ async fn reconcile_live_head(
 
 async fn response(state: &AppState, record: PullRequestRecord) -> AppResult<PullRequestResponse> {
     let approval_count = db::approval_count(&state.pool, record.id, &record.head_oid).await?;
+    let author = db::user_by_id(&state.pool, record.author_id)
+        .await?
+        .ok_or(AppError::NotFound)?;
     Ok(PullRequestResponse {
         id: record.id,
         space_id: record.space_id,
@@ -266,6 +295,9 @@ async fn response(state: &AppState, record: PullRequestRecord) -> AppResult<Pull
         status: record.status,
         merged_by: record.merged_by,
         approval_count,
+        author_handle: author.handle,
+        author_name: author.display_name,
+        author_avatar_url: author.avatar_url,
     })
 }
 
@@ -278,6 +310,7 @@ fn git_error(error: GitRepoError) -> AppError {
             AppError::Conflict(format!("Cloud ref {reference} is missing"))
         }
         GitRepoError::InvalidReceive(message) => AppError::BadRequest(message),
+        GitRepoError::DiffTooLarge(_) => AppError::BadRequest(error.to_string()),
         other => AppError::Internal(other.to_string()),
     }
 }

--- a/cloud/src/spaces.rs
+++ b/cloud/src/spaces.rs
@@ -195,7 +195,7 @@ async fn require_manager(state: &AppState, space_id: Uuid, user_id: Uuid) -> App
     }
 }
 
-fn space_response(
+pub(crate) fn space_response(
     state: &AppState,
     membership: SpaceMembership,
     user_id: Uuid,

--- a/cloud/tests/auth.rs
+++ b/cloud/tests/auth.rs
@@ -1,11 +1,11 @@
 use cowiki_cloud::auth::{
-    OAUTH_STATE_TTL, api_key_hash, random_secret, validate_desktop_callback, verify_api_key,
+    OAUTH_STATE_TTL, api_key_hash, random_secret, validate_loopback_callback, verify_api_key,
 };
 use std::time::{Duration, SystemTime};
 
 #[test]
 fn desktop_callback_accepts_only_an_exact_loopback_url() {
-    assert!(validate_desktop_callback("http://127.0.0.1:39281/auth/callback").is_ok());
+    assert!(validate_loopback_callback("http://127.0.0.1:39281/auth/callback").is_ok());
     for value in [
         "https://evil.example/auth/callback",
         "http://localhost:39281/auth/callback",
@@ -15,7 +15,7 @@ fn desktop_callback_accepts_only_an_exact_loopback_url() {
         "file:///tmp/callback",
     ] {
         assert!(
-            validate_desktop_callback(value).is_err(),
+            validate_loopback_callback(value).is_err(),
             "accepted {value}"
         );
     }

--- a/cloud/tests/auth.rs
+++ b/cloud/tests/auth.rs
@@ -1,7 +1,16 @@
+mod support;
+
+use axum::body::{Body, to_bytes};
 use cowiki_cloud::auth::{
     OAUTH_STATE_TTL, api_key_hash, random_secret, validate_loopback_callback, verify_api_key,
 };
+use cowiki_cloud::config::Config;
+use http::{Request, StatusCode};
+use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
+use support::TestDatabase;
+use tower::ServiceExt;
 
 #[test]
 fn desktop_callback_accepts_only_an_exact_loopback_url() {
@@ -51,4 +60,122 @@ fn oauth_state_lifetime_is_ten_minutes() {
     assert_eq!(OAUTH_STATE_TTL, Duration::from_secs(600));
     let issued = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
     assert!(issued + OAUTH_STATE_TTL > issued);
+}
+
+#[tokio::test]
+async fn exchange_codes_are_single_use_and_logout_revokes_the_api_key() {
+    let Some(database) = TestDatabase::create().await else {
+        eprintln!("TEST_DATABASE_URL is not set; PostgreSQL integration assertion skipped");
+        return;
+    };
+    let user = cowiki_cloud::db::upsert_github_user(
+        &database.pool,
+        991_337,
+        "auth-user",
+        "Auth User",
+        None,
+    )
+    .await
+    .unwrap();
+    let code = cowiki_cloud::db::create_desktop_exchange_code(
+        &database.pool,
+        user.id,
+        "0123456789abcdef0123456789abcdef",
+    )
+    .await
+    .unwrap();
+    let repos = tempfile::tempdir().unwrap();
+    let app = cowiki_cloud::build_router(
+        test_config(repos.path().to_str().unwrap()),
+        database.pool.clone(),
+    )
+    .unwrap();
+
+    let exchanged = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/api/auth/exchange",
+            json!({ "code": code, "client": "web" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(exchanged.status(), StatusCode::OK);
+    let credential = response_json(exchanged).await;
+    let api_key = credential["apiKey"].as_str().unwrap();
+
+    let replayed = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/api/auth/exchange",
+            json!({ "code": code, "client": "web" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(replayed.status(), StatusCode::BAD_REQUEST);
+
+    let authenticated = app
+        .clone()
+        .oneshot(auth_request("GET", "/api/me", api_key))
+        .await
+        .unwrap();
+    assert_eq!(authenticated.status(), StatusCode::OK);
+    let logged_out = app
+        .clone()
+        .oneshot(auth_request("POST", "/api/auth/logout", api_key))
+        .await
+        .unwrap();
+    assert_eq!(logged_out.status(), StatusCode::NO_CONTENT);
+    let revoked = app
+        .oneshot(auth_request("GET", "/api/me", api_key))
+        .await
+        .unwrap();
+    assert_eq!(revoked.status(), StatusCode::UNAUTHORIZED);
+
+    database.finish().await;
+}
+
+fn test_config(repo_root: &str) -> Config {
+    Config::from_values(HashMap::from([
+        (
+            "DATABASE_URL".into(),
+            "postgres://postgres:cowiki@127.0.0.1:55432/postgres".into(),
+        ),
+        ("COWIKI_REPO_ROOT".into(), repo_root.into()),
+        (
+            "COWIKI_PUBLIC_ORIGIN".into(),
+            "https://cloud.cowiki.test".into(),
+        ),
+        ("GITHUB_CLIENT_ID".into(), "test".into()),
+        ("GITHUB_CLIENT_SECRET".into(), "test".into()),
+        (
+            "COWIKI_TOKEN_PEPPER".into(),
+            "0123456789abcdef0123456789abcdef".into(),
+        ),
+    ]))
+    .unwrap()
+}
+
+fn json_request(method: &str, uri: &str, value: Value) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(value.to_string()))
+        .unwrap()
+}
+
+fn auth_request(method: &str, uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn response_json(response: http::Response<Body>) -> Value {
+    let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
 }

--- a/cloud/tests/container_contract.sh
+++ b/cloud/tests/container_contract.sh
@@ -6,8 +6,12 @@ dockerfile="$root/cloud/Dockerfile"
 compose="$root/docker-compose.cloud.yml"
 example_env="$root/.env.cloud.example"
 entrypoint="$root/cloud/entrypoint.sh"
+dev_compose="$root/docker-compose.dev.yml"
+local_env="$root/.env.cloud.local.example"
+dev_script="$root/scripts/dev-cloud.sh"
+vite_config="$root/web/vite.config.ts"
 
-for file in "$dockerfile" "$compose" "$example_env" "$entrypoint"; do
+for file in "$dockerfile" "$compose" "$example_env" "$entrypoint" "$dev_compose" "$local_env" "$dev_script" "$vite_config"; do
   test -f "$file" || { echo "missing deployment file: $file" >&2; exit 1; }
 done
 
@@ -21,5 +25,11 @@ grep -Fq 'healthcheck:' "$compose"
 grep -Fq 'condition: service_healthy' "$compose"
 grep -Fq '/var/lib/cowiki/repos' "$compose"
 grep -Fq 'exec /usr/bin/tini -- /usr/local/bin/cowiki-cloud' "$entrypoint"
+grep -Fq '55432:5432' "$dev_compose"
+grep -Fq 'COWIKI_PUBLIC_ORIGIN=http://localhost:5173' "$local_env"
+grep -Fq 'docker-compose.dev.yml' "$dev_script"
+grep -Fq "'/api': cloudTarget" "$vite_config"
+grep -Fq "'/git': cloudTarget" "$vite_config"
+grep -Fq "'/healthz': cloudTarget" "$vite_config"
 
 echo "Cloud container contract passed"

--- a/cloud/tests/git_repo.rs
+++ b/cloud/tests/git_repo.rs
@@ -158,6 +158,58 @@ fn fast_forward_main_uses_expected_head_and_compare_and_swap() {
     assert!(error.to_string().contains("not based"));
 }
 
+#[test]
+fn markdown_diff_reports_only_markdown_changes_and_enforces_a_size_limit() {
+    let root = tempfile::tempdir().unwrap();
+    let working = tempfile::tempdir().unwrap();
+    let store = GitRepoStore::new(root.path()).unwrap();
+    let space = Uuid::new_v4();
+    store.ensure_space(space).unwrap();
+
+    run(working.path(), &["init", "-b", "main"]);
+    run(working.path(), &["config", "user.name", "Test"]);
+    run(
+        working.path(),
+        &["config", "user.email", "test@cowiki.local"],
+    );
+    std::fs::write(working.path().join("index.md"), "# One\n").unwrap();
+    std::fs::write(working.path().join("notes.txt"), "one\n").unwrap();
+    run(working.path(), &["add", "."]);
+    run(working.path(), &["commit", "-m", "one"]);
+    let base = rev(working.path(), "HEAD");
+
+    std::fs::write(working.path().join("index.md"), "# Two\n\nMore\n").unwrap();
+    std::fs::write(working.path().join("notes.txt"), "two\n").unwrap();
+    run(working.path(), &["commit", "-am", "two"]);
+    let head = rev(working.path(), "HEAD");
+    run(
+        working.path(),
+        &[
+            "remote",
+            "add",
+            "cloud",
+            store.repo_path(space).to_str().unwrap(),
+        ],
+    );
+    run(working.path(), &["push", "cloud", "main"]);
+
+    let diff = store
+        .markdown_diff(space, &base, &head, 1024 * 1024)
+        .unwrap();
+    assert_eq!(diff.base_oid, base);
+    assert_eq!(diff.head_oid, head);
+    assert_eq!(diff.files.len(), 1);
+    assert_eq!(diff.files[0].path, "index.md");
+    assert_eq!(diff.files[0].status, "modified");
+    assert_eq!(diff.files[0].additions, 3);
+    assert_eq!(diff.files[0].deletions, 1);
+    assert!(diff.patch.contains("diff --git a/index.md b/index.md"));
+    assert!(!diff.patch.contains("notes.txt"));
+
+    let error = store.markdown_diff(space, &base, &head, 16).unwrap_err();
+    assert!(error.to_string().contains("size limit"));
+}
+
 fn run(directory: &std::path::Path, arguments: &[&str]) {
     let output = Command::new("git")
         .args(arguments)

--- a/cloud/tests/invitations.rs
+++ b/cloud/tests/invitations.rs
@@ -36,15 +36,9 @@ async fn invitations_are_space_scoped_revocable_and_preserve_existing_roles() {
     let editor_key = insert_api_key(&database.pool, editor).await;
     let candidate_key = insert_api_key(&database.pool, candidate).await;
     let space = Uuid::new_v4();
-    cowiki_cloud::db::create_space(
-        &database.pool,
-        space,
-        owner,
-        "Competition",
-        "competition",
-    )
-    .await
-    .unwrap();
+    cowiki_cloud::db::create_space(&database.pool, space, owner, "Competition", "competition")
+        .await
+        .unwrap();
     insert_member(&database.pool, space, manager, MemberRole::Manager).await;
     insert_member(&database.pool, space, editor, MemberRole::Editor).await;
     let repos = tempfile::tempdir().unwrap();
@@ -101,10 +95,7 @@ async fn invitations_are_space_scoped_revocable_and_preserve_existing_roles() {
 
     let preview = app
         .clone()
-        .oneshot(public_request(
-            "GET",
-            &format!("/api/invitations/{token}"),
-        ))
+        .oneshot(public_request("GET", &format!("/api/invitations/{token}")))
         .await
         .unwrap();
     assert_eq!(preview.status(), StatusCode::OK);
@@ -195,10 +186,7 @@ async fn invitations_are_space_scoped_revocable_and_preserve_existing_roles() {
     assert_eq!(revoked.status(), StatusCode::NO_CONTENT);
     let after_revoke = app
         .clone()
-        .oneshot(public_request(
-            "GET",
-            &format!("/api/invitations/{token}"),
-        ))
+        .oneshot(public_request("GET", &format!("/api/invitations/{token}")))
         .await
         .unwrap();
     assert_eq!(after_revoke.status(), StatusCode::NOT_FOUND);

--- a/cloud/tests/invitations.rs
+++ b/cloud/tests/invitations.rs
@@ -1,0 +1,322 @@
+mod support;
+
+use axum::body::{Body, to_bytes};
+use cowiki_cloud::auth::api_key_hash;
+use cowiki_cloud::config::Config;
+use cowiki_cloud::invitations::validate_invitation_input;
+use cowiki_cloud::model::MemberRole;
+use http::{Request, StatusCode};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use support::TestDatabase;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+#[test]
+fn invitation_roles_and_expiry_are_bounded() {
+    assert!(validate_invitation_input(MemberRole::Editor, 168).is_ok());
+    assert!(validate_invitation_input(MemberRole::Viewer, 1).is_ok());
+    assert!(validate_invitation_input(MemberRole::Owner, 24).is_err());
+    assert!(validate_invitation_input(MemberRole::Manager, 0).is_err());
+    assert!(validate_invitation_input(MemberRole::Manager, 721).is_err());
+}
+
+#[tokio::test]
+async fn invitations_are_space_scoped_revocable_and_preserve_existing_roles() {
+    let Some(database) = TestDatabase::create().await else {
+        eprintln!("TEST_DATABASE_URL is not set; PostgreSQL integration assertion skipped");
+        return;
+    };
+    let owner = insert_user(&database.pool, "invite-owner").await;
+    let manager = insert_user(&database.pool, "invite-manager").await;
+    let editor = insert_user(&database.pool, "invite-editor").await;
+    let candidate = insert_user(&database.pool, "invite-candidate").await;
+    let owner_key = insert_api_key(&database.pool, owner).await;
+    let manager_key = insert_api_key(&database.pool, manager).await;
+    let editor_key = insert_api_key(&database.pool, editor).await;
+    let candidate_key = insert_api_key(&database.pool, candidate).await;
+    let space = Uuid::new_v4();
+    cowiki_cloud::db::create_space(
+        &database.pool,
+        space,
+        owner,
+        "Competition",
+        "competition",
+    )
+    .await
+    .unwrap();
+    insert_member(&database.pool, space, manager, MemberRole::Manager).await;
+    insert_member(&database.pool, space, editor, MemberRole::Editor).await;
+    let repos = tempfile::tempdir().unwrap();
+    let app = cowiki_cloud::build_router(
+        test_config(repos.path().to_str().unwrap()),
+        database.pool.clone(),
+    )
+    .unwrap();
+
+    let forbidden = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/api/spaces/{space}/invitations"),
+            &editor_key,
+            json!({ "role": "viewer", "expiresInHours": 24 }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
+
+    let owner_role = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/api/spaces/{space}/invitations"),
+            &owner_key,
+            json!({ "role": "owner", "expiresInHours": 24 }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(owner_role.status(), StatusCode::BAD_REQUEST);
+
+    let created = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/api/spaces/{space}/invitations"),
+            &manager_key,
+            json!({ "role": "editor", "expiresInHours": 24 }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let created = response_json(created).await;
+    let invitation_id = created["id"].as_str().unwrap();
+    let token = created["token"].as_str().unwrap();
+    assert_eq!(created["spaceId"], space.to_string());
+    assert_eq!(created["role"], "editor");
+    assert_eq!(
+        created["inviteUrl"],
+        format!("https://cloud.cowiki.test/invite/{token}")
+    );
+
+    let preview = app
+        .clone()
+        .oneshot(public_request(
+            "GET",
+            &format!("/api/invitations/{token}"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(preview.status(), StatusCode::OK);
+    let preview = response_json(preview).await;
+    assert_eq!(preview["spaceName"], "Competition");
+    assert_eq!(preview["spaceSlug"], "competition");
+    assert_eq!(preview["role"], "editor");
+
+    let accepted = app
+        .clone()
+        .oneshot(auth_request(
+            "POST",
+            &format!("/api/invitations/{token}/accept"),
+            &candidate_key,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(accepted.status(), StatusCode::OK);
+    let accepted = response_json(accepted).await;
+    assert_eq!(accepted["id"], space.to_string());
+    assert_eq!(accepted["role"], "editor");
+
+    let accepted_again = app
+        .clone()
+        .oneshot(auth_request(
+            "POST",
+            &format!("/api/invitations/{token}/accept"),
+            &candidate_key,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(accepted_again.status(), StatusCode::OK);
+    let accepted_count: i32 =
+        sqlx::query_scalar("SELECT accepted_count FROM space_invitations WHERE id = $1")
+            .bind(Uuid::parse_str(invitation_id).unwrap())
+            .fetch_one(&database.pool)
+            .await
+            .unwrap();
+    assert_eq!(accepted_count, 1);
+
+    let viewer_invite = app
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            &format!("/api/spaces/{space}/invitations"),
+            &owner_key,
+            json!({ "role": "viewer", "expiresInHours": 24 }),
+        ))
+        .await
+        .unwrap();
+    let viewer_invite = response_json(viewer_invite).await;
+    let viewer_token = viewer_invite["token"].as_str().unwrap();
+    let manager_accepts = app
+        .clone()
+        .oneshot(auth_request(
+            "POST",
+            &format!("/api/invitations/{viewer_token}/accept"),
+            &manager_key,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(manager_accepts.status(), StatusCode::OK);
+    assert_eq!(response_json(manager_accepts).await["role"], "manager");
+
+    let listed = app
+        .clone()
+        .oneshot(auth_request(
+            "GET",
+            &format!("/api/spaces/{space}/invitations"),
+            &owner_key,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(listed.status(), StatusCode::OK);
+    let listed = response_json(listed).await;
+    assert_eq!(listed.as_array().unwrap().len(), 2);
+    assert!(listed[0].get("token").is_none());
+
+    let revoked = app
+        .clone()
+        .oneshot(auth_request(
+            "DELETE",
+            &format!("/api/spaces/{space}/invitations/{invitation_id}"),
+            &manager_key,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(revoked.status(), StatusCode::NO_CONTENT);
+    let after_revoke = app
+        .clone()
+        .oneshot(public_request(
+            "GET",
+            &format!("/api/invitations/{token}"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(after_revoke.status(), StatusCode::NOT_FOUND);
+
+    sqlx::query("UPDATE space_invitations SET expires_at = now() - interval '1 minute'")
+        .execute(&database.pool)
+        .await
+        .unwrap();
+    let expired = app
+        .oneshot(public_request(
+            "GET",
+            &format!("/api/invitations/{viewer_token}"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(expired.status(), StatusCode::NOT_FOUND);
+
+    let audit_actions: Vec<String> = sqlx::query_scalar(
+        "SELECT action FROM audit_events
+         WHERE space_id = $1 AND action LIKE 'space_invitation.%' ORDER BY id",
+    )
+    .bind(space)
+    .fetch_all(&database.pool)
+    .await
+    .unwrap();
+    assert!(audit_actions.contains(&"space_invitation.created".to_string()));
+    assert!(audit_actions.contains(&"space_invitation.accepted".to_string()));
+    assert!(audit_actions.contains(&"space_invitation.revoked".to_string()));
+
+    database.finish().await;
+}
+
+async fn insert_user(pool: &sqlx::PgPool, handle: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO users (id, github_id, handle, display_name) VALUES ($1, $2, $3, $3)")
+        .bind(id)
+        .bind((id.as_u128() & i64::MAX as u128) as i64)
+        .bind(handle)
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+async fn insert_api_key(pool: &sqlx::PgPool, user_id: Uuid) -> String {
+    let key = format!("cw_key_{user_id}");
+    let hash = api_key_hash(&key, "0123456789abcdef0123456789abcdef");
+    sqlx::query(
+        "INSERT INTO api_keys (id, user_id, token_hash, label) VALUES ($1, $2, $3, 'test')",
+    )
+    .bind(Uuid::new_v4())
+    .bind(user_id)
+    .bind(hash.as_slice())
+    .execute(pool)
+    .await
+    .unwrap();
+    key
+}
+
+async fn insert_member(pool: &sqlx::PgPool, space: Uuid, user: Uuid, role: MemberRole) {
+    sqlx::query("INSERT INTO space_members (space_id, user_id, role) VALUES ($1, $2, $3)")
+        .bind(space)
+        .bind(user)
+        .bind(role)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+fn test_config(repo_root: &str) -> Config {
+    Config::from_values(HashMap::from([
+        (
+            "DATABASE_URL".into(),
+            "postgres://postgres:cowiki@127.0.0.1:55432/postgres".into(),
+        ),
+        ("COWIKI_REPO_ROOT".into(), repo_root.into()),
+        (
+            "COWIKI_PUBLIC_ORIGIN".into(),
+            "https://cloud.cowiki.test".into(),
+        ),
+        ("GITHUB_CLIENT_ID".into(), "test".into()),
+        ("GITHUB_CLIENT_SECRET".into(), "test".into()),
+        (
+            "COWIKI_TOKEN_PEPPER".into(),
+            "0123456789abcdef0123456789abcdef".into(),
+        ),
+    ]))
+    .unwrap()
+}
+
+fn json_request(method: &str, uri: &str, token: &str, value: Value) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(value.to_string()))
+        .unwrap()
+}
+
+fn auth_request(method: &str, uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn public_request(method: &str, uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn response_json(response: http::Response<Body>) -> Value {
+    let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}

--- a/cloud/tests/invitations.rs
+++ b/cloud/tests/invitations.rs
@@ -9,6 +9,7 @@ use http::{Request, StatusCode};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use support::TestDatabase;
+use time::OffsetDateTime;
 use tower::ServiceExt;
 use uuid::Uuid;
 
@@ -215,6 +216,82 @@ async fn invitations_are_space_scoped_revocable_and_preserve_existing_roles() {
     assert!(audit_actions.contains(&"space_invitation.created".to_string()));
     assert!(audit_actions.contains(&"space_invitation.accepted".to_string()));
     assert!(audit_actions.contains(&"space_invitation.revoked".to_string()));
+
+    database.finish().await;
+}
+
+#[tokio::test]
+async fn concurrent_invitations_create_one_membership() {
+    let Some(database) = TestDatabase::create().await else {
+        eprintln!("TEST_DATABASE_URL is not set; PostgreSQL integration assertion skipped");
+        return;
+    };
+    let owner = insert_user(&database.pool, "concurrent-owner").await;
+    let candidate = insert_user(&database.pool, "concurrent-candidate").await;
+    let space = Uuid::new_v4();
+    cowiki_cloud::db::create_space(
+        &database.pool,
+        space,
+        owner,
+        "Concurrent Invitations",
+        "concurrent-invitations",
+    )
+    .await
+    .unwrap();
+    let first_hash = api_key_hash(
+        "cw_invite_concurrent_first",
+        "0123456789abcdef0123456789abcdef",
+    );
+    let second_hash = api_key_hash(
+        "cw_invite_concurrent_second",
+        "0123456789abcdef0123456789abcdef",
+    );
+    let expires_at = OffsetDateTime::now_utc() + time::Duration::hours(1);
+    cowiki_cloud::db::create_space_invitation(
+        &database.pool,
+        Uuid::new_v4(),
+        space,
+        owner,
+        MemberRole::Editor,
+        &first_hash,
+        expires_at,
+    )
+    .await
+    .unwrap();
+    cowiki_cloud::db::create_space_invitation(
+        &database.pool,
+        Uuid::new_v4(),
+        space,
+        owner,
+        MemberRole::Editor,
+        &second_hash,
+        expires_at,
+    )
+    .await
+    .unwrap();
+
+    let first = cowiki_cloud::db::accept_space_invitation(&database.pool, &first_hash, candidate);
+    let second = cowiki_cloud::db::accept_space_invitation(&database.pool, &second_hash, candidate);
+    let (first, second) = tokio::join!(first, second);
+    assert_eq!(first.unwrap().unwrap().role, MemberRole::Editor);
+    assert_eq!(second.unwrap().unwrap().role, MemberRole::Editor);
+    let membership_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM space_members WHERE space_id = $1 AND user_id = $2",
+    )
+    .bind(space)
+    .bind(candidate)
+    .fetch_one(&database.pool)
+    .await
+    .unwrap();
+    let accepted_count: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(SUM(accepted_count), 0) FROM space_invitations WHERE space_id = $1",
+    )
+    .bind(space)
+    .fetch_one(&database.pool)
+    .await
+    .unwrap();
+    assert_eq!(membership_count, 1);
+    assert_eq!(accepted_count, 1);
 
     database.finish().await;
 }

--- a/cloud/tests/pull_requests.rs
+++ b/cloud/tests/pull_requests.rs
@@ -62,6 +62,33 @@ async fn live_user_branch_invalidates_approval_and_merges_with_expected_head() {
     assert_eq!(created["headOid"], second_oid);
     assert_eq!(created["approvalCount"], 0);
 
+    let editor_approval = app
+        .clone()
+        .oneshot(auth_request(
+            "POST",
+            &format!("/api/spaces/{space}/pull-requests/{pr_id}/approve"),
+            &editor_key,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(editor_approval.status(), StatusCode::FORBIDDEN);
+
+    let diff = app
+        .clone()
+        .oneshot(auth_request(
+            "GET",
+            &format!("/api/spaces/{space}/pull-requests/{pr_id}/diff"),
+            &editor_key,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(diff.status(), StatusCode::OK);
+    let diff = response_json(diff).await;
+    assert_eq!(diff["baseOid"], created["baseOid"]);
+    assert_eq!(diff["headOid"], created["headOid"]);
+    assert_eq!(diff["files"][0]["path"], "index.md");
+    assert!(diff["patch"].as_str().unwrap().contains("# Two"));
+
     let same = app
         .clone()
         .oneshot(json_request(

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,4 @@
+services:
+  postgres:
+    ports:
+      - "55432:5432"

--- a/docs/cloud-deployment.md
+++ b/docs/cloud-deployment.md
@@ -18,6 +18,23 @@ The service applies embedded SQL migrations before listening. Startup fails if P
 
 The browser application and API are expected to share `COWIKI_PUBLIC_ORIGIN`. API CORS responses allow that exact origin, REST request bodies are limited to 1 MiB, REST requests time out after 30 seconds, and Git service children are terminated after 120 seconds. Keep a reverse-proxy request limit at least as large as the Cloud Git limit (256 MiB) on `/git/*`, while using a smaller limit for `/api/*`.
 
+## Local Cloud and browser
+
+Register a development GitHub OAuth app with callback
+`http://localhost:5173/api/auth/github/callback`. Then:
+
+```bash
+cp .env.cloud.local.example .env.cloud.local
+# Fill GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, and a stable random
+# COWIKI_TOKEN_PEPPER in .env.cloud.local.
+scripts/dev-cloud.sh
+```
+
+The script starts PostgreSQL on `127.0.0.1:55432`, Cloud on
+`127.0.0.1:8787`, and Vite on `127.0.0.1:5173`. Vite proxies `/api`, `/git`,
+and `/healthz` so OAuth callbacks, browser requests, and Git URLs use the same
+public origin. Open `http://localhost:5173/cloud`.
+
 ## Publish and review workflow
 
 The desktop app exposes one Space-scoped Cloud action. It never publishes a local Space in the background:

--- a/docs/cloud-deployment.md
+++ b/docs/cloud-deployment.md
@@ -37,7 +37,15 @@ public origin. Open `http://localhost:5173/cloud`.
 
 ## Publish and review workflow
 
-The desktop app exposes one Space-scoped Cloud action. It never publishes a local Space in the background:
+The competition path does not require the desktop app:
+
+1. Create a shared Space in the browser.
+2. Explicitly ask the local Agent to publish a clean Markdown repository to that Space. The bundled `cowiki publish` command initializes Cloud `main` and `user/<owner-id>` atomically at the local `main` commit.
+3. Create a Space-scoped invitation link in Members. Participants sign in, accept the invitation, and can read only merged Cloud `main` in the browser.
+4. Participants use the bundled skill to clone or set up the repository. `cowiki submit` commits eligible Markdown, rebases on Cloud `main`, pushes only `user/<user-id>` with a lease, and creates or updates the participant's pull request.
+5. An Owner or Manager reviews the exact Markdown diff, approves the current head, and merges it. The browser Wiki never displays local drafts or unmerged user branches as published knowledge.
+
+The desktop app exposes the same Space-scoped lifecycle as a convenience. It never publishes a local Space in the background:
 
 1. **Publish Space** creates the PostgreSQL control-plane record and bare Git repository. The local `main` commit initializes both Cloud `main` and `user/<owner-id>` at the same OID.
 2. **Sync** fetches Cloud `main`. A clean local `main` is rebased automatically; a conflict stops without silently choosing either side.
@@ -51,8 +59,9 @@ Pull requests follow subsequent pushes to `user/<user-id>`. An approval is count
 | Capability | Owner | Manager | Editor | Viewer |
 | --- | --- | --- | --- | --- |
 | Read Cloud Wiki, members, and PRs | Yes | Yes | Yes | Yes |
-| Push `user/<own-id>` and create/approve PRs | Yes | Yes | Yes | No |
-| Merge PRs | Yes | Yes | No | No |
+| Push `user/<own-id>` and create PRs | Yes | Yes | Yes | No |
+| Review, approve, and merge PRs | Yes | Yes | No | No |
+| Create and revoke Space invitations | Yes | Yes | No | No |
 | Add, change, or remove non-owner members | Yes | Yes | No | No |
 | Bootstrap a new Space | Yes | No | No | No |
 

--- a/docs/superpowers/plans/2026-07-28-competition-cloud-submissions.md
+++ b/docs/superpowers/plans/2026-07-28-competition-cloud-submissions.md
@@ -1,0 +1,480 @@
+# Competition Cloud Submissions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver an invite-only, browser-readable Cloud Space with enforced roles, Markdown PR diffs and review/merge, plus a cross-platform local Agent submission command.
+
+**Architecture:** PostgreSQL remains authoritative for identities, memberships, invitations, credentials, PR state, approvals, and audit events; one bare Git repository per Space remains authoritative for content. The browser is a read-and-manage control plane, while a dependency-light Node command performs local OAuth, Git synchronization, branch push, and PR creation for the Agent skill.
+
+**Tech Stack:** Rust 2024, Axum, SQLx/PostgreSQL, bare Git Smart HTTP, React 19, TypeScript 6, Vite 8, Node 20.
+
+---
+
+## File map
+
+- `cloud/migrations/002_space_invitations.sql` — invitation persistence, validity constraints, and indexes.
+- `cloud/src/invitations.rs` — invitation preview/create/list/accept/revoke HTTP boundary.
+- `cloud/src/db.rs` — transactional invitation and audit persistence.
+- `cloud/src/git_repo.rs` — bounded Markdown diff extraction from a bare Space repository.
+- `cloud/src/pull_requests.rs` — review authorization and diff endpoint.
+- `cloud/src/auth.rs` — shared one-time browser OAuth exchange for web, desktop, and CLI.
+- `web/src/cloud/CloudInvitationPage.tsx` — Space-specific invitation acceptance.
+- `web/src/cloud/CloudMembersView.tsx` — invitation creation/list/revocation management.
+- `web/src/cloud/CloudReviewsView.tsx` — changed-file summary and unified Markdown diff.
+- `web/src/cloud/client.ts` — typed APIs for invitations and PR diffs.
+- `web/src/App.tsx`, `web/src/pages/LoginPage.tsx`, `web/src/auth-flow.ts` — one-time exchange and post-login return path.
+- `tools/cowiki-cli/cowiki.mjs` — cross-platform `login`, `setup`, `clone`, `status`, and `submit`.
+- `tools/cowiki-cli/lib/*.mjs` — isolated config, HTTP, OAuth, and Git adapters.
+- `skills/cowiki-space/SKILL.md` — Agent contract that invokes the deterministic command.
+- `docker-compose.dev.yml`, `.env.cloud.local.example`, `scripts/dev-cloud.sh`, `web/vite.config.ts` — reproducible local Cloud/browser startup.
+
+### Task 1: Repair browser OAuth and generalize the one-time exchange
+
+**Files:**
+- Modify: `cloud/src/auth.rs`
+- Modify: `cloud/src/db.rs`
+- Modify: `cloud/tests/auth.rs`
+- Modify: `web/src/auth-flow.ts`
+- Modify: `web/src/App.tsx`
+- Modify: `web/src/pages/LoginPage.tsx`
+- Modify: `web/tests/auth-flow.test.ts`
+
+- [ ] **Step 1: Add failing auth-flow tests**
+
+Test that `#auth_code=cw_once_test` is parsed, exchanged with `POST /api/auth/exchange`, and that a safe `/invite/<token>` return path round-trips while `https://evil.example` is rejected.
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+Run: `cd web && npm run test:auth-flow`
+
+Expected: FAIL because web auth codes and safe return paths are not implemented.
+
+- [ ] **Step 3: Add the shared exchange contract**
+
+Expose both `/api/auth/exchange` and the compatibility alias `/api/auth/desktop/exchange`. Accept `client=desktop` and `client=cli` only with an exact `http://127.0.0.1:<port>/auth/callback`; issue labeled API keys through:
+
+```rust
+pub async fn exchange_code(
+    pool: &PgPool,
+    raw_code: &str,
+    pepper: &str,
+    label: &str,
+) -> Result<Option<IssuedApiKey>, sqlx::Error>
+```
+
+Keep codes single-use and 60 seconds long.
+
+- [ ] **Step 4: Exchange the browser fragment before routing**
+
+Add:
+
+```ts
+export function parseWebOAuthFragment(hash: string): string | null
+export function safeAuthReturnPath(value: string | null): string
+export async function exchangeOAuthCode(apiBase: string, code: string): Promise<OAuthCredential>
+```
+
+`App` must await the exchange, store the returned credential, scrub the fragment, and redirect `/auth/callback` to the saved same-origin path.
+
+- [ ] **Step 5: Run auth and build checks**
+
+Run: `cd cloud && cargo test --test auth`
+
+Expected: PASS.
+
+Run: `cd web && npm run test:auth-flow && npm run build`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cloud/src/auth.rs cloud/src/db.rs cloud/tests/auth.rs web/src/auth-flow.ts web/src/App.tsx web/src/pages/LoginPage.tsx web/tests/auth-flow.test.ts
+git commit -m "fix(auth): complete browser and CLI OAuth exchange"
+```
+
+### Task 2: Add Space-scoped invitations with transactional permissions
+
+**Files:**
+- Create: `cloud/migrations/002_space_invitations.sql`
+- Create: `cloud/src/invitations.rs`
+- Create: `cloud/tests/invitations.rs`
+- Modify: `cloud/src/lib.rs`
+- Modify: `cloud/src/db.rs`
+- Modify: `cloud/src/model.rs`
+
+- [ ] **Step 1: Write failing invitation integration tests**
+
+Cover:
+
+```text
+Owner/Manager create Editor or Viewer invitation
+Editor cannot create or revoke invitation
+Owner role cannot be invited
+valid token preview does not require authentication
+accept creates membership only in the invitation's Space
+existing membership is never downgraded
+expired/revoked/unknown tokens return 404
+accept/create/revoke write audit events
+```
+
+- [ ] **Step 2: Run the focused test and verify failure**
+
+Run: `cd cloud && TEST_DATABASE_URL=postgres://cowiki:cowiki@127.0.0.1:55432/postgres cargo test --test invitations`
+
+Expected: FAIL because the migration and routes do not exist.
+
+- [ ] **Step 3: Add the migration**
+
+Create `space_invitations` with UUID identity, `space_id`, `created_by`, non-owner `role`, unique `token_hash`, `expires_at`, nullable `revoked_at`, `accepted_count`, and timestamps. Index active invitations by Space.
+
+- [ ] **Step 4: Add transactional DB operations**
+
+Implement:
+
+```rust
+create_space_invitation(...)
+list_space_invitations(...)
+preview_space_invitation(...)
+accept_space_invitation(...)
+revoke_space_invitation(...)
+```
+
+Lock the invitation row during accept, validate time/revocation, preserve any existing membership role, increment `accepted_count` only for a new member, and write audit rows in the same transaction.
+
+- [ ] **Step 5: Add invitation routes**
+
+Expose:
+
+```text
+GET    /api/invitations/:token
+POST   /api/invitations/:token/accept
+GET    /api/spaces/:space_id/invitations
+POST   /api/spaces/:space_id/invitations
+DELETE /api/spaces/:space_id/invitations/:invitation_id
+```
+
+Return the raw token only from create, build an invite URL from `COWIKI_PUBLIC_ORIGIN`, allow expiry from 1–720 hours, and map invalid/expired/revoked tokens to the same 404 response.
+
+- [ ] **Step 6: Run invitation and existing Space tests**
+
+Run: `cd cloud && TEST_DATABASE_URL=postgres://cowiki:cowiki@127.0.0.1:55432/postgres cargo test --test invitations --test spaces`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cloud/migrations/002_space_invitations.sql cloud/src/invitations.rs cloud/tests/invitations.rs cloud/src/lib.rs cloud/src/db.rs cloud/src/model.rs
+git commit -m "feat(cloud): add Space invitation lifecycle"
+```
+
+### Task 3: Add server-authoritative Markdown PR diffs and reviewer permissions
+
+**Files:**
+- Modify: `cloud/src/git_repo.rs`
+- Modify: `cloud/src/pull_requests.rs`
+- Modify: `cloud/src/db.rs`
+- Modify: `cloud/tests/git_repo.rs`
+- Modify: `cloud/tests/pull_requests.rs`
+
+- [ ] **Step 1: Add failing diff and authorization tests**
+
+Assert that any member can read the current PR diff, the response is tied to the reconciled `baseOid` and `headOid`, only `.md` changes are rendered, output over 2 MiB is rejected, Editors cannot approve, and Owner/Manager approval succeeds.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run: `cd cloud && TEST_DATABASE_URL=postgres://cowiki:cowiki@127.0.0.1:55432/postgres cargo test --test git_repo --test pull_requests`
+
+Expected: FAIL on the missing diff endpoint and Editor approval.
+
+- [ ] **Step 3: Add bounded diff extraction**
+
+Implement:
+
+```rust
+pub struct PullRequestDiff {
+    pub files: Vec<ChangedMarkdownFile>,
+    pub patch: String,
+}
+
+pub fn markdown_diff(
+    &self,
+    space_id: Uuid,
+    base_oid: &str,
+    head_oid: &str,
+    max_bytes: usize,
+) -> Result<PullRequestDiff, GitRepoError>
+```
+
+Run Git directly against the bare repository with fixed OIDs, `--no-ext-diff`, `--no-color`, and Markdown pathspecs; do not invoke a shell.
+
+- [ ] **Step 4: Add the diff endpoint and tighten approval**
+
+Expose `GET /api/spaces/:space_id/pull-requests/:pull_request_id/diff`. Reconcile the live head before diffing and return the exact OIDs in the response. Change approval authorization from `can_push()` to `can_merge()`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd cloud && TEST_DATABASE_URL=postgres://cowiki:cowiki@127.0.0.1:55432/postgres cargo test`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cloud/src/git_repo.rs cloud/src/pull_requests.rs cloud/src/db.rs cloud/tests/git_repo.rs cloud/tests/pull_requests.rs
+git commit -m "feat(cloud): expose reviewed Markdown pull request diffs"
+```
+
+### Task 4: Add invitation acceptance and browser auth return
+
+**Files:**
+- Create: `web/src/cloud/CloudInvitationPage.tsx`
+- Modify: `web/src/App.tsx`
+- Modify: `web/src/cloud/client.ts`
+- Modify: `web/src/pages/LoginPage.tsx`
+- Modify: `web/tests/cloud-client.test.ts`
+- Modify: `web/tests/cloud-shell.test.ts`
+
+- [ ] **Step 1: Add failing typed-client and shell tests**
+
+Assert exact request paths and bodies for invitation preview/accept and verify the invitation page offers GitHub sign-in when anonymous and opens the invited Space after acceptance.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run: `cd web && npm run test:cloud-client && npm run test:cloud-shell`
+
+Expected: FAIL because the invitation APIs and route are missing.
+
+- [ ] **Step 3: Add typed invitation APIs**
+
+Add `CloudInvitationPreview`, `CloudInvitation`, `previewInvitation`, `acceptInvitation`, `listInvitations`, `createInvitation`, and `revokeInvitation`. Keep public preview separate from the bearer-authenticated request helper.
+
+- [ ] **Step 4: Add `/invite/:token`**
+
+Render Space name, granted role, and expiry. A signed-out user stores only the safe current path before GitHub sign-in. A signed-in user can accept; success navigates to `/cloud/spaces/:id/wiki`.
+
+- [ ] **Step 5: Verify**
+
+Run: `cd web && npm run test:auth-flow && npm run test:cloud-client && npm run test:cloud-shell && npm run build`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/cloud/CloudInvitationPage.tsx web/src/App.tsx web/src/cloud/client.ts web/src/pages/LoginPage.tsx web/tests/cloud-client.test.ts web/tests/cloud-shell.test.ts
+git commit -m "feat(web): add invited Space join flow"
+```
+
+### Task 5: Add invitation administration to Members
+
+**Files:**
+- Modify: `web/src/cloud/CloudMembersView.tsx`
+- Modify: `web/tests/cloud-shell.test.ts`
+
+- [ ] **Step 1: Add a failing UI contract test**
+
+Require Owners/Managers to see invitation role, expiry, copy, and revoke controls; require Editor/Viewer to see no invitation management actions.
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `cd web && npm run test:cloud-shell`
+
+Expected: FAIL on missing invitation administration.
+
+- [ ] **Step 3: Implement invitation management**
+
+Add an “Invite link” panel above the member list. Default to Editor and seven days, show the newly created URL with a copy button, list active invitations, and reload server state after create/revoke.
+
+- [ ] **Step 4: Verify**
+
+Run: `cd web && npm run test:cloud-shell && npm run build`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/cloud/CloudMembersView.tsx web/tests/cloud-shell.test.ts
+git commit -m "feat(web): manage Space invitation links"
+```
+
+### Task 6: Render the actual PR diff in browser review
+
+**Files:**
+- Modify: `web/src/cloud/client.ts`
+- Modify: `web/src/cloud/CloudReviewsView.tsx`
+- Modify: `web/tests/cloud-client.test.ts`
+- Modify: `web/tests/cloud-shell.test.ts`
+
+- [ ] **Step 1: Add failing diff-client and view tests**
+
+Assert the diff request path, OID types, changed-file counts, patch rendering, refresh on PR selection/head change, and that only Manager/Owner receive approve/merge actions.
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `cd web && npm run test:cloud-client && npm run test:cloud-shell`
+
+Expected: FAIL because the review view has metadata only.
+
+- [ ] **Step 3: Add diff models and request**
+
+Add:
+
+```ts
+interface CloudPullRequestDiff {
+  baseOid: string;
+  headOid: string;
+  files: Array<{ path: string; status: string; additions: number; deletions: number }>;
+  patch: string;
+}
+```
+
+- [ ] **Step 4: Render safe unified diff**
+
+Render patch text as React text nodes, splitting lines only for styling. Never inject HTML. Show changed files and line totals before actions; disable merge when the loaded diff head differs from the selected PR head.
+
+- [ ] **Step 5: Verify**
+
+Run: `cd web && npm run test:cloud-client && npm run test:cloud-shell && npm run build`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/cloud/client.ts web/src/cloud/CloudReviewsView.tsx web/tests/cloud-client.test.ts web/tests/cloud-shell.test.ts
+git commit -m "feat(web): show Markdown diffs in Cloud reviews"
+```
+
+### Task 7: Add the cross-platform local command and Agent contract
+
+**Files:**
+- Create: `tools/cowiki-cli/package.json`
+- Create: `tools/cowiki-cli/cowiki.mjs`
+- Create: `tools/cowiki-cli/lib/config.mjs`
+- Create: `tools/cowiki-cli/lib/cloud.mjs`
+- Create: `tools/cowiki-cli/lib/oauth.mjs`
+- Create: `tools/cowiki-cli/lib/git.mjs`
+- Create: `tools/cowiki-cli/test/config.test.mjs`
+- Create: `tools/cowiki-cli/test/git.test.mjs`
+- Create: `tools/cowiki-cli/test/submit.test.mjs`
+- Modify: `skills/cowiki-space/SKILL.md`
+
+- [ ] **Step 1: Add failing CLI unit tests**
+
+Use temporary Git repositories and a fake HTTP server to cover config permissions, loopback callback validation, setup remote configuration, Markdown-only commit, rebase conflict stop, force-with-lease push, PR create/update, Viewer rejection, and credential redaction from output.
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `cd tools/cowiki-cli && npm test`
+
+Expected: FAIL because the command does not exist.
+
+- [ ] **Step 3: Implement login and configuration**
+
+`cowiki login --server <origin>` opens `/api/auth/github?client=cli&callback=<loopback>`, listens only on `127.0.0.1`, exchanges the one-time code, and writes the credential to the platform config directory with user-only permissions.
+
+- [ ] **Step 4: Implement repository setup**
+
+`cowiki setup --server <origin> --space <uuid>` validates membership through `GET /api/spaces/:id`, configures a `cowiki` remote, fetches `main` plus the caller's user branch, and writes non-secret `.cowiki/cloud.json`.
+
+- [ ] **Step 5: Implement safe submission**
+
+`cowiki submit -m <message>` requires local `main`, rejects an active rebase and unsupported dirty files, commits Markdown changes with the Cloud identity, fetches and rebases onto Cloud main, stops on conflict, pushes only `user/<user-id>` with force-with-lease, then creates or updates the open PR.
+
+- [ ] **Step 6: Update the skill**
+
+Keep direct Markdown editing as the Agent behavior, but require `cowiki status` before Cloud work and `cowiki submit -m ...` only after an explicit submit request. Prohibit raw API-key handling and manual reimplementation of Git/Cloud steps.
+
+- [ ] **Step 7: Verify**
+
+Run: `cd tools/cowiki-cli && npm test`
+
+Expected: PASS.
+
+Run: `node tools/cowiki-cli/cowiki.mjs --help`
+
+Expected: lists `login`, `setup`, `status`, and `submit`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tools/cowiki-cli skills/cowiki-space/SKILL.md
+git commit -m "feat(cli): add Agent-driven Cloud submission command"
+```
+
+### Task 8: Make local Cloud and browser startup reproducible
+
+**Files:**
+- Create: `.env.cloud.local.example`
+- Create: `docker-compose.dev.yml`
+- Create: `scripts/dev-cloud.sh`
+- Modify: `web/vite.config.ts`
+- Modify: `docs/cloud-deployment.md`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Add a local startup contract test**
+
+Extend `cloud/tests/container_contract.sh` to require the local override, browser-origin configuration, and Vite proxies for `/api` and `/git`.
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `bash cloud/tests/container_contract.sh`
+
+Expected: FAIL on missing local startup files and wrong Vite API port.
+
+- [ ] **Step 3: Add development configuration**
+
+Use PostgreSQL on host port `55432`, Cloud on `8787`, and the browser on `5173`. Set `COWIKI_PUBLIC_ORIGIN=http://localhost:5173`; proxy `/api`, `/git`, and `/healthz` from Vite to Cloud. Keep real GitHub OAuth credentials only in ignored `.env.cloud.local`.
+
+- [ ] **Step 4: Add one-command startup**
+
+`scripts/dev-cloud.sh` validates non-placeholder OAuth credentials, starts PostgreSQL and Cloud with Docker Compose, installs existing web dependencies when needed, starts Vite, checks both health endpoints, and prints `http://localhost:5173/cloud`.
+
+- [ ] **Step 5: Verify local services**
+
+Run: `cp .env.cloud.local.example .env.cloud.local`, fill the existing local OAuth credentials, then run `scripts/dev-cloud.sh`.
+
+Expected: `curl --fail http://localhost:8787/healthz` and `curl --fail http://localhost:5173/healthz` both return `{"status":"ok"}`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .env.cloud.local.example docker-compose.dev.yml scripts/dev-cloud.sh web/vite.config.ts docs/cloud-deployment.md .gitignore cloud/tests/container_contract.sh
+git commit -m "chore(dev): add local Cloud browser environment"
+```
+
+### Task 9: End-to-end competition verification
+
+**Files:**
+- Verify: `docs/cloud-deployment.md`
+
+- [ ] **Step 1: Run all server tests**
+
+Run: `cd cloud && TEST_DATABASE_URL=postgres://cowiki:cowiki@127.0.0.1:55432/postgres cargo test`
+
+Expected: PASS with no skipped PostgreSQL assertions.
+
+- [ ] **Step 2: Run all web tests and production build**
+
+Run: `cd web && npm test && npm run lint && npm run build`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run CLI tests**
+
+Run: `cd tools/cowiki-cli && npm test`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the fresh-user smoke path**
+
+Create Owner, Manager, Editor, Viewer, and outsider fixtures. Verify invite acceptance, browser main read, Editor submit, Manager diff/approve/merge, merged browser content, Viewer submit rejection, outsider 404, invitation revocation, and credential revocation.
+
+- [ ] **Step 5: Inspect the branch**
+
+Run: `git diff --check && git status --short && git log --oneline origin/dev..HEAD`
+
+Expected: no whitespace errors, no uncommitted files, and focused commits for each completed subsystem.

--- a/docs/superpowers/specs/2026-07-28-competition-cloud-submissions-design.md
+++ b/docs/superpowers/specs/2026-07-28-competition-cloud-submissions-design.md
@@ -1,0 +1,72 @@
+# Competition Cloud Submissions
+
+## Goal
+
+Give every competition participant a reliable way to read a shared Space and submit local work without installing the CoWiki desktop client. Keep editing local-first while making identity, permissions, membership, review, and merge authoritative in CoWiki Cloud.
+
+## Product boundary
+
+- The browser is the collaboration control plane: sign-in, invited-space access, read-only Space browsing, member management, pull-request diff/review, approval, and merge.
+- Local files remain the editing surface. Browser editing is out of scope.
+- Participants install Git, a supported Agent CLI, the CoWiki Space skill, and a small cross-platform CoWiki command.
+- The Agent calls the command; it does not reproduce credential, Git, rebase, or Cloud API logic itself.
+
+## Joining a Space
+
+An invitation belongs to exactly one Space. An Owner or Manager creates an invitation link with a role, expiry, and revocable token. Competition invitations default to `Editor`.
+
+Opening the link requires GitHub sign-in. Accepting it creates or updates membership only for that Space, then opens its browser view. Invitations are not public discovery links and cannot grant `Owner`.
+
+## Roles
+
+| Action | Owner | Manager | Editor | Viewer |
+| --- | --- | --- | --- | --- |
+| Read Cloud `main` | Yes | Yes | Yes | Yes |
+| Submit own branch / PR | Yes | Yes | Yes | No |
+| Review and approve PR | Yes | Yes | No | No |
+| Merge PR | Yes | Yes | No | No |
+| Create/revoke invitations | Yes | Yes | No | No |
+| Manage non-owner members | Yes | Yes | No | No |
+| Change/remove Owner or delete Space | Yes | No | No | No |
+
+Every REST endpoint and Git operation enforces the same server-side role checks. Browser visibility is not treated as authorization.
+
+## Storage
+
+PostgreSQL is authoritative for users, Spaces, memberships, invitations, API credentials, pull requests, head-specific approvals, and audit events. Invitation tokens and API credentials are stored only as hashes.
+
+Each Space has one server-side bare Git repository. Git is authoritative for Markdown content and history. The browser reads the accepted `main` branch; participants push only to their own `user/<user-id>` branch.
+
+Database changes that accompany Git operations use explicit states and reconciliation so an interrupted request cannot silently report an unmerged commit as merged.
+
+## Participant flow
+
+1. Open the Space invitation and sign in with GitHub.
+2. Accept the invitation and read the Space in the browser.
+3. Run CoWiki setup locally. The command opens the system browser and receives a short-lived, one-time exchange result; long-lived credentials are not copied from browser storage.
+4. The Agent edits the local Markdown repository.
+5. `cowiki submit` validates membership, commits eligible changes, fetches Cloud `main`, rebases safely, pushes the caller's user branch, and creates or updates its open PR.
+6. A conflict stops before push and gives a recoverable local error.
+
+## Administrator flow
+
+Owners and Managers can see members, issue or revoke invitations, change non-owner roles, and remove non-owner members. The review screen shows the actual Markdown diff, changed files, submitter, current head, approval state, and merge readiness.
+
+Approval is tied to the exact PR head and is invalidated by a new push. Merge requires the expected head, an open PR, a mergeable branch based on current Cloud `main`, and an authorized reviewer. All management, approval, and merge actions produce audit events.
+
+## Failure and security handling
+
+- Invalid, expired, revoked, or exhausted invitations reveal no private Space content.
+- Non-members receive the same not-found-style response for private Space resources.
+- Removed or downgraded members lose access immediately on the next request.
+- Git rejects direct pushes to `main`, pushes to another user's branch, and Viewer pushes.
+- Authentication exchange codes are single-use and short-lived; API credentials can be revoked.
+- Rebase conflicts and stale PR heads never trigger a partial merge.
+
+## Competition acceptance test
+
+A fresh Windows participant can install the prerequisites, join one invited Space, read it in the browser, authenticate the local tool, submit a Markdown change, and see the resulting PR. A Manager can inspect its diff, approve it, merge it, and see the new content on Cloud `main`. A Viewer cannot submit, an outsider cannot read, and revoked invitations and credentials stop working.
+
+## Deferred
+
+Browser editing, public self-join, desktop-client distribution, comments, advanced branch management, and organization-wide administration are not required for the competition path.

--- a/docs/superpowers/specs/2026-07-28-competition-cloud-submissions-design.md
+++ b/docs/superpowers/specs/2026-07-28-competition-cloud-submissions-design.md
@@ -27,7 +27,7 @@ Opening the link requires GitHub sign-in. Accepting it creates or updates member
 | Merge PR | Yes | Yes | No | No |
 | Create/revoke invitations | Yes | Yes | No | No |
 | Manage non-owner members | Yes | Yes | No | No |
-| Change/remove Owner or delete Space | Yes | No | No | No |
+| Bootstrap the first Cloud revision | Yes | No | No | No |
 
 Every REST endpoint and Git operation enforces the same server-side role checks. Browser visibility is not treated as authorization.
 
@@ -50,13 +50,13 @@ Database changes that accompany Git operations use explicit states and reconcili
 
 ## Administrator flow
 
-Owners and Managers can see members, issue or revoke invitations, change non-owner roles, and remove non-owner members. The review screen shows the actual Markdown diff, changed files, submitter, current head, approval state, and merge readiness.
+Any signed-in user can create a shared Space and becomes its Owner. The Owner explicitly publishes the first revision from a clean local repository; the bootstrap atomically creates Cloud `main` and the Owner branch. Owners and Managers can then see members, issue or revoke invitations, change non-owner roles, and remove non-owner members. The review screen shows the actual Markdown diff, changed files, submitter, current head, approval state, and merge readiness.
 
 Approval is tied to the exact PR head and is invalidated by a new push. Merge requires the expected head, an open PR, a mergeable branch based on current Cloud `main`, and an authorized reviewer. All management, approval, and merge actions produce audit events.
 
 ## Failure and security handling
 
-- Invalid, expired, revoked, or exhausted invitations reveal no private Space content.
+- Invalid, expired, or revoked invitations reveal no private Space content.
 - Non-members receive the same not-found-style response for private Space resources.
 - Removed or downgraded members lose access immediately on the next request.
 - Git rejects direct pushes to `main`, pushes to another user's branch, and Viewer pushes.
@@ -69,4 +69,4 @@ A fresh Windows participant can install the prerequisites, join one invited Spac
 
 ## Deferred
 
-Browser editing, public self-join, desktop-client distribution, comments, advanced branch management, and organization-wide administration are not required for the competition path.
+Browser editing, public self-join, desktop-client distribution, comments, ownership transfer, Space deletion, advanced branch management, and organization-wide administration are not required for the competition path.

--- a/scripts/dev-cloud.sh
+++ b/scripts/dev-cloud.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+env_file="$root/.env.cloud.local"
+base_compose="$root/docker-compose.cloud.yml"
+dev_compose="$root/docker-compose.dev.yml"
+
+if [[ ! -f "$env_file" ]]; then
+  echo "Missing $env_file. Copy .env.cloud.local.example and add the local GitHub OAuth credentials." >&2
+  exit 1
+fi
+
+for name in GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET COWIKI_TOKEN_PEPPER; do
+  value="$(sed -n "s/^${name}=//p" "$env_file" | tail -n 1)"
+  if [[ -z "$value" || "$value" == replace-* || "$value" == change-* ]]; then
+    echo "$name is missing or still a placeholder in $env_file" >&2
+    exit 1
+  fi
+done
+
+docker compose \
+  --env-file "$env_file" \
+  -f "$base_compose" \
+  -f "$dev_compose" \
+  up -d --build
+
+if [[ ! -d "$root/web/node_modules" ]]; then
+  npm --prefix "$root/web" ci
+fi
+
+for _attempt in {1..60}; do
+  if curl --silent --fail http://127.0.0.1:8787/healthz >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+curl --silent --fail http://127.0.0.1:8787/healthz >/dev/null
+
+npm --prefix "$root/web" run dev -- --host 127.0.0.1 &
+vite_pid=$!
+trap 'kill "$vite_pid" 2>/dev/null || true' EXIT INT TERM
+
+for _attempt in {1..30}; do
+  if curl --silent --fail http://127.0.0.1:5173/healthz >/dev/null; then
+    echo "CoWiki Cloud browser is ready at http://localhost:5173/cloud"
+    wait "$vite_pid"
+    exit $?
+  fi
+  sleep 1
+done
+
+echo "Vite did not become ready on http://127.0.0.1:5173" >&2
+exit 1

--- a/skills/cowiki-space/SKILL.md
+++ b/skills/cowiki-space/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cowiki-space
-description: Use when searching, maintaining, reviewing, or explicitly submitting a local CoWiki knowledge Space.
+description: Use when searching, maintaining, reviewing, explicitly publishing, or submitting a local CoWiki knowledge Space.
 ---
 
 # Maintain a CoWiki Space
@@ -62,6 +62,16 @@ node <skill-dir>/scripts/cowiki.mjs clone --server <Cloud origin> --space <Space
 node <skill-dir>/scripts/cowiki.mjs setup --server <Cloud origin> --space <Space UUID> --cwd <existing repository>
 node <skill-dir>/scripts/cowiki.mjs status --cwd <repository>
 ```
+
+When the user explicitly asks to turn a clean local repository into the first
+revision of a newly created shared Space, run:
+
+```text
+node <skill-dir>/scripts/cowiki.mjs publish --server <Cloud origin> --space <Space UUID> --cwd <repository>
+```
+
+This Owner-only command atomically creates Cloud `main` and the Owner branch.
+Do not use it for an initialized Space.
 
 Run `submit --message` only after an explicit user submit request:
 

--- a/skills/cowiki-space/SKILL.md
+++ b/skills/cowiki-space/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cowiki-space
-description: Use when searching, maintaining, or reviewing a local CoWiki knowledge Space.
+description: Use when searching, maintaining, reviewing, or explicitly submitting a local CoWiki knowledge Space.
 ---
 
 # Maintain a CoWiki Space
@@ -26,8 +26,8 @@ Edit the Markdown files directly. Preserve unknown frontmatter fields and the
 Space's established structure. Treat raw files under `.cowiki/sources/` as
 immutable evidence. Keep affected links, `index.md`, and `log.md` coherent.
 
-No local account, API key, or server is required. The retired standalone CLI
-and Cloud commands are not part of the local Space workflow.
+Local work requires no account, API key, or server. Connecting and submitting
+to a shared Space is a separate, explicit workflow.
 
 ## Respect the execution mode
 
@@ -40,5 +40,36 @@ checkout, merge, rebase, or push. CoWiki turns the resulting diff into an Agent
 Change; the user can continue editing, request another pass, merge it into the
 latest Draft, or discard it.
 
-In either mode, do not create Git history or operate CoWiki review state. The
-desktop app owns checkpoints, Agent Changes, merge, and discard.
+In Background mode, do not create Git history or operate CoWiki review state.
+The desktop app owns Agent Changes, merge, and discard.
+
+## Shared Space commands
+
+The installed skill carries a deterministic command at
+`scripts/cowiki.mjs`. Resolve that path relative to this `SKILL.md` and invoke
+it with Node 20 or newer. Do not reproduce its authentication, rebase, push,
+or Cloud API steps with raw shell commands.
+
+The command opens the system browser for GitHub sign-in and stores the
+credential outside the repository. Never handle an API key yourself.
+`.cowiki/cloud.json` contains only non-secret Space linkage.
+
+Use these commands only in Live mode:
+
+```text
+node <skill-dir>/scripts/cowiki.mjs login --server <Cloud origin>
+node <skill-dir>/scripts/cowiki.mjs clone --server <Cloud origin> --space <Space UUID> --directory <path>
+node <skill-dir>/scripts/cowiki.mjs setup --server <Cloud origin> --space <Space UUID> --cwd <existing repository>
+node <skill-dir>/scripts/cowiki.mjs status --cwd <repository>
+```
+
+Run `submit --message` only after an explicit user submit request:
+
+```text
+node <skill-dir>/scripts/cowiki.mjs submit --cwd <repository> --message "<summary>"
+```
+
+The command commits eligible Markdown, rebases on Cloud `main`, pushes only
+the signed-in user's branch with a lease, and creates or updates the pull
+request. If it reports a conflict, stop and report the conflicting paths; do
+not force, abort, or choose a side without the user.

--- a/skills/cowiki-space/scripts/cowiki.mjs
+++ b/skills/cowiki-space/scripts/cowiki.mjs
@@ -34,6 +34,9 @@ export async function main(argv = process.argv.slice(2)) {
     case 'setup':
       await setupCommand(options);
       return;
+    case 'publish':
+      await publishCommand(options);
+      return;
     case 'clone':
       await cloneCommand(options);
       return;
@@ -57,20 +60,32 @@ async function loginCommand(options) {
 }
 
 async function setupCommand(options) {
+  await linkCommand(options, false);
+}
+
+async function publishCommand(options) {
+  await linkCommand(options, true);
+}
+
+async function linkCommand(options, bootstrap) {
   const cwd = path.resolve(options.cwd || process.cwd());
   const server = serverOption(options);
   const spaceId = requiredOption(options, 'space');
   const credential = await credentialFor(server);
   const cloud = new CloudClient(credential);
   const remote = await cloud.getSpace(spaceId);
-  setupCowikiRemote(cwd, remote, credential);
+  setupCowikiRemote(cwd, remote, credential, { bootstrap });
   await writeSpaceConfig(cwd, {
     server,
     spaceId: remote.id,
     gitUrl: remote.gitUrl,
     userRef: remote.userRef,
   });
-  process.stdout.write(`Linked ${remote.name} to ${cwd}.\n`);
+  process.stdout.write(
+    bootstrap
+      ? `Published ${cwd} as the first revision of ${remote.name}.\n`
+      : `Linked ${remote.name} to ${cwd}.\n`,
+  );
 }
 
 async function cloneCommand(options) {
@@ -180,6 +195,7 @@ function printHelp() {
 Usage:
   cowiki login [--server URL]
   cowiki setup --space UUID [--server URL] [--cwd PATH]
+  cowiki publish --space UUID [--server URL] [--cwd PATH]
   cowiki clone --space UUID [--server URL] [--directory PATH]
   cowiki status [--cwd PATH]
   cowiki submit --message TEXT [--body TEXT] [--cwd PATH]

--- a/skills/cowiki-space/scripts/cowiki.mjs
+++ b/skills/cowiki-space/scripts/cowiki.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+
+import { CloudClient } from './lib/cloud.mjs';
+import {
+  normalizeServerOrigin,
+  readCredential,
+  readSpaceConfig,
+  writeCredential,
+  writeSpaceConfig,
+} from './lib/config.mjs';
+import {
+  repositoryStatus,
+  runGit,
+  setupCowikiRemote,
+  submitRepository,
+} from './lib/git.mjs';
+import { loginWithBrowser } from './lib/oauth.mjs';
+
+const DEFAULT_SERVER = process.env.COWIKI_CLOUD_URL || 'https://cloud.cowiki.app';
+
+export async function main(argv = process.argv.slice(2)) {
+  const [command, ...rest] = argv;
+  if (!command || ['--help', '-h', 'help'].includes(command)) {
+    printHelp();
+    return;
+  }
+  const options = parseOptions(rest);
+  switch (command) {
+    case 'login':
+      await loginCommand(options);
+      return;
+    case 'setup':
+      await setupCommand(options);
+      return;
+    case 'clone':
+      await cloneCommand(options);
+      return;
+    case 'status':
+      await statusCommand(options);
+      return;
+    case 'submit':
+      await submitCommand(options);
+      return;
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+}
+
+async function loginCommand(options) {
+  const server = serverOption(options);
+  process.stdout.write(`Opening ${server} for GitHub sign-in…\n`);
+  const credential = await loginWithBrowser({ server });
+  const filename = await writeCredential(credential);
+  process.stdout.write(`Signed in as ${credential.userName}. Credential saved to ${filename}.\n`);
+}
+
+async function setupCommand(options) {
+  const cwd = path.resolve(options.cwd || process.cwd());
+  const server = serverOption(options);
+  const spaceId = requiredOption(options, 'space');
+  const credential = await credentialFor(server);
+  const cloud = new CloudClient(credential);
+  const remote = await cloud.getSpace(spaceId);
+  setupCowikiRemote(cwd, remote, credential);
+  await writeSpaceConfig(cwd, {
+    server,
+    spaceId: remote.id,
+    gitUrl: remote.gitUrl,
+    userRef: remote.userRef,
+  });
+  process.stdout.write(`Linked ${remote.name} to ${cwd}.\n`);
+}
+
+async function cloneCommand(options) {
+  const server = serverOption(options);
+  const spaceId = requiredOption(options, 'space');
+  const credential = await credentialFor(server);
+  const cloud = new CloudClient(credential);
+  const remote = await cloud.getSpace(spaceId);
+  const destination = path.resolve(options.directory || remote.slug);
+  runGit(process.cwd(), [
+    'clone',
+    '--origin',
+    'cowiki',
+    '--branch',
+    'main',
+    remote.gitUrl,
+    destination,
+  ], { apiKey: credential.apiKey });
+  setupCowikiRemote(destination, remote, credential);
+  await writeSpaceConfig(destination, {
+    server,
+    spaceId: remote.id,
+    gitUrl: remote.gitUrl,
+    userRef: remote.userRef,
+  });
+  process.stdout.write(`Cloned ${remote.name} to ${destination}.\n`);
+}
+
+async function statusCommand(options) {
+  const cwd = path.resolve(options.cwd || process.cwd());
+  const space = await readSpaceConfig(cwd);
+  const credential = await requiredCredential(space.server);
+  const status = repositoryStatus(cwd);
+  process.stdout.write(`${JSON.stringify({
+    server: space.server,
+    spaceId: space.spaceId,
+    userId: credential.userId,
+    ...status,
+  }, null, 2)}\n`);
+}
+
+async function submitCommand(options) {
+  const cwd = path.resolve(options.cwd || process.cwd());
+  const message = requiredOption(options, 'message');
+  const spaceConfig = await readSpaceConfig(cwd);
+  const credential = await requiredCredential(spaceConfig.server);
+  const cloud = new CloudClient(credential);
+  const remote = await cloud.getSpace(spaceConfig.spaceId);
+  if (remote.userRef !== spaceConfig.userRef || remote.gitUrl !== spaceConfig.gitUrl) {
+    throw new Error('Stored Space link no longer matches Cloud; run setup again');
+  }
+  const result = await submitRepository({
+    cwd,
+    message,
+    body: options.body || '',
+    space: remote,
+    credential,
+    cloud,
+  });
+  process.stdout.write(
+    `Submitted pull request #${result.pullRequest.number}: ${result.pullRequest.title}\n`,
+  );
+}
+
+async function credentialFor(server) {
+  const existing = await readCredential(server);
+  if (existing) return existing;
+  process.stdout.write('No credential found; opening browser sign-in…\n');
+  const credential = await loginWithBrowser({ server });
+  await writeCredential(credential);
+  return credential;
+}
+
+async function requiredCredential(server) {
+  const credential = await readCredential(server);
+  if (!credential) throw new Error(`Not signed in to ${server}; run cowiki login --server ${server}`);
+  return credential;
+}
+
+function serverOption(options) {
+  return normalizeServerOrigin(options.server || DEFAULT_SERVER);
+}
+
+function parseOptions(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (!value.startsWith('--')) throw new Error(`Unexpected argument: ${value}`);
+    const key = value.slice(2);
+    const next = args[index + 1];
+    if (!next || next.startsWith('--')) throw new Error(`Missing value for --${key}`);
+    options[key === 'm' ? 'message' : key] = next;
+    index += 1;
+  }
+  return options;
+}
+
+function requiredOption(options, name) {
+  const value = options[name]?.trim();
+  if (!value) throw new Error(`--${name} is required`);
+  return value;
+}
+
+function printHelp() {
+  process.stdout.write(`CoWiki local-first Cloud command
+
+Usage:
+  cowiki login [--server URL]
+  cowiki setup --space UUID [--server URL] [--cwd PATH]
+  cowiki clone --space UUID [--server URL] [--directory PATH]
+  cowiki status [--cwd PATH]
+  cowiki submit --message TEXT [--body TEXT] [--cwd PATH]
+`);
+}
+
+function redactSecrets(value) {
+  return String(value).replace(/cw_(?:key|once|invite)_[A-Za-z0-9_-]+/g, 'cw_[redacted]');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`CoWiki: ${redactSecrets(error?.message || error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/skills/cowiki-space/scripts/lib/cloud.mjs
+++ b/skills/cowiki-space/scripts/lib/cloud.mjs
@@ -1,0 +1,50 @@
+import { normalizeServerOrigin } from './config.mjs';
+
+export class CloudError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.name = 'CloudError';
+    this.status = status;
+  }
+}
+
+export class CloudClient {
+  constructor(credential, fetchImpl = fetch) {
+    this.credential = {
+      ...credential,
+      server: normalizeServerOrigin(credential.server),
+    };
+    this.fetchImpl = fetchImpl;
+  }
+
+  async request(pathname, init = {}) {
+    const headers = new Headers(init.headers);
+    headers.set('Accept', 'application/json');
+    headers.set('Authorization', `Bearer ${this.credential.apiKey}`);
+    if (init.body != null) headers.set('Content-Type', 'application/json');
+    const response = await this.fetchImpl(
+      `${this.credential.server}${pathname}`,
+      { ...init, headers },
+    );
+    if (!response.ok) {
+      const payload = await response.json().catch(() => null);
+      throw new CloudError(
+        response.status,
+        payload?.error || `Cloud request failed (${response.status})`,
+      );
+    }
+    if (response.status === 204) return undefined;
+    return response.json();
+  }
+
+  getSpace(spaceId) {
+    return this.request(`/api/spaces/${encodeURIComponent(spaceId)}`);
+  }
+
+  createOrUpdatePullRequest(spaceId, title, body = '') {
+    return this.request(`/api/spaces/${encodeURIComponent(spaceId)}/pull-requests`, {
+      method: 'POST',
+      body: JSON.stringify({ title, body }),
+    });
+  }
+}

--- a/skills/cowiki-space/scripts/lib/config.mjs
+++ b/skills/cowiki-space/scripts/lib/config.mjs
@@ -1,0 +1,115 @@
+import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+export function normalizeServerOrigin(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Cloud server must be a valid URL');
+  }
+  if (!['http:', 'https:'].includes(url.protocol)
+      || url.username
+      || url.password
+      || !url.hostname
+      || !['', '/'].includes(url.pathname)
+      || url.search
+      || url.hash) {
+    throw new Error('Cloud server must be a root HTTP(S) origin without credentials');
+  }
+  return url.origin;
+}
+
+export function credentialPath({
+  env = process.env,
+  platform = process.platform,
+  home = os.homedir(),
+} = {}) {
+  if (platform === 'win32') {
+    const root = env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    return path.join(root, 'CoWiki', 'credentials.json');
+  }
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'CoWiki', 'credentials.json');
+  }
+  return path.join(env.XDG_CONFIG_HOME || path.join(home, '.config'), 'cowiki', 'credentials.json');
+}
+
+export async function writeCredential(credential, options = {}) {
+  const server = normalizeServerOrigin(credential.server);
+  if (!credential.apiKey?.startsWith('cw_key_') || !credential.userId || !credential.userName) {
+    throw new Error('Cloud returned an invalid credential');
+  }
+  const filename = credentialPath(options);
+  await mkdir(path.dirname(filename), { recursive: true, mode: 0o700 });
+  const temporary = `${filename}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify({ ...credential, server }, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  await chmod(temporary, 0o600).catch(() => {});
+  await rename(temporary, filename);
+  await chmod(filename, 0o600).catch(() => {});
+  return filename;
+}
+
+export async function readCredential(server, options = {}) {
+  const filename = credentialPath(options);
+  let payload;
+  try {
+    payload = JSON.parse(await readFile(filename, 'utf8'));
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw new Error(`Could not read CoWiki credential: ${error.message}`);
+  }
+  const expected = normalizeServerOrigin(server);
+  if (normalizeServerOrigin(payload.server) !== expected) return null;
+  if (!payload.apiKey?.startsWith('cw_key_') || !payload.userId || !payload.userName) {
+    throw new Error('Stored CoWiki credential is invalid; run login again');
+  }
+  return {
+    server: expected,
+    apiKey: payload.apiKey,
+    userId: payload.userId,
+    userName: payload.userName,
+  };
+}
+
+export function spaceConfigPath(cwd = process.cwd()) {
+  return path.join(cwd, '.cowiki', 'cloud.json');
+}
+
+export async function writeSpaceConfig(cwd, space) {
+  const filename = spaceConfigPath(cwd);
+  await mkdir(path.dirname(filename), { recursive: true });
+  const value = {
+    server: normalizeServerOrigin(space.server),
+    spaceId: space.spaceId,
+    gitUrl: space.gitUrl,
+    userRef: space.userRef,
+  };
+  await writeFile(filename, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  return filename;
+}
+
+export async function readSpaceConfig(cwd = process.cwd()) {
+  let payload;
+  try {
+    payload = JSON.parse(await readFile(spaceConfigPath(cwd), 'utf8'));
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new Error('This repository is not linked to CoWiki Cloud; run setup first');
+    }
+    throw new Error(`Could not read .cowiki/cloud.json: ${error.message}`);
+  }
+  if (!payload.spaceId || !payload.gitUrl || !payload.userRef) {
+    throw new Error('.cowiki/cloud.json is invalid; run setup again');
+  }
+  return {
+    server: normalizeServerOrigin(payload.server),
+    spaceId: payload.spaceId,
+    gitUrl: payload.gitUrl,
+    userRef: payload.userRef,
+  };
+}

--- a/skills/cowiki-space/scripts/lib/git.mjs
+++ b/skills/cowiki-space/scripts/lib/git.mjs
@@ -39,7 +39,10 @@ export function listDirtyPaths(cwd) {
     if (!record) continue;
     const status = record.slice(0, 2);
     paths.push(record.slice(3));
-    if (/[RC]/.test(status) && records[index + 1]) index += 1;
+    if (/[RC]/.test(status) && records[index + 1]) {
+      paths.push(records[index + 1]);
+      index += 1;
+    }
   }
   return [...new Set(paths)];
 }
@@ -72,7 +75,7 @@ export function commitMarkdown(cwd, message, credential) {
   return result.status === 0;
 }
 
-export function setupCowikiRemote(cwd, space, credential) {
+export function setupCowikiRemote(cwd, space, credential, { bootstrap = false } = {}) {
   if (space.userRef !== `user/${credential.userId}`) {
     throw new Error('Cloud returned a user branch for another account');
   }
@@ -89,6 +92,18 @@ export function setupCowikiRemote(cwd, space, credential) {
     'remote.cowiki.fetch',
     '+refs/heads/main:refs/remotes/cowiki/main',
   ]);
+  const main = runGit(cwd, ['ls-remote', '--exit-code', 'cowiki', 'refs/heads/main'], {
+    apiKey: credential.apiKey,
+    allowFailure: true,
+  });
+  if (main.status === 2) {
+    if (!bootstrap) {
+      throw new Error('Cloud main is empty; use cowiki publish to create its first revision');
+    }
+    bootstrapCloudSpace(cwd, space, credential);
+  } else if (main.status !== 0) {
+    throw new Error(main.stderr.trim() || 'Could not inspect Cloud main');
+  }
   fetchCloudRefs(cwd, space, credential);
 }
 
@@ -153,6 +168,30 @@ function fetchCloudRefs(cwd, space, credential) {
     'cowiki',
     `+refs/heads/${space.userRef}:refs/remotes/cowiki/${space.userRef}`,
   ], { apiKey: credential.apiKey, allowFailure: true });
+}
+
+function bootstrapCloudSpace(cwd, space, credential) {
+  if (space.role !== 'owner') {
+    throw new Error('Cloud main is empty; only the Space owner can publish the first revision');
+  }
+  ensureMain(cwd);
+  ensureNoRebase(cwd);
+  const dirty = listDirtyPaths(cwd);
+  if (dirty.length > 0) {
+    throw new Error('Commit or discard local changes before publishing the first Cloud revision');
+  }
+  const tracked = runGit(cwd, ['ls-tree', '-r', '--name-only', '-z', 'HEAD'])
+    .stdout
+    .split('\0')
+    .filter(Boolean);
+  assertMarkdownOnly(tracked);
+  runGit(cwd, [
+    'push',
+    '--atomic',
+    'cowiki',
+    'HEAD:refs/heads/main',
+    `HEAD:refs/heads/${space.userRef}`,
+  ], { apiKey: credential.apiKey });
 }
 
 export function repositoryStatus(cwd) {

--- a/skills/cowiki-space/scripts/lib/git.mjs
+++ b/skills/cowiki-space/scripts/lib/git.mjs
@@ -1,0 +1,198 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+export function gitAuthEnvironment(apiKey, base = process.env) {
+  if (!apiKey?.startsWith('cw_key_')) throw new Error('A valid CoWiki credential is required');
+  return {
+    ...base,
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'http.extraHeader',
+    GIT_CONFIG_VALUE_0: `Authorization: Bearer ${apiKey}`,
+  };
+}
+
+export function runGit(cwd, args, { apiKey, allowFailure = false, env = process.env } = {}) {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: apiKey ? gitAuthEnvironment(apiKey, env) : env,
+  });
+  if (result.error) throw new Error(`Could not start Git: ${result.error.message}`);
+  if (!allowFailure && result.status !== 0) {
+    throw new Error(result.stderr.trim() || `Git ${args[0]} failed`);
+  }
+  return result;
+}
+
+export function listDirtyPaths(cwd) {
+  const output = runGit(cwd, ['status', '--porcelain=v1', '-z', '--untracked-files=all']).stdout;
+  const records = output.split('\0');
+  const paths = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record) continue;
+    const status = record.slice(0, 2);
+    paths.push(record.slice(3));
+    if (/[RC]/.test(status) && records[index + 1]) index += 1;
+  }
+  return [...new Set(paths)];
+}
+
+export function assertMarkdownOnly(paths) {
+  const unsupported = paths.filter((value) => !isAllowedMarkdownPath(value));
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Cloud submission supports Markdown only; unsupported files: ${unsupported.join(', ')}`,
+    );
+  }
+}
+
+export function commitMarkdown(cwd, message, credential) {
+  const title = message?.trim();
+  if (!title) throw new Error('A commit message is required');
+  const dirty = listDirtyPaths(cwd);
+  if (dirty.length === 0) return false;
+  assertMarkdownOnly(dirty);
+  runGit(cwd, ['add', '-A', '--', ...dirty]);
+  const result = runGit(cwd, [
+    '-c',
+    `user.name=${credential.userName}`,
+    '-c',
+    `user.email=${credential.userId}@users.cowiki.app`,
+    'commit',
+    '-m',
+    title,
+  ]);
+  return result.status === 0;
+}
+
+export function setupCowikiRemote(cwd, space, credential) {
+  if (space.userRef !== `user/${credential.userId}`) {
+    throw new Error('Cloud returned a user branch for another account');
+  }
+  const existing = runGit(cwd, ['remote', 'get-url', 'cowiki'], { allowFailure: true });
+  if (existing.status === 0 && existing.stdout.trim() !== space.gitUrl) {
+    throw new Error("Git remote 'cowiki' points to a different Cloud Space");
+  }
+  if (existing.status !== 0) runGit(cwd, ['remote', 'add', 'cowiki', space.gitUrl]);
+  ignoreCloudConfig(cwd);
+  runGit(cwd, ['config', '--unset-all', 'remote.cowiki.fetch'], { allowFailure: true });
+  runGit(cwd, [
+    'config',
+    '--add',
+    'remote.cowiki.fetch',
+    '+refs/heads/main:refs/remotes/cowiki/main',
+  ]);
+  fetchCloudRefs(cwd, space, credential);
+}
+
+export function ignoreCloudConfig(cwd) {
+  const raw = runGit(cwd, ['rev-parse', '--git-path', 'info/exclude']).stdout.trim();
+  const filename = path.isAbsolute(raw) ? raw : path.join(cwd, raw);
+  mkdirSync(path.dirname(filename), { recursive: true });
+  const existing = existsSync(filename) ? readFileSync(filename, 'utf8') : '';
+  const rule = '.cowiki/cloud.json';
+  if (!existing.split(/\r?\n/).includes(rule)) {
+    appendFileSync(filename, `${existing && !existing.endsWith('\n') ? '\n' : ''}${rule}\n`, 'utf8');
+  }
+}
+
+export async function submitRepository({
+  cwd,
+  message,
+  body = '',
+  space,
+  credential,
+  cloud,
+}) {
+  ensureMain(cwd);
+  ensureNoRebase(cwd);
+  const committed = commitMarkdown(cwd, message, credential);
+  fetchCloudRefs(cwd, space, credential);
+  const rebase = runGit(cwd, ['rebase', 'refs/remotes/cowiki/main'], { allowFailure: true });
+  if (rebase.status !== 0) {
+    const conflicts = runGit(cwd, ['diff', '--name-only', '--diff-filter=U'], {
+      allowFailure: true,
+    }).stdout.trim();
+    throw new Error(
+      conflicts
+        ? `Rebase stopped with conflicts in: ${conflicts.split('\n').join(', ')}`
+        : rebase.stderr.trim() || 'Could not rebase onto Cloud main',
+    );
+  }
+  const tracking = `refs/remotes/cowiki/${space.userRef}`;
+  const tracked = runGit(cwd, ['rev-parse', '--verify', tracking], { allowFailure: true });
+  const expected = tracked.status === 0 ? tracked.stdout.trim() : '';
+  runGit(cwd, [
+    'push',
+    `--force-with-lease=refs/heads/${space.userRef}:${expected}`,
+    'cowiki',
+    `HEAD:refs/heads/${space.userRef}`,
+  ], { apiKey: credential.apiKey });
+  fetchCloudRefs(cwd, space, credential);
+  const title = message?.trim() || runGit(cwd, ['log', '-1', '--pretty=%s']).stdout.trim();
+  const pullRequest = await cloud.createOrUpdatePullRequest(space.id, title, body.trim());
+  return { committed, pullRequest };
+}
+
+function fetchCloudRefs(cwd, space, credential) {
+  runGit(cwd, [
+    'fetch',
+    '--prune',
+    'cowiki',
+    '+refs/heads/main:refs/remotes/cowiki/main',
+  ], { apiKey: credential.apiKey });
+  runGit(cwd, [
+    'fetch',
+    'cowiki',
+    `+refs/heads/${space.userRef}:refs/remotes/cowiki/${space.userRef}`,
+  ], { apiKey: credential.apiKey, allowFailure: true });
+}
+
+export function repositoryStatus(cwd) {
+  ensureMain(cwd);
+  const dirty = listDirtyPaths(cwd);
+  const head = runGit(cwd, ['rev-parse', 'HEAD']).stdout.trim();
+  const cloudMain = runGit(cwd, ['rev-parse', '--verify', 'refs/remotes/cowiki/main'], {
+    allowFailure: true,
+  });
+  return {
+    branch: 'main',
+    dirty,
+    head,
+    cloudMain: cloudMain.status === 0 ? cloudMain.stdout.trim() : null,
+  };
+}
+
+function ensureMain(cwd) {
+  const branch = runGit(cwd, ['branch', '--show-current']).stdout.trim();
+  if (branch !== 'main') {
+    throw new Error('Cloud submission requires the local main branch');
+  }
+}
+
+function ensureNoRebase(cwd) {
+  const gitDir = runGit(cwd, ['rev-parse', '--git-dir']).stdout.trim();
+  const absolute = path.isAbsolute(gitDir) ? gitDir : path.join(cwd, gitDir);
+  if (existsSync(path.join(absolute, 'rebase-merge'))
+      || existsSync(path.join(absolute, 'rebase-apply'))) {
+    throw new Error('A Git rebase is already in progress; resolve or abort it before submitting');
+  }
+}
+
+function isAllowedMarkdownPath(value) {
+  const normalized = value.replaceAll('\\', '/');
+  if (!normalized.toLowerCase().endsWith('.md')) return false;
+  const parts = normalized.split('/');
+  if (parts.some((part) => !part || part === '.' || part === '..')) return false;
+  if (!parts.some((part) => part.startsWith('.'))) return true;
+  return parts[0] === '.cowiki'
+    && parts[1] === 'sources'
+    && parts.slice(2).every((part) => !part.startsWith('.'));
+}

--- a/skills/cowiki-space/scripts/lib/oauth.mjs
+++ b/skills/cowiki-space/scripts/lib/oauth.mjs
@@ -1,0 +1,92 @@
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+
+import { normalizeServerOrigin } from './config.mjs';
+
+export async function loginWithBrowser({
+  server,
+  fetchImpl = fetch,
+  openBrowser = openSystemBrowser,
+  timeoutMs = 120_000,
+}) {
+  const origin = normalizeServerOrigin(server);
+  let complete;
+  let fail;
+  const callbackResult = new Promise((resolve, reject) => {
+    complete = resolve;
+    fail = reject;
+  });
+  const listener = http.createServer((request, response) => {
+    try {
+      const url = new URL(request.url, 'http://127.0.0.1');
+      if (url.pathname !== '/auth/callback') {
+        response.writeHead(404).end('Not found');
+        return;
+      }
+      const code = url.searchParams.get('code');
+      if (!code) throw new Error('Cloud callback did not include a code');
+      response.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('CoWiki sign-in complete. You can return to your terminal.');
+      complete(code);
+    } catch (error) {
+      response.writeHead(400).end('CoWiki sign-in failed.');
+      fail(error);
+    }
+  });
+  await new Promise((resolve, reject) => {
+    listener.once('error', reject);
+    listener.listen(0, '127.0.0.1', resolve);
+  });
+  const address = listener.address();
+  const callback = `http://127.0.0.1:${address.port}/auth/callback`;
+  const loginUrl = new URL('/api/auth/github', origin);
+  loginUrl.searchParams.set('client', 'cli');
+  loginUrl.searchParams.set('callback', callback);
+  await openBrowser(loginUrl.toString());
+  const timer = setTimeout(() => fail(new Error('Cloud sign-in timed out')), timeoutMs);
+  try {
+    const code = await callbackResult;
+    const response = await fetchImpl(`${origin}/api/auth/exchange`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ code, client: 'cli' }),
+    });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => null);
+      throw new Error(payload?.error || `Cloud sign-in failed (${response.status})`);
+    }
+    const payload = await response.json();
+    return {
+      server: origin,
+      apiKey: payload.apiKey,
+      userId: payload.userId,
+      userName: payload.userName,
+    };
+  } finally {
+    clearTimeout(timer);
+    await new Promise((resolve) => listener.close(resolve));
+  }
+}
+
+export function openSystemBrowser(url) {
+  return new Promise((resolve, reject) => {
+    let command;
+    let args;
+    if (process.platform === 'darwin') {
+      command = 'open';
+      args = [url];
+    } else if (process.platform === 'win32') {
+      command = 'rundll32';
+      args = ['url.dll,FileProtocolHandler', url];
+    } else {
+      command = 'xdg-open';
+      args = [url];
+    }
+    const child = spawn(command, args, { detached: true, stdio: 'ignore' });
+    child.once('error', reject);
+    child.once('spawn', () => {
+      child.unref();
+      resolve();
+    });
+  });
+}

--- a/tools/cowiki-cli/package.json
+++ b/tools/cowiki-cli/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@cowiki/competition-cli-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/tools/cowiki-cli/test/config.test.mjs
+++ b/tools/cowiki-cli/test/config.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, stat } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  normalizeServerOrigin,
+  readCredential,
+  writeCredential,
+} from '../../../skills/cowiki-space/scripts/lib/config.mjs';
+
+test('credentials are scoped to one normalized server and stored user-only', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'cowiki-config-'));
+  const env = { XDG_CONFIG_HOME: root };
+  const credential = {
+    server: 'https://cloud.cowiki.test',
+    apiKey: 'cw_key_secret',
+    userId: '11111111-1111-4111-8111-111111111111',
+    userName: 'Ada',
+  };
+  const filename = await writeCredential(credential, { env, platform: 'linux' });
+  assert.equal(filename, path.join(root, 'cowiki', 'credentials.json'));
+  assert.deepEqual(await readCredential('https://cloud.cowiki.test/', { env, platform: 'linux' }), credential);
+  assert.equal(JSON.parse(await readFile(filename, 'utf8')).apiKey, 'cw_key_secret');
+  if (process.platform !== 'win32') {
+    assert.equal((await stat(filename)).mode & 0o777, 0o600);
+  }
+});
+
+test('server origins reject credentials, paths, and non-http schemes', () => {
+  assert.equal(normalizeServerOrigin('https://cloud.cowiki.test/'), 'https://cloud.cowiki.test');
+  for (const value of [
+    'https://user:secret@cloud.cowiki.test',
+    'https://cloud.cowiki.test/path',
+    'file:///tmp/cloud',
+  ]) {
+    assert.throws(() => normalizeServerOrigin(value));
+  }
+});

--- a/tools/cowiki-cli/test/git.test.mjs
+++ b/tools/cowiki-cli/test/git.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+import {
+  assertMarkdownOnly,
+  commitMarkdown,
+  gitAuthEnvironment,
+  ignoreCloudConfig,
+  listDirtyPaths,
+} from '../../../skills/cowiki-space/scripts/lib/git.mjs';
+
+test('submission commits Markdown but refuses unsupported dirty files', async () => {
+  const repo = await mkdtemp(path.join(os.tmpdir(), 'cowiki-git-'));
+  run(repo, ['init', '-b', 'main']);
+  run(repo, ['config', 'user.name', 'Test']);
+  run(repo, ['config', 'user.email', 'test@cowiki.local']);
+  await writeFile(path.join(repo, 'index.md'), '# One\n');
+  run(repo, ['add', 'index.md']);
+  run(repo, ['commit', '-m', 'initial']);
+
+  await writeFile(path.join(repo, 'index.md'), '# Two\n');
+  await writeFile(path.join(repo, 'notes.txt'), 'unsupported\n');
+  const dirty = listDirtyPaths(repo);
+  assert.deepEqual(dirty.sort(), ['index.md', 'notes.txt']);
+  assert.throws(() => assertMarkdownOnly(dirty), /notes\.txt/);
+
+  run(repo, ['clean', '-f', '--', 'notes.txt']);
+  const committed = commitMarkdown(repo, 'Update page', {
+    userId: '11111111-1111-4111-8111-111111111111',
+    userName: 'Ada',
+  });
+  assert.equal(committed, true);
+  assert.equal(run(repo, ['show', '--format=', '--name-only', 'HEAD']).trim(), 'index.md');
+});
+
+test('Git bearer credentials are passed through environment configuration, not arguments', () => {
+  const env = gitAuthEnvironment('cw_key_secret', {});
+  assert.equal(env.GIT_CONFIG_COUNT, '1');
+  assert.equal(env.GIT_CONFIG_KEY_0, 'http.extraHeader');
+  assert.equal(env.GIT_CONFIG_VALUE_0, 'Authorization: Bearer cw_key_secret');
+});
+
+test('local Cloud linkage is excluded from Git submissions', async () => {
+  const repo = await mkdtemp(path.join(os.tmpdir(), 'cowiki-ignore-'));
+  run(repo, ['init', '-b', 'main']);
+  await writeFile(path.join(repo, 'index.md'), '# Space\n');
+  run(repo, ['add', 'index.md']);
+  run(repo, ['-c', 'user.name=Test', '-c', 'user.email=test@cowiki.local', 'commit', '-m', 'initial']);
+  ignoreCloudConfig(repo);
+  const ignored = spawnSync('git', ['check-ignore', '.cowiki/cloud.json'], {
+    cwd: repo,
+    encoding: 'utf8',
+  });
+  assert.equal(ignored.status, 0, ignored.stderr);
+});
+
+function run(cwd, args) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout;
+}

--- a/tools/cowiki-cli/test/git.test.mjs
+++ b/tools/cowiki-cli/test/git.test.mjs
@@ -37,6 +37,21 @@ test('submission commits Markdown but refuses unsupported dirty files', async ()
   assert.equal(run(repo, ['show', '--format=', '--name-only', 'HEAD']).trim(), 'index.md');
 });
 
+test('a rename validates both the old and new path', async () => {
+  const repo = await mkdtemp(path.join(os.tmpdir(), 'cowiki-rename-'));
+  run(repo, ['init', '-b', 'main']);
+  run(repo, ['config', 'user.name', 'Test']);
+  run(repo, ['config', 'user.email', 'test@cowiki.local']);
+  await writeFile(path.join(repo, 'notes.txt'), 'not Markdown\n');
+  run(repo, ['add', 'notes.txt']);
+  run(repo, ['commit', '-m', 'initial']);
+
+  run(repo, ['mv', 'notes.txt', 'notes.md']);
+  const dirty = listDirtyPaths(repo);
+  assert.deepEqual(dirty.sort(), ['notes.md', 'notes.txt']);
+  assert.throws(() => assertMarkdownOnly(dirty), /notes\.txt/);
+});
+
 test('Git bearer credentials are passed through environment configuration, not arguments', () => {
   const env = gitAuthEnvironment('cw_key_secret', {});
   assert.equal(env.GIT_CONFIG_COUNT, '1');

--- a/tools/cowiki-cli/test/oauth.test.mjs
+++ b/tools/cowiki-cli/test/oauth.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { loginWithBrowser } from '../../../skills/cowiki-space/scripts/lib/oauth.mjs';
+
+test('CLI login accepts one loopback code and exchanges it without exposing the API key', async () => {
+  const calls = [];
+  const credential = await loginWithBrowser({
+    server: 'https://cloud.cowiki.test',
+    timeoutMs: 2_000,
+    openBrowser: async (loginUrl) => {
+      const url = new URL(loginUrl);
+      calls.push(url);
+      assert.equal(url.searchParams.get('client'), 'cli');
+      const callback = new URL(url.searchParams.get('callback'));
+      assert.equal(callback.hostname, '127.0.0.1');
+      assert.equal(callback.pathname, '/auth/callback');
+      callback.searchParams.set('code', 'cw_once_test');
+      await fetch(callback);
+    },
+    fetchImpl: async (input, init) => {
+      calls.push({ input: String(input), init });
+      return Response.json({
+        apiKey: 'cw_key_secret',
+        userId: '11111111-1111-4111-8111-111111111111',
+        userName: 'Ada',
+      });
+    },
+  });
+  assert.equal(credential.apiKey, 'cw_key_secret');
+  assert.equal(calls[1].input, 'https://cloud.cowiki.test/api/auth/exchange');
+  assert.deepEqual(JSON.parse(calls[1].init.body), {
+    code: 'cw_once_test',
+    client: 'cli',
+  });
+});

--- a/tools/cowiki-cli/test/submit.test.mjs
+++ b/tools/cowiki-cli/test/submit.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+import {
+  setupCowikiRemote,
+  submitRepository,
+} from '../../../skills/cowiki-space/scripts/lib/git.mjs';
+
+test('submit rebases, pushes only the user branch with a lease, and creates a PR', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'cowiki-submit-'));
+  const remote = path.join(root, 'remote.git');
+  const repo = path.join(root, 'work');
+  run(root, ['init', '--bare', '--initial-branch=main', remote]);
+  run(root, ['init', '-b', 'main', repo]);
+  run(repo, ['config', 'user.name', 'Test']);
+  run(repo, ['config', 'user.email', 'test@cowiki.local']);
+  await writeFile(path.join(repo, 'index.md'), '# One\n');
+  run(repo, ['add', 'index.md']);
+  run(repo, ['commit', '-m', 'initial']);
+  run(repo, ['remote', 'add', 'seed', remote]);
+  run(repo, ['push', 'seed', 'main']);
+
+  const credential = {
+    server: 'https://cloud.cowiki.test',
+    apiKey: 'cw_key_secret',
+    userId: '11111111-1111-4111-8111-111111111111',
+    userName: 'Ada',
+  };
+  const space = {
+    id: '22222222-2222-4222-8222-222222222222',
+    gitUrl: remote,
+    userRef: `user/${credential.userId}`,
+  };
+  setupCowikiRemote(repo, space, credential);
+  await writeFile(path.join(repo, 'index.md'), '# Two\n');
+  const requests = [];
+  const cloud = {
+    async createOrUpdatePullRequest(spaceId, title, body) {
+      requests.push({ spaceId, title, body });
+      return { id: 'pr-id', number: 1, title, status: 'open' };
+    },
+  };
+
+  const result = await submitRepository({
+    cwd: repo,
+    message: 'Share solution',
+    body: 'Ready',
+    space,
+    credential,
+    cloud,
+  });
+  assert.equal(result.pullRequest.number, 1);
+  assert.deepEqual(requests, [{
+    spaceId: space.id,
+    title: 'Share solution',
+    body: 'Ready',
+  }]);
+  assert.equal(
+    run(root, ['--git-dir', remote, 'rev-parse', `refs/heads/${space.userRef}`]).trim(),
+    run(repo, ['rev-parse', 'HEAD']).trim(),
+  );
+  assert.equal(run(root, ['--git-dir', remote, 'rev-parse', 'refs/heads/main']).trim() !== '', true);
+});
+
+function run(cwd, args) {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, COWIKI_INTERNAL: '1' },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout;
+}

--- a/tools/cowiki-cli/test/submit.test.mjs
+++ b/tools/cowiki-cli/test/submit.test.mjs
@@ -66,6 +66,40 @@ test('submit rebases, pushes only the user branch with a lease, and creates a PR
   assert.equal(run(root, ['--git-dir', remote, 'rev-parse', 'refs/heads/main']).trim() !== '', true);
 });
 
+test('owner publish bootstraps an empty shared Space from a clean local main', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'cowiki-bootstrap-'));
+  const remote = path.join(root, 'remote.git');
+  const repo = path.join(root, 'work');
+  run(root, ['init', '--bare', '--initial-branch=main', remote]);
+  run(root, ['init', '-b', 'main', repo]);
+  run(repo, ['config', 'user.name', 'Test']);
+  run(repo, ['config', 'user.email', 'test@cowiki.local']);
+  await writeFile(path.join(repo, 'index.md'), '# Competition\n');
+  run(repo, ['add', 'index.md']);
+  run(repo, ['commit', '-m', 'initial']);
+  const credential = {
+    server: 'https://cloud.cowiki.test',
+    apiKey: 'cw_key_secret',
+    userId: '11111111-1111-4111-8111-111111111111',
+    userName: 'Ada',
+  };
+  const space = {
+    id: '22222222-2222-4222-8222-222222222222',
+    gitUrl: remote,
+    userRef: `user/${credential.userId}`,
+    role: 'owner',
+  };
+
+  setupCowikiRemote(repo, space, credential, { bootstrap: true });
+
+  const head = run(repo, ['rev-parse', 'HEAD']).trim();
+  assert.equal(run(root, ['--git-dir', remote, 'rev-parse', 'refs/heads/main']).trim(), head);
+  assert.equal(
+    run(root, ['--git-dir', remote, 'rev-parse', `refs/heads/${space.userRef}`]).trim(),
+    head,
+  );
+});
+
 function run(cwd, args) {
   const result = spawnSync('git', args, {
     cwd,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { LoginPage } from './pages/LoginPage';
 import { authHeaders, clearAuth, getCurrentAuth, getStoredAuth, storeAuth, tryLocalLogin } from './auth';
 import { apiBase, isDesktopClient } from './runtime';
 import { CloudApp } from './cloud/CloudApp';
+import { CloudInvitationPage } from './cloud/CloudInvitationPage';
 import {
   AUTH_RETURN_PATH_STORAGE,
   exchangeOAuthCode,
@@ -82,6 +83,8 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/invite/:token" element={<CloudInvitationPage />} />
+        <Route path="/auth/callback" element={<Navigate to="/login" replace />} />
         <Route path="/cloud/*" element={<CloudApp />} />
         <Route path="/" element={isDesktopClient()
           ? <ProtectedRoute><MainLayout /></ProtectedRoute>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,31 +2,39 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { MainLayout } from './pages/MainLayout';
 import { LoginPage } from './pages/LoginPage';
-import { authHeaders, clearAuth, getCurrentAuth, getStoredAuth, storeAuth, tryLocalLogin } from './auth';
+import { authHeaders, clearAuth, getCurrentAuth, getStoredAuth, storeAuth } from './auth';
 import { apiBase, isDesktopClient } from './runtime';
 import { CloudApp } from './cloud/CloudApp';
 import { CloudInvitationPage } from './cloud/CloudInvitationPage';
 import {
   AUTH_RETURN_PATH_STORAGE,
+  createWebAuthBootstrap,
   exchangeOAuthCode,
   parseWebOAuthFragment,
   safeAuthReturnPath,
+  validateWebCredential,
 } from './auth-flow';
 
-/** OAuth returns a short-lived one-time code in the fragment. Exchange it
- * before routing, persist only the resulting credential, and scrub the URL. */
-async function consumeOAuthFragment(): Promise<boolean> {
-  const code = parseWebOAuthFragment(window.location.hash);
-  if (!code) return false;
-  const credential = await exchangeOAuthCode(apiBase(), code);
-  storeAuth(credential.apiKey, credential.userName, credential.userId);
-  const returnPath = safeAuthReturnPath(
-    window.sessionStorage.getItem(AUTH_RETURN_PATH_STORAGE),
-  );
-  window.sessionStorage.removeItem(AUTH_RETURN_PATH_STORAGE);
-  window.history.replaceState(null, '', returnPath);
-  return true;
-}
+const runWebAuthBootstrap = createWebAuthBootstrap({
+  readOAuthCode: () => parseWebOAuthFragment(window.location.hash),
+  exchangeOAuthCode: (code) => exchangeOAuthCode(apiBase(), code),
+  storeCredential: (credential) => {
+    storeAuth(credential.apiKey, credential.userName, credential.userId);
+  },
+  hasStoredCredential: () => Boolean(getStoredAuth()),
+  validateStoredCredential: () => validateWebCredential(apiBase(), authHeaders()),
+  clearCredential: clearAuth,
+  finishOAuth: () => {
+    const returnPath = safeAuthReturnPath(
+      window.sessionStorage.getItem(AUTH_RETURN_PATH_STORAGE),
+    );
+    window.sessionStorage.removeItem(AUTH_RETURN_PATH_STORAGE);
+    window.history.replaceState(null, '', returnPath);
+  },
+  failOAuth: () => {
+    window.history.replaceState(null, '', '/login?error=oauth');
+  },
+});
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   // No hash read here — the OAuth fragment is consumed once at startup (below),
@@ -42,36 +50,13 @@ export default function App() {
   const [ready, setReady] = useState(false);
   useEffect(() => {
     const bootstrap = async () => {
-      try {
-        await consumeOAuthFragment();
-      } catch {
-        clearAuth();
-        window.history.replaceState(null, '', '/login?error=oauth');
-      }
       // Desktop local mode talks straight to the Tauri local engine. It has no
       // account and must never wait for, or redirect through, a sign-in flow.
       if (isDesktopClient()) {
         setReady(true);
         return;
       }
-      // Local-first: without a stored session, try the backend's local-mode
-      // sign-in (single-user installs / the desktop app's local server).
-      // Hosted deploys disable the endpoint and fall through to login.
-      if (!getStoredAuth()) {
-        await tryLocalLogin();
-      } else {
-        // A stored session can go stale (e.g. the local metadata store was
-        // recreated). Validate once at boot; on a definite 401 re-mint via
-        // local login. Network errors keep the session — being offline must
-        // not log anyone out.
-        try {
-          const res = await fetch(`${apiBase()}/auth/me`, { headers: authHeaders() });
-          if (res.status === 401) {
-            clearAuth();
-            await tryLocalLogin();
-          }
-        } catch { /* offline — keep session */ }
-      }
+      await runWebAuthBootstrap();
       setReady(true);
     };
     void bootstrap();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,21 +5,25 @@ import { LoginPage } from './pages/LoginPage';
 import { authHeaders, clearAuth, getCurrentAuth, getStoredAuth, storeAuth, tryLocalLogin } from './auth';
 import { apiBase, isDesktopClient } from './runtime';
 import { CloudApp } from './cloud/CloudApp';
+import {
+  AUTH_RETURN_PATH_STORAGE,
+  exchangeOAuthCode,
+  parseWebOAuthFragment,
+  safeAuthReturnPath,
+} from './auth-flow';
 
-/** OAuth hands the credential over in the URL *fragment* (never sent to servers,
- *  logs, or Referer). Parse #api_key=...&user_name=...&user_id=..., store, then
- *  scrub the fragment from the address bar/history. */
-function consumeOAuthFragment(): boolean {
-  const hash = window.location.hash.replace(/^#/, '');
-  if (!hash.includes('api_key=')) return false;
-  const params = new URLSearchParams(hash);
-  const apiKey = params.get('api_key');
-  const userName = params.get('user_name');
-  const userId = params.get('user_id');
-  if (!apiKey || !userName || !userId) return false;
-  storeAuth(apiKey, userName, userId);
-  // Scrub the fragment so the key doesn't linger in the URL/history entry.
-  window.history.replaceState(null, '', window.location.pathname);
+/** OAuth returns a short-lived one-time code in the fragment. Exchange it
+ * before routing, persist only the resulting credential, and scrub the URL. */
+async function consumeOAuthFragment(): Promise<boolean> {
+  const code = parseWebOAuthFragment(window.location.hash);
+  if (!code) return false;
+  const credential = await exchangeOAuthCode(apiBase(), code);
+  storeAuth(credential.apiKey, credential.userName, credential.userId);
+  const returnPath = safeAuthReturnPath(
+    window.sessionStorage.getItem(AUTH_RETURN_PATH_STORAGE),
+  );
+  window.sessionStorage.removeItem(AUTH_RETURN_PATH_STORAGE);
+  window.history.replaceState(null, '', returnPath);
   return true;
 }
 
@@ -37,7 +41,12 @@ export default function App() {
   const [ready, setReady] = useState(false);
   useEffect(() => {
     const bootstrap = async () => {
-      consumeOAuthFragment();
+      try {
+        await consumeOAuthFragment();
+      } catch {
+        clearAuth();
+        window.history.replaceState(null, '', '/login?error=oauth');
+      }
       // Desktop local mode talks straight to the Tauri local engine. It has no
       // account and must never wait for, or redirect through, a sign-in flow.
       if (isDesktopClient()) {

--- a/web/src/auth-flow.ts
+++ b/web/src/auth-flow.ts
@@ -4,6 +4,17 @@ export interface OAuthCredential {
   userId: string;
 }
 
+export interface WebAuthBootstrapDependencies {
+  readOAuthCode(): string | null;
+  exchangeOAuthCode(code: string): Promise<OAuthCredential>;
+  storeCredential(credential: OAuthCredential): void;
+  hasStoredCredential(): boolean;
+  validateStoredCredential(): Promise<Response>;
+  clearCredential(): void;
+  finishOAuth(): void;
+  failOAuth(): void;
+}
+
 export const AUTH_RETURN_PATH_STORAGE = 'cowiki.authReturnPath';
 
 export function buildWebGithubLoginUrl(apiBase: string): string {
@@ -68,6 +79,46 @@ export async function exchangeOAuthCode(
     apiKey: payload.apiKey,
     userName: payload.userName,
     userId: payload.userId,
+  };
+}
+
+export function validateWebCredential(
+  apiBase: string,
+  headers: HeadersInit,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  return fetchImpl(`${apiBase.replace(/\/$/, '')}/me`, { headers });
+}
+
+export function createWebAuthBootstrap(dependencies: WebAuthBootstrapDependencies) {
+  let inFlight: Promise<void> | null = null;
+
+  const bootstrap = async () => {
+    const code = dependencies.readOAuthCode();
+    if (code) {
+      try {
+        const credential = await dependencies.exchangeOAuthCode(code);
+        dependencies.storeCredential(credential);
+        dependencies.finishOAuth();
+      } catch {
+        dependencies.clearCredential();
+        dependencies.failOAuth();
+        return;
+      }
+    }
+
+    if (!dependencies.hasStoredCredential()) return;
+    try {
+      const response = await dependencies.validateStoredCredential();
+      if (response.status === 401) dependencies.clearCredential();
+    } catch {
+      // Keep the stored session while offline.
+    }
+  };
+
+  return () => {
+    if (!inFlight) inFlight = bootstrap();
+    return inFlight;
   };
 }
 

--- a/web/src/auth-flow.ts
+++ b/web/src/auth-flow.ts
@@ -4,15 +4,71 @@ export interface OAuthCredential {
   userId: string;
 }
 
+export const AUTH_RETURN_PATH_STORAGE = 'cowiki.authReturnPath';
+
 export function buildWebGithubLoginUrl(apiBase: string): string {
   return `${apiBase.replace(/\/$/, '')}/auth/github`;
 }
 
 export function buildDesktopGithubLoginUrl(apiBase: string, callbackUrl: string): string {
+  return buildLoopbackGithubLoginUrl(apiBase, 'desktop', callbackUrl);
+}
+
+export function buildLoopbackGithubLoginUrl(
+  apiBase: string,
+  client: 'desktop' | 'cli',
+  callbackUrl: string,
+): string {
   const url = new URL(buildWebGithubLoginUrl(apiBase));
-  url.searchParams.set('client', 'desktop');
+  url.searchParams.set('client', client);
   url.searchParams.set('callback', callbackUrl);
   return url.toString();
+}
+
+export function parseWebOAuthFragment(hash: string): string | null {
+  const params = new URLSearchParams(hash.replace(/^#/, ''));
+  const code = params.get('auth_code')?.trim();
+  return code || null;
+}
+
+export function safeAuthReturnPath(value: string | null): string {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) return '/cloud';
+  try {
+    const parsed = new URL(value, 'https://cowiki.local');
+    if (parsed.origin !== 'https://cowiki.local') return '/cloud';
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return '/cloud';
+  }
+}
+
+export async function exchangeOAuthCode(
+  apiBase: string,
+  code: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<OAuthCredential> {
+  const response = await fetchImpl(`${apiBase.replace(/\/$/, '')}/auth/exchange`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ code, client: 'web' }),
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null) as { error?: string } | null;
+    throw new Error(payload?.error || `Cloud sign-in failed (${response.status})`);
+  }
+  const payload = await response.json() as {
+    apiKey?: string;
+    userName?: string;
+    userId?: string;
+  };
+  if (!payload.apiKey || !payload.userName || !payload.userId) {
+    throw new Error('Cloud returned an invalid sign-in response');
+  }
+  return {
+    apiKey: payload.apiKey,
+    userName: payload.userName,
+    userId: payload.userId,
+  };
 }
 
 export function parseDesktopOAuthCallback(callbackUrl: string): OAuthCredential | null {

--- a/web/src/cloud/CloudApp.tsx
+++ b/web/src/cloud/CloudApp.tsx
@@ -25,12 +25,18 @@ export function CloudApp({ session: injectedSession }: CloudAppProps) {
   if (!session || !client) return <Navigate to="/login" replace />;
 
   const route = parseCloudRoute(location.pathname);
-  const signOut = () => {
-    clearAuth();
-    navigate('/login', { replace: true });
+  const signOut = async () => {
+    try {
+      await client.logout();
+    } catch {
+      // Local sign-out must still complete if the server is offline.
+    } finally {
+      clearAuth();
+      navigate('/login', { replace: true });
+    }
   };
   if (location.pathname === '/cloud' || location.pathname === '/cloud/') {
-    return <CloudHome client={client} session={session} onSignOut={signOut} />;
+    return <CloudHome client={client} session={session} onSignOut={() => void signOut()} />;
   }
   if (route) {
     return (
@@ -38,7 +44,7 @@ export function CloudApp({ session: injectedSession }: CloudAppProps) {
         client={client}
         session={session}
         route={route}
-        onSignOut={signOut}
+        onSignOut={() => void signOut()}
       />
     );
   }

--- a/web/src/cloud/CloudHome.tsx
+++ b/web/src/cloud/CloudHome.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
-import { ArrowRight, Cloud, LogOut, RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import { ArrowRight, Cloud, LogOut, Plus, RefreshCw } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { AvatarBadge } from '../components/ui/avatar-badge';
 import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
 import type { CloudClient, CloudSpace } from './client';
 import { cloudSpaceRoute } from './routes';
 import type { CloudSession } from './session';
@@ -17,6 +18,12 @@ export function CloudHome({ client, session, onSignOut }: CloudHomeProps) {
   const [spaces, setSpaces] = useState<CloudSpace[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [showCreate, setShowCreate] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [slugEdited, setSlugEdited] = useState(false);
+  const [createdSpace, setCreatedSpace] = useState<CloudSpace | null>(null);
   const loadSpaces = useCallback(async () => {
     setLoading(true);
     setError('');
@@ -29,7 +36,42 @@ export function CloudHome({ client, session, onSignOut }: CloudHomeProps) {
     }
   }, [client]);
 
-  useEffect(() => { void loadSpaces(); }, [loadSpaces]);
+  useEffect(() => {
+    let active = true;
+    void client.listSpaces()
+      .then((value) => { if (active) setSpaces(value); })
+      .catch((cause) => {
+        if (active) {
+          setError(cause instanceof Error ? cause.message : 'Could not load Cloud Spaces.');
+        }
+      })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [client]);
+
+  const createSharedSpace = async (event: FormEvent) => {
+    event.preventDefault();
+    setCreating(true);
+    setError('');
+    try {
+      const created = await client.createSpace(name.trim(), slug.trim());
+      setCreatedSpace(created);
+      setName('');
+      setSlug('');
+      setSlugEdited(false);
+      setShowCreate(false);
+      await loadSpaces();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not create this shared Space.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const changeName = (value: string) => {
+    setName(value);
+    if (!slugEdited) setSlug(spaceSlug(value));
+  };
 
   return (
     <div className="min-h-screen bg-bg text-text">
@@ -45,11 +87,45 @@ export function CloudHome({ client, session, onSignOut }: CloudHomeProps) {
               Browse knowledge that has reached Cloud main. Local drafts stay on their authors&apos; devices until submitted and merged.
             </p>
           </div>
-          <Button variant="outline" onClick={() => void loadSpaces()} disabled={loading}>
-            <RefreshCw className={loading ? 'animate-spin' : ''} /> Refresh
-          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => void loadSpaces()} disabled={loading}>
+              <RefreshCw className={loading ? 'animate-spin' : ''} /> Refresh
+            </Button>
+            <Button onClick={() => setShowCreate((value) => !value)}>
+              <Plus /> New shared Space
+            </Button>
+          </div>
         </div>
 
+        {showCreate && (
+          <form className="mb-6 grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-3 rounded-xl border bg-panel p-5" onSubmit={(event) => void createSharedSpace(event)}>
+            <Input
+              aria-label="Shared Space name"
+              placeholder="Competition knowledge"
+              value={name}
+              onChange={(event) => changeName(event.target.value)}
+            />
+            <Input
+              aria-label="Shared Space slug"
+              placeholder="competition-knowledge"
+              value={slug}
+              onChange={(event) => {
+                setSlug(event.target.value);
+                setSlugEdited(true);
+              }}
+            />
+            <Button type="submit" disabled={creating || !name.trim() || !slug.trim()}>
+              {creating ? 'Creating…' : 'Create Space'}
+            </Button>
+          </form>
+        )}
+        {createdSpace && (
+          <CloudNotice tone="success">
+            <strong>{createdSpace.name}</strong> is ready. Ask your local Agent to connect the
+            repository to Space <code>{createdSpace.id}</code> on <code>{session.baseUrl}</code>;
+            an explicit Owner publish will create the first Cloud main revision.
+          </CloudNotice>
+        )}
         {error && <CloudNotice tone="error">{error}</CloudNotice>}
         {loading ? (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -60,7 +136,8 @@ export function CloudHome({ client, session, onSignOut }: CloudHomeProps) {
             <div className="mx-auto mb-5 grid size-12 place-items-center rounded-xl bg-accent-soft text-accent"><Cloud /></div>
             <h2 className="font-serif text-2xl font-semibold">No shared Space yet</h2>
             <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-text-tertiary">
-              Open a local Space in the CoWiki desktop app and choose Publish to Cloud. Publishing is explicit and never uploads a Space in the background.
+              Create one here, then ask your local Agent to connect and publish a repository.
+              Publishing remains explicit.
             </p>
           </section>
         ) : (
@@ -117,4 +194,13 @@ export function CloudNotice({ children, tone = 'neutral' }: { children: React.Re
       ? 'border-green/20 bg-green-soft text-green'
       : 'border-border bg-secondary text-text-secondary';
   return <div className={`mb-5 rounded-lg border px-4 py-3 text-sm ${styles}`}>{children}</div>;
+}
+
+function spaceSlug(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 63);
 }

--- a/web/src/cloud/CloudInvitationPage.tsx
+++ b/web/src/cloud/CloudInvitationPage.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowRight, CalendarClock, ShieldCheck } from 'lucide-react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { getStoredAuth } from '../auth';
+import { Button } from '../components/ui/button';
+import { apiOrigin } from '../runtime';
+import {
+  CloudApiError,
+  createCloudClient,
+  previewCloudInvitation,
+  type CloudInvitationPreview,
+} from './client';
+import { CloudNotice, SpaceMonogram } from './CloudHome';
+import { cloudSpaceRoute } from './routes';
+
+export function CloudInvitationPage() {
+  const { token = '' } = useParams();
+  const navigate = useNavigate();
+  const [invitation, setInvitation] = useState<CloudInvitationPreview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [joining, setJoining] = useState(false);
+  const [error, setError] = useState('');
+  const baseUrl = apiOrigin() || window.location.origin;
+  const auth = getStoredAuth();
+  const client = useMemo(() => {
+    if (!auth?.api_key || auth.mode !== 'remote') return null;
+    return createCloudClient({
+      baseUrl,
+      apiKey: auth.api_key,
+      userId: auth.id,
+      userName: auth.name,
+    });
+  }, [auth?.api_key, auth?.id, auth?.mode, auth?.name, baseUrl]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError('');
+    void previewCloudInvitation(baseUrl, token)
+      .then((value) => { if (active) setInvitation(value); })
+      .catch((cause) => {
+        if (!active) return;
+        setError(
+          cause instanceof CloudApiError && cause.status === 404
+            ? 'This invitation is invalid, expired, or has been revoked.'
+            : cause instanceof Error ? cause.message : 'Could not load this invitation.',
+        );
+      })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [baseUrl, token]);
+
+  const accept = async () => {
+    if (!client || !invitation) return;
+    setJoining(true);
+    setError('');
+    try {
+      const space = await client.acceptInvitation(token);
+      navigate(cloudSpaceRoute(space.id, 'wiki'), { replace: true });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not join this Space.');
+      setJoining(false);
+    }
+  };
+
+  const returnTo = `/invite/${encodeURIComponent(token)}`;
+
+  return (
+    <main className="grid min-h-screen place-items-center bg-bg-secondary px-6 py-12 text-text">
+      <section className="w-full max-w-lg rounded-2xl border bg-panel p-8 shadow-lg">
+        <div className="mb-8 flex items-center gap-3">
+          <img src="/cowiki-logo.svg" alt="CoWiki" width={32} height={32} />
+          <span className="font-serif text-xl font-bold">CoWiki</span>
+        </div>
+        {loading && <p className="text-sm text-text-tertiary">Loading invitation…</p>}
+        {error && <CloudNotice tone="error">{error}</CloudNotice>}
+        {!loading && invitation && (
+          <>
+            <div className="mb-6 flex items-center gap-4">
+              <SpaceMonogram name={invitation.spaceName} />
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-[0.1em] text-accent">
+                  Space invitation
+                </div>
+                <h1 className="mt-1 font-serif text-3xl font-bold">{invitation.spaceName}</h1>
+              </div>
+            </div>
+            <p className="text-sm leading-6 text-text-secondary">
+              Join this shared Space to read its accepted knowledge in the browser and submit
+              local work for review.
+            </p>
+            <div className="my-6 grid gap-3 rounded-xl bg-secondary p-4 text-sm">
+              <div className="flex items-center gap-2">
+                <ShieldCheck size={16} className="text-accent" />
+                Role: <strong className="capitalize">{invitation.role}</strong>
+              </div>
+              <div className="flex items-center gap-2 text-text-secondary">
+                <CalendarClock size={16} />
+                Expires {new Date(invitation.expiresAt).toLocaleString()}
+              </div>
+            </div>
+            {client ? (
+              <Button className="w-full" disabled={joining} onClick={() => void accept()}>
+                {joining ? 'Joining…' : 'Join Space'} <ArrowRight />
+              </Button>
+            ) : (
+              <Button asChild className="w-full">
+                <Link to={`/login?returnTo=${encodeURIComponent(returnTo)}`}>
+                  Sign in with GitHub <ArrowRight />
+                </Link>
+              </Button>
+            )}
+          </>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/web/src/cloud/CloudInvitationPage.tsx
+++ b/web/src/cloud/CloudInvitationPage.tsx
@@ -34,8 +34,6 @@ export function CloudInvitationPage() {
 
   useEffect(() => {
     let active = true;
-    setLoading(true);
-    setError('');
     void previewCloudInvitation(baseUrl, token)
       .then((value) => { if (active) setInvitation(value); })
       .catch((cause) => {

--- a/web/src/cloud/CloudMembersView.tsx
+++ b/web/src/cloud/CloudMembersView.tsx
@@ -36,7 +36,17 @@ export function CloudMembersView({ client, space, currentUserId }: { client: Clo
       setNotice({ tone: 'error', message: cause instanceof Error ? cause.message : 'Could not load members.' });
     }
   }, [client, space.id]);
-  useEffect(() => { void loadMembers(); }, [loadMembers]);
+  useEffect(() => {
+    let active = true;
+    void client.listMembers(space.id)
+      .then((value) => { if (active) setMembers(value); })
+      .catch((cause) => {
+        if (active) {
+          setNotice({ tone: 'error', message: cause instanceof Error ? cause.message : 'Could not load members.' });
+        }
+      });
+    return () => { active = false; };
+  }, [client, space.id]);
 
   const loadInvitations = useCallback(async () => {
     if (mode !== 'manage') return;
@@ -46,7 +56,18 @@ export function CloudMembersView({ client, space, currentUserId }: { client: Clo
       setNotice({ tone: 'error', message: cause instanceof Error ? cause.message : 'Could not load invitations.' });
     }
   }, [client, mode, space.id]);
-  useEffect(() => { void loadInvitations(); }, [loadInvitations]);
+  useEffect(() => {
+    if (mode !== 'manage') return;
+    let active = true;
+    void client.listInvitations(space.id)
+      .then((value) => { if (active) setInvitations(value); })
+      .catch((cause) => {
+        if (active) {
+          setNotice({ tone: 'error', message: cause instanceof Error ? cause.message : 'Could not load invitations.' });
+        }
+      });
+    return () => { active = false; };
+  }, [client, mode, space.id]);
 
   const saveMember = async (memberHandle: string, nextRole: CloudRole) => {
     setPending(memberHandle);

--- a/web/src/cloud/CloudMembersView.tsx
+++ b/web/src/cloud/CloudMembersView.tsx
@@ -1,19 +1,30 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Shield, Trash2, UserPlus } from 'lucide-react';
+import { Ban, Copy, Link2, Shield, Trash2, UserPlus } from 'lucide-react';
 import { AvatarBadge } from '../components/ui/avatar-badge';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
-import type { CloudClient, CloudMember, CloudSpace } from './client';
+import type {
+  CloudClient,
+  CloudInvitation,
+  CloudInvitableRole,
+  CloudMember,
+  CloudSpace,
+} from './client';
 import { memberManagementMode } from './cloud-shell-model';
 import { CloudNotice } from './CloudHome';
 import type { CloudRole } from './session';
 
 const editableRoles: CloudRole[] = ['manager', 'editor', 'viewer'];
+const invitationRoles: CloudInvitableRole[] = ['manager', 'editor', 'viewer'];
 
 export function CloudMembersView({ client, space, currentUserId }: { client: CloudClient; space: CloudSpace; currentUserId: string }) {
   const [members, setMembers] = useState<CloudMember[]>([]);
+  const [invitations, setInvitations] = useState<CloudInvitation[]>([]);
   const [handle, setHandle] = useState('');
   const [role, setRole] = useState<CloudRole>('editor');
+  const [invitationRole, setInvitationRole] = useState<CloudInvitableRole>('editor');
+  const [expiresInHours, setExpiresInHours] = useState(168);
+  const [latestInviteUrl, setLatestInviteUrl] = useState('');
   const [pending, setPending] = useState('');
   const [notice, setNotice] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
   const mode = memberManagementMode(space.role);
@@ -26,6 +37,16 @@ export function CloudMembersView({ client, space, currentUserId }: { client: Clo
     }
   }, [client, space.id]);
   useEffect(() => { void loadMembers(); }, [loadMembers]);
+
+  const loadInvitations = useCallback(async () => {
+    if (mode !== 'manage') return;
+    try {
+      setInvitations(await client.listInvitations(space.id));
+    } catch (cause) {
+      setNotice({ tone: 'error', message: cause instanceof Error ? cause.message : 'Could not load invitations.' });
+    }
+  }, [client, mode, space.id]);
+  useEffect(() => { void loadInvitations(); }, [loadInvitations]);
 
   const saveMember = async (memberHandle: string, nextRole: CloudRole) => {
     setPending(memberHandle);
@@ -56,6 +77,50 @@ export function CloudMembersView({ client, space, currentUserId }: { client: Clo
     }
   };
 
+  const createInvitation = async () => {
+    setPending('create-invitation');
+    setNotice(null);
+    try {
+      const invitation = await client.createInvitation(
+        space.id,
+        invitationRole,
+        expiresInHours,
+      );
+      setLatestInviteUrl(invitation.inviteUrl || '');
+      setNotice({ tone: 'success', message: 'Invitation link created for this Space.' });
+    } catch (cause) {
+      setNotice({ tone: 'error', message: cause instanceof Error ? cause.message : 'Could not create invitation.' });
+    } finally {
+      await loadInvitations();
+      setPending('');
+    }
+  };
+
+  const revokeInvitation = async (invitation: CloudInvitation) => {
+    setPending(invitation.id);
+    setNotice(null);
+    try {
+      await client.revokeInvitation(space.id, invitation.id);
+      setNotice({ tone: 'success', message: 'Invitation revoked.' });
+      setLatestInviteUrl('');
+    } catch (cause) {
+      setNotice({ tone: 'error', message: cause instanceof Error ? cause.message : 'Could not revoke invitation.' });
+    } finally {
+      await loadInvitations();
+      setPending('');
+    }
+  };
+
+  const copyInviteUrl = async () => {
+    if (!latestInviteUrl) return;
+    try {
+      await navigator.clipboard.writeText(latestInviteUrl);
+      setNotice({ tone: 'success', message: 'Invitation link copied.' });
+    } catch {
+      setNotice({ tone: 'error', message: 'Copy failed. Select the link and copy it manually.' });
+    }
+  };
+
   return (
     <div className="mx-auto w-full max-w-4xl px-10 py-12">
       <div className="mb-8">
@@ -64,13 +129,54 @@ export function CloudMembersView({ client, space, currentUserId }: { client: Clo
       </div>
       {notice && <CloudNotice tone={notice.tone}>{notice.message}</CloudNotice>}
       {mode === 'manage' && (
-        <form className="mb-7 grid grid-cols-[1fr_150px_auto] gap-2 rounded-xl border bg-panel p-4" onSubmit={(event) => { event.preventDefault(); if (handle.trim()) void saveMember(handle.trim(), role); }}>
-          <Input aria-label="GitHub handle" placeholder="GitHub handle" value={handle} onChange={(event) => setHandle(event.target.value)} />
-          <select className="h-9 rounded-md border bg-bg px-3 text-sm" value={role} onChange={(event) => setRole(event.target.value as CloudRole)}>
-            {editableRoles.map((value) => <option key={value} value={value}>{capitalize(value)}</option>)}
-          </select>
-          <Button type="submit" disabled={!handle.trim() || !!pending}><UserPlus /> Add or update</Button>
-        </form>
+        <>
+          <section className="mb-7 rounded-xl border bg-panel p-5">
+            <div className="mb-4 flex items-start gap-3">
+              <div className="grid size-9 place-items-center rounded-lg bg-accent-soft text-accent"><Link2 size={17} /></div>
+              <div>
+                <h2 className="text-sm font-semibold">Invite link</h2>
+                <p className="mt-1 text-xs text-text-tertiary">The link grants access only to this Space after GitHub sign-in.</p>
+              </div>
+            </div>
+            <div className="grid grid-cols-[150px_150px_auto] gap-2">
+              <select aria-label="Invitation role" className="h-9 rounded-md border bg-bg px-3 text-sm" value={invitationRole} onChange={(event) => setInvitationRole(event.target.value as CloudInvitableRole)}>
+                {invitationRoles.map((value) => <option key={value} value={value}>{capitalize(value)}</option>)}
+              </select>
+              <select aria-label="Invitation expiry" className="h-9 rounded-md border bg-bg px-3 text-sm" value={expiresInHours} onChange={(event) => setExpiresInHours(Number(event.target.value))}>
+                <option value={24}>One day</option>
+                <option value={168}>Seven days</option>
+                <option value={720}>Thirty days</option>
+              </select>
+              <Button disabled={!!pending} onClick={() => void createInvitation()}><Link2 /> Create link</Button>
+            </div>
+            {latestInviteUrl && (
+              <div className="mt-3 flex gap-2">
+                <Input aria-label="New invitation link" readOnly value={latestInviteUrl} onFocus={(event) => event.currentTarget.select()} />
+                <Button variant="outline" onClick={() => void copyInviteUrl()}><Copy /> Copy link</Button>
+              </div>
+            )}
+            {invitations.length > 0 && (
+              <div className="mt-4 border-t pt-3">
+                {invitations.map((invitation) => (
+                  <div key={invitation.id} className="flex items-center gap-3 py-2 text-xs">
+                    <span className="w-20 font-semibold capitalize">{invitation.role}</span>
+                    <span className="flex-1 text-text-tertiary">
+                      Expires {new Date(invitation.expiresAt).toLocaleString()} · {invitation.acceptedCount} joined
+                    </span>
+                    <Button variant="ghost" size="sm" disabled={!!pending} onClick={() => void revokeInvitation(invitation)}><Ban /> Revoke</Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+          <form className="mb-7 grid grid-cols-[1fr_150px_auto] gap-2 rounded-xl border bg-panel p-4" onSubmit={(event) => { event.preventDefault(); if (handle.trim()) void saveMember(handle.trim(), role); }}>
+            <Input aria-label="GitHub handle" placeholder="Existing GitHub user" value={handle} onChange={(event) => setHandle(event.target.value)} />
+            <select className="h-9 rounded-md border bg-bg px-3 text-sm" value={role} onChange={(event) => setRole(event.target.value as CloudRole)}>
+              {editableRoles.map((value) => <option key={value} value={value}>{capitalize(value)}</option>)}
+            </select>
+            <Button type="submit" disabled={!handle.trim() || !!pending}><UserPlus /> Add directly</Button>
+          </form>
+        </>
       )}
       {mode === 'read' && <CloudNotice>You can view membership. Owners and managers can change roles.</CloudNotice>}
 

--- a/web/src/cloud/CloudReviewsView.tsx
+++ b/web/src/cloud/CloudReviewsView.tsx
@@ -2,8 +2,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Check, GitMerge, GitPullRequest, RefreshCw } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Button } from '../components/ui/button';
-import { canPush } from './session';
-import type { CloudClient, CloudPullRequest, CloudSpace } from './client';
+import { canMerge } from './session';
+import type {
+  CloudClient,
+  CloudPullRequest,
+  CloudPullRequestDiff,
+  CloudSpace,
+} from './client';
 import { CloudApiError } from './client';
 import { mergeActionVisible } from './cloud-shell-model';
 import { CloudNotice } from './CloudHome';
@@ -13,6 +18,9 @@ export function CloudReviewsView({ client, space, pullRequestId }: { client: Clo
   const [pullRequests, setPullRequests] = useState<CloudPullRequest[]>([]);
   const [loading, setLoading] = useState(true);
   const [pending, setPending] = useState('');
+  const [diff, setDiff] = useState<CloudPullRequestDiff | null>(null);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const [diffError, setDiffError] = useState('');
   const [notice, setNotice] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
   const selected = useMemo(() => pullRequests.find((pullRequest) => pullRequest.id === pullRequestId) ?? null, [pullRequestId, pullRequests]);
 
@@ -27,6 +35,24 @@ export function CloudReviewsView({ client, space, pullRequestId }: { client: Clo
     }
   }, [client, space.id]);
   useEffect(() => { void loadPullRequests(); }, [loadPullRequests]);
+  useEffect(() => {
+    if (!selected) {
+      setDiff(null);
+      setDiffError('');
+      return;
+    }
+    let active = true;
+    setDiff(null);
+    setDiffError('');
+    setDiffLoading(true);
+    void client.getPullRequestDiff(space.id, selected.id)
+      .then((value) => { if (active) setDiff(value); })
+      .catch((cause) => {
+        if (active) setDiffError(cause instanceof Error ? cause.message : 'Could not load this diff.');
+      })
+      .finally(() => { if (active) setDiffLoading(false); });
+    return () => { active = false; };
+  }, [client, selected?.headOid, selected?.id, space.id]);
 
   const approve = async (pullRequest: CloudPullRequest) => {
     setPending('approve');
@@ -76,6 +102,7 @@ export function CloudReviewsView({ client, space, pullRequestId }: { client: Clo
           {pullRequests.map((pullRequest) => (
             <Link key={pullRequest.id} to={cloudSpaceRoute(space.id, 'reviews', pullRequest.id)} className={`block border-b px-5 py-4 text-inherit no-underline last:border-b-0 ${selected?.id === pullRequest.id ? 'bg-accent-soft' : 'hover:bg-secondary'}`}>
               <div className="flex items-center gap-2 text-sm font-semibold"><GitPullRequest size={15} className="text-accent" />#{pullRequest.number} {pullRequest.title}</div>
+              <div className="mt-1 text-xs text-text-secondary">{pullRequest.authorName} <span className="text-text-tertiary">@{pullRequest.authorHandle}</span></div>
               <div className="mt-2 flex items-center justify-between text-[11px] text-text-tertiary"><span className="font-mono">{pullRequest.headRef}</span><span className="capitalize">{pullRequest.status}</span></div>
             </Link>
           ))}
@@ -92,14 +119,55 @@ export function CloudReviewsView({ client, space, pullRequestId }: { client: Clo
               </div>
               {selected.body && <p className="mb-6 whitespace-pre-wrap text-sm leading-6 text-text-secondary">{selected.body}</p>}
               <dl className="grid grid-cols-[90px_1fr] gap-x-4 gap-y-3 border-y py-5 text-xs">
+                <dt className="text-text-tertiary">Author</dt><dd>{selected.authorName} <span className="text-text-tertiary">@{selected.authorHandle}</span></dd>
                 <dt className="text-text-tertiary">Branch</dt><dd className="font-mono">{selected.headRef} → {selected.baseRef}</dd>
                 <dt className="text-text-tertiary">Head</dt><dd className="font-mono">{selected.headOid}</dd>
                 <dt className="text-text-tertiary">Approvals</dt><dd>{selected.approvalCount}</dd>
               </dl>
+              <div className="mt-6">
+                <h3 className="text-sm font-semibold">Changed files</h3>
+                {diffLoading && <p className="mt-3 text-xs text-text-tertiary">Loading current diff…</p>}
+                {diffError && <div className="mt-3"><CloudNotice tone="error">{diffError}</CloudNotice></div>}
+                {diff && (
+                  <>
+                    <div className="mt-3 overflow-hidden rounded-lg border">
+                      {diff.files.length === 0 && <p className="p-4 text-xs text-text-tertiary">No visible Markdown changes.</p>}
+                      {diff.files.map((file) => (
+                        <div key={`${file.status}:${file.path}`} className="flex items-center gap-3 border-b px-4 py-2.5 text-xs last:border-b-0">
+                          <span className="w-16 capitalize text-text-tertiary">{file.status}</span>
+                          <span className="min-w-0 flex-1 truncate font-mono">{file.path}</span>
+                          <span className="text-success">+{file.additions}</span>
+                          <span className="text-destructive">−{file.deletions}</span>
+                        </div>
+                      ))}
+                    </div>
+                    {diff.patch && (
+                      <pre className="mt-4 max-h-[520px] overflow-auto rounded-lg border bg-bg-secondary p-0 text-[11px] leading-5">
+                        {diff.patch.split('\n').map((line, index) => (
+                          <div
+                            key={`${index}:${line}`}
+                            className={`min-w-max px-4 ${
+                              line.startsWith('+') && !line.startsWith('+++')
+                                ? 'bg-green-50 text-green-800'
+                                : line.startsWith('-') && !line.startsWith('---')
+                                  ? 'bg-red-50 text-red-800'
+                                  : line.startsWith('@@')
+                                    ? 'bg-blue-50 text-blue-800'
+                                    : 'text-text-secondary'
+                            }`}
+                          >
+                            {line || ' '}
+                          </div>
+                        ))}
+                      </pre>
+                    )}
+                  </>
+                )}
+              </div>
               {selected.status === 'open' && (
                 <div className="mt-6 flex flex-wrap gap-2">
-                  {canPush(space.role) && <Button variant="outline" disabled={!!pending} onClick={() => void approve(selected)}><Check /> Approve current head</Button>}
-                  {mergeActionVisible(space.role) && <Button disabled={!!pending} onClick={() => void merge(selected)}><GitMerge /> Merge into main</Button>}
+                  {canMerge(space.role) && <Button variant="outline" disabled={!!pending || !diff || diff.headOid !== selected.headOid} onClick={() => void approve(selected)}><Check /> Approve current head</Button>}
+                  {mergeActionVisible(space.role) && <Button disabled={!!pending || !diff || diff.headOid !== selected.headOid} onClick={() => void merge(selected)}><GitMerge /> Merge into main</Button>}
                 </div>
               )}
             </>

--- a/web/src/cloud/CloudReviewsView.tsx
+++ b/web/src/cloud/CloudReviewsView.tsx
@@ -19,8 +19,7 @@ export function CloudReviewsView({ client, space, pullRequestId }: { client: Clo
   const [loading, setLoading] = useState(true);
   const [pending, setPending] = useState('');
   const [diff, setDiff] = useState<CloudPullRequestDiff | null>(null);
-  const [diffLoading, setDiffLoading] = useState(false);
-  const [diffError, setDiffError] = useState('');
+  const [diffError, setDiffError] = useState<{ pullRequestId: string; message: string } | null>(null);
   const [notice, setNotice] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
   const selected = useMemo(() => pullRequests.find((pullRequest) => pullRequest.id === pullRequestId) ?? null, [pullRequestId, pullRequests]);
 
@@ -34,25 +33,43 @@ export function CloudReviewsView({ client, space, pullRequestId }: { client: Clo
       setLoading(false);
     }
   }, [client, space.id]);
-  useEffect(() => { void loadPullRequests(); }, [loadPullRequests]);
   useEffect(() => {
-    if (!selected) {
-      setDiff(null);
-      setDiffError('');
-      return;
-    }
     let active = true;
-    setDiff(null);
-    setDiffError('');
-    setDiffLoading(true);
-    void client.getPullRequestDiff(space.id, selected.id)
-      .then((value) => { if (active) setDiff(value); })
+    void client.listPullRequests(space.id)
+      .then((value) => { if (active) setPullRequests(value); })
       .catch((cause) => {
-        if (active) setDiffError(cause instanceof Error ? cause.message : 'Could not load this diff.');
+        if (active) {
+          setNotice({ tone: 'error', message: cause instanceof Error ? cause.message : 'Could not load pull requests.' });
+        }
       })
-      .finally(() => { if (active) setDiffLoading(false); });
+      .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
-  }, [client, selected?.headOid, selected?.id, space.id]);
+  }, [client, space.id]);
+
+  const selectedId = selected?.id;
+  const selectedHeadOid = selected?.headOid;
+  useEffect(() => {
+    if (!selectedId || !selectedHeadOid) return;
+    let active = true;
+    void client.getPullRequestDiff(space.id, selectedId)
+      .then((value) => {
+        if (!active) return;
+        setDiff(value);
+        setDiffError(null);
+      })
+      .catch((cause) => {
+        if (active) {
+          setDiffError({
+            pullRequestId: selectedId,
+            message: cause instanceof Error ? cause.message : 'Could not load this diff.',
+          });
+        }
+      });
+    return () => { active = false; };
+  }, [client, selectedHeadOid, selectedId, space.id]);
+
+  const currentDiff = selected && diff?.headOid === selected.headOid ? diff : null;
+  const currentDiffError = selected && diffError?.pullRequestId === selected.id ? diffError.message : '';
 
   const approve = async (pullRequest: CloudPullRequest) => {
     setPending('approve');
@@ -126,13 +143,13 @@ export function CloudReviewsView({ client, space, pullRequestId }: { client: Clo
               </dl>
               <div className="mt-6">
                 <h3 className="text-sm font-semibold">Changed files</h3>
-                {diffLoading && <p className="mt-3 text-xs text-text-tertiary">Loading current diff…</p>}
-                {diffError && <div className="mt-3"><CloudNotice tone="error">{diffError}</CloudNotice></div>}
-                {diff && (
+                {!currentDiff && !currentDiffError && <p className="mt-3 text-xs text-text-tertiary">Loading current diff…</p>}
+                {currentDiffError && <div className="mt-3"><CloudNotice tone="error">{currentDiffError}</CloudNotice></div>}
+                {currentDiff && (
                   <>
                     <div className="mt-3 overflow-hidden rounded-lg border">
-                      {diff.files.length === 0 && <p className="p-4 text-xs text-text-tertiary">No visible Markdown changes.</p>}
-                      {diff.files.map((file) => (
+                      {currentDiff.files.length === 0 && <p className="p-4 text-xs text-text-tertiary">No visible Markdown changes.</p>}
+                      {currentDiff.files.map((file) => (
                         <div key={`${file.status}:${file.path}`} className="flex items-center gap-3 border-b px-4 py-2.5 text-xs last:border-b-0">
                           <span className="w-16 capitalize text-text-tertiary">{file.status}</span>
                           <span className="min-w-0 flex-1 truncate font-mono">{file.path}</span>
@@ -141,9 +158,9 @@ export function CloudReviewsView({ client, space, pullRequestId }: { client: Clo
                         </div>
                       ))}
                     </div>
-                    {diff.patch && (
+                    {currentDiff.patch && (
                       <pre className="mt-4 max-h-[520px] overflow-auto rounded-lg border bg-bg-secondary p-0 text-[11px] leading-5">
-                        {diff.patch.split('\n').map((line, index) => (
+                        {currentDiff.patch.split('\n').map((line, index) => (
                           <div
                             key={`${index}:${line}`}
                             className={`min-w-max px-4 ${
@@ -166,8 +183,8 @@ export function CloudReviewsView({ client, space, pullRequestId }: { client: Clo
               </div>
               {selected.status === 'open' && (
                 <div className="mt-6 flex flex-wrap gap-2">
-                  {canMerge(space.role) && <Button variant="outline" disabled={!!pending || !diff || diff.headOid !== selected.headOid} onClick={() => void approve(selected)}><Check /> Approve current head</Button>}
-                  {mergeActionVisible(space.role) && <Button disabled={!!pending || !diff || diff.headOid !== selected.headOid} onClick={() => void merge(selected)}><GitMerge /> Merge into main</Button>}
+                  {canMerge(space.role) && <Button variant="outline" disabled={!!pending || !currentDiff} onClick={() => void approve(selected)}><Check /> Approve current head</Button>}
+                  {mergeActionVisible(space.role) && <Button disabled={!!pending || !currentDiff} onClick={() => void merge(selected)}><GitMerge /> Merge into main</Button>}
                 </div>
               )}
             </>

--- a/web/src/cloud/client.ts
+++ b/web/src/cloud/client.ts
@@ -50,6 +50,27 @@ export interface CloudMember {
   role: CloudRole;
 }
 
+export type CloudInvitableRole = Exclude<CloudRole, 'owner'>;
+
+export interface CloudInvitationPreview {
+  spaceId: string;
+  spaceName: string;
+  spaceSlug: string;
+  role: CloudInvitableRole;
+  expiresAt: string;
+}
+
+export interface CloudInvitation {
+  id: string;
+  spaceId: string;
+  role: CloudInvitableRole;
+  expiresAt: string;
+  acceptedCount: number;
+  createdAt: string;
+  token?: string;
+  inviteUrl?: string;
+}
+
 export type CloudPullRequestStatus = 'open' | 'merged' | 'closed';
 
 export interface CloudPullRequest {
@@ -89,6 +110,14 @@ export interface CloudClient {
   listMembers(spaceId: string): Promise<CloudMember[]>;
   setMember(spaceId: string, handle: string, role: CloudRole): Promise<CloudMember>;
   removeMember(spaceId: string, memberId: string): Promise<void>;
+  acceptInvitation(token: string): Promise<CloudSpace>;
+  listInvitations(spaceId: string): Promise<CloudInvitation[]>;
+  createInvitation(
+    spaceId: string,
+    role: CloudInvitableRole,
+    expiresInHours: number,
+  ): Promise<CloudInvitation>;
+  revokeInvitation(spaceId: string, invitationId: string): Promise<void>;
   listPullRequests(spaceId: string): Promise<CloudPullRequest[]>;
   getPullRequest(spaceId: string, pullRequestId: string): Promise<CloudPullRequest>;
   approvePullRequest(spaceId: string, pullRequestId: string): Promise<CloudPullRequest>;
@@ -146,6 +175,22 @@ export function createCloudClient(
       `${spacePath(spaceId, '/members')}/${encodeURIComponent(memberId)}`,
       { method: 'DELETE' },
     ),
+    acceptInvitation: (token) => request(
+      `/api/invitations/${encodeURIComponent(token)}/accept`,
+      { method: 'POST' },
+    ),
+    listInvitations: (spaceId) => request(spacePath(spaceId, '/invitations')),
+    createInvitation: (spaceId, role, expiresInHours) => request(
+      spacePath(spaceId, '/invitations'),
+      {
+        method: 'POST',
+        body: JSON.stringify({ role, expiresInHours }),
+      },
+    ),
+    revokeInvitation: (spaceId, invitationId) => request(
+      `${spacePath(spaceId, '/invitations')}/${encodeURIComponent(invitationId)}`,
+      { method: 'DELETE' },
+    ),
     listPullRequests: (spaceId) => request(spacePath(spaceId, '/pull-requests')),
     getPullRequest: (spaceId, pullRequestId) => request(pullRequestPath(spaceId, pullRequestId)),
     approvePullRequest: (spaceId, pullRequestId) => request(
@@ -157,4 +202,24 @@ export function createCloudClient(
       { method: 'POST', body: JSON.stringify({ expectedHeadOid }) },
     ),
   };
+}
+
+export async function previewCloudInvitation(
+  baseUrl: string,
+  token: string,
+  fetchImpl: CloudFetch = fetch,
+): Promise<CloudInvitationPreview> {
+  const origin = baseUrl.replace(/\/$/, '');
+  const response = await fetchImpl(
+    `${origin}/api/invitations/${encodeURIComponent(token)}`,
+    { headers: { Accept: 'application/json' } },
+  );
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null) as { error?: string } | null;
+    throw new CloudApiError(
+      response.status,
+      payload?.error || `Invitation request failed (${response.status})`,
+    );
+  }
+  return response.json() as Promise<CloudInvitationPreview>;
 }

--- a/web/src/cloud/client.ts
+++ b/web/src/cloud/client.ts
@@ -87,6 +87,21 @@ export interface CloudPullRequest {
   status: CloudPullRequestStatus;
   mergedBy: string | null;
   approvalCount: number;
+  authorHandle: string;
+  authorName: string;
+  authorAvatarUrl: string | null;
+}
+
+export interface CloudPullRequestDiff {
+  baseOid: string;
+  headOid: string;
+  files: Array<{
+    path: string;
+    status: string;
+    additions: number;
+    deletions: number;
+  }>;
+  patch: string;
 }
 
 export class CloudApiError extends Error {
@@ -120,6 +135,7 @@ export interface CloudClient {
   revokeInvitation(spaceId: string, invitationId: string): Promise<void>;
   listPullRequests(spaceId: string): Promise<CloudPullRequest[]>;
   getPullRequest(spaceId: string, pullRequestId: string): Promise<CloudPullRequest>;
+  getPullRequestDiff(spaceId: string, pullRequestId: string): Promise<CloudPullRequestDiff>;
   approvePullRequest(spaceId: string, pullRequestId: string): Promise<CloudPullRequest>;
   mergePullRequest(spaceId: string, pullRequestId: string, expectedHeadOid: string): Promise<CloudPullRequest>;
 }
@@ -193,6 +209,9 @@ export function createCloudClient(
     ),
     listPullRequests: (spaceId) => request(spacePath(spaceId, '/pull-requests')),
     getPullRequest: (spaceId, pullRequestId) => request(pullRequestPath(spaceId, pullRequestId)),
+    getPullRequestDiff: (spaceId, pullRequestId) => request(
+      pullRequestPath(spaceId, pullRequestId, '/diff'),
+    ),
     approvePullRequest: (spaceId, pullRequestId) => request(
       pullRequestPath(spaceId, pullRequestId, '/approve'),
       { method: 'POST' },

--- a/web/src/cloud/client.ts
+++ b/web/src/cloud/client.ts
@@ -117,6 +117,7 @@ export class CloudApiError extends Error {
 export interface CloudClient {
   readonly session: CloudSession;
   currentUser(): Promise<CloudUser>;
+  logout(): Promise<void>;
   listSpaces(): Promise<CloudSpace[]>;
   createSpace(name: string, slug: string): Promise<CloudSpace>;
   getSpace(spaceId: string): Promise<CloudSpace>;
@@ -171,6 +172,7 @@ export function createCloudClient(
       const response = await request<{ user: CloudUser }>('/api/me');
       return response.user;
     },
+    logout: () => request('/api/auth/logout', { method: 'POST' }),
     listSpaces: () => request('/api/spaces'),
     createSpace: (name, slug) => request('/api/spaces', {
       method: 'POST',

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,23 +1,32 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { getStoredAuth, storeAuth } from '../auth';
-import { buildWebGithubLoginUrl } from '../auth-flow';
+import {
+  AUTH_RETURN_PATH_STORAGE,
+  buildWebGithubLoginUrl,
+  safeAuthReturnPath,
+} from '../auth-flow';
 import { startDesktopGithubOAuth } from '../desktop-auth';
 import { apiBase, isDesktopClient } from '../runtime';
 import { C } from '@/lib/design';
 
 export function LoginPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const desktop = isDesktopClient();
+  const returnPath = safeAuthReturnPath(new URLSearchParams(location.search).get('returnTo'));
 
   useEffect(() => {
     if (getStoredAuth()) {
-      navigate(desktop ? '/' : '/cloud', { replace: true });
+      navigate(desktop ? '/' : returnPath, { replace: true });
     }
-  }, [desktop, navigate]);
+  }, [desktop, navigate, returnPath]);
 
   const signInWithGitHub = async (event: React.MouseEvent<HTMLAnchorElement>) => {
-    if (!desktop) return;
+    if (!desktop) {
+      window.sessionStorage.setItem(AUTH_RETURN_PATH_STORAGE, returnPath);
+      return;
+    }
     event.preventDefault();
     const credential = await startDesktopGithubOAuth();
     storeAuth(credential.apiKey, credential.userName, credential.userId);

--- a/web/tests/agent-contract.test.ts
+++ b/web/tests/agent-contract.test.ts
@@ -16,9 +16,14 @@ test('the shipped Agent skill describes the local Space workflow', () => {
   assert.match(skill, /edit .*Markdown files directly/i);
   assert.match(skill, /Live mode/i);
   assert.match(skill, /Background mode/i);
-  assert.match(skill, /no .*API key.*server/i);
+  assert.match(skill, /local work requires no account.*server/i);
   assert.match(skill, /arbitrary (?:OKF )?hierarchy/i);
-  assert.doesNotMatch(skill, /cowiki (?:setup|compile|write|submit)\b/i);
+  assert.match(skill, /scripts\/cowiki\.mjs/);
+  assert.match(skill, /submit --message/);
+  assert.match(skill, /explicit.*submit request/i);
+  assert.match(skill, /never.*API key/i);
+  assert.match(skill, /do not reproduce.*rebase.*push/i);
+  assert.doesNotMatch(skill, /cowiki (?:compile|write)\b/i);
   assert.doesNotMatch(skill, /cowiki review (?:show|approve|reject)\b/i);
   assert.doesNotMatch(skill, /wiki\/entities\/concepts/i);
 });

--- a/web/tests/auth-flow.test.ts
+++ b/web/tests/auth-flow.test.ts
@@ -4,8 +4,11 @@ import test from 'node:test';
 
 import {
   buildDesktopGithubLoginUrl,
+  buildLoopbackGithubLoginUrl,
   buildWebGithubLoginUrl,
+  parseWebOAuthFragment,
   parseDesktopOAuthCallback,
+  safeAuthReturnPath,
 } from '../src/auth-flow.ts';
 
 const loginPage = readFileSync(new URL('../src/pages/LoginPage.tsx', import.meta.url), 'utf8');
@@ -34,6 +37,25 @@ test('desktop callback accepts credential query params from the loopback listene
       'http://127.0.0.1:39281/auth/callback?api_key=cw_123&user_name=octo-cat&user_id=user-1',
     ),
     { apiKey: 'cw_123', userName: 'octo-cat', userId: 'user-1' },
+  );
+});
+
+test('browser OAuth exchanges a short-lived fragment code and accepts only local return paths', () => {
+  assert.equal(parseWebOAuthFragment('#auth_code=cw_once_test'), 'cw_once_test');
+  assert.equal(parseWebOAuthFragment('#api_key=cw_key_secret'), null);
+  assert.equal(safeAuthReturnPath('/invite/cw_invite_test'), '/invite/cw_invite_test');
+  assert.equal(safeAuthReturnPath('https://evil.example/invite/test'), '/cloud');
+  assert.equal(safeAuthReturnPath('//evil.example/invite/test'), '/cloud');
+});
+
+test('CLI OAuth uses the same exact loopback boundary as desktop', () => {
+  assert.equal(
+    buildLoopbackGithubLoginUrl(
+      'https://cloud.cowiki.test/api',
+      'cli',
+      'http://127.0.0.1:40821/auth/callback',
+    ),
+    'https://cloud.cowiki.test/api/auth/github?client=cli&callback=http%3A%2F%2F127.0.0.1%3A40821%2Fauth%2Fcallback',
   );
 });
 

--- a/web/tests/auth-flow.test.ts
+++ b/web/tests/auth-flow.test.ts
@@ -6,11 +6,14 @@ import {
   buildDesktopGithubLoginUrl,
   buildLoopbackGithubLoginUrl,
   buildWebGithubLoginUrl,
+  createWebAuthBootstrap,
   parseWebOAuthFragment,
   parseDesktopOAuthCallback,
   safeAuthReturnPath,
+  validateWebCredential,
 } from '../src/auth-flow.ts';
 
+const appSource = readFileSync(new URL('../src/App.tsx', import.meta.url), 'utf8');
 const loginPage = readFileSync(new URL('../src/pages/LoginPage.tsx', import.meta.url), 'utf8');
 const spaceRail = readFileSync(new URL('../src/components/layout/SpaceRail.tsx', import.meta.url), 'utf8');
 
@@ -46,6 +49,74 @@ test('browser OAuth exchanges a short-lived fragment code and accepts only local
   assert.equal(safeAuthReturnPath('/invite/cw_invite_test'), '/invite/cw_invite_test');
   assert.equal(safeAuthReturnPath('https://evil.example/invite/test'), '/cloud');
   assert.equal(safeAuthReturnPath('//evil.example/invite/test'), '/cloud');
+});
+
+test('web auth bootstrap is single-flight when React StrictMode starts it twice', async () => {
+  let exchanges = 0;
+  let stores = 0;
+  let clears = 0;
+  const run = createWebAuthBootstrap({
+    readOAuthCode: () => 'cw_once_test',
+    exchangeOAuthCode: async () => {
+      exchanges += 1;
+      return { apiKey: 'cw_key_test', userName: 'octo-cat', userId: 'user-1' };
+    },
+    storeCredential: () => { stores += 1; },
+    hasStoredCredential: () => true,
+    validateStoredCredential: async () => new Response(null, { status: 200 }),
+    clearCredential: () => { clears += 1; },
+    finishOAuth: () => {},
+    failOAuth: () => {},
+  });
+
+  const first = run();
+  const second = run();
+
+  assert.strictEqual(first, second);
+  await Promise.all([first, second]);
+  assert.equal(exchanges, 1);
+  assert.equal(stores, 1);
+  assert.equal(clears, 0);
+});
+
+test('web auth bootstrap does not probe desktop local login without a Cloud credential', async () => {
+  let validations = 0;
+  const run = createWebAuthBootstrap({
+    readOAuthCode: () => null,
+    exchangeOAuthCode: async () => {
+      throw new Error('OAuth exchange should not run');
+    },
+    storeCredential: () => {},
+    hasStoredCredential: () => false,
+    validateStoredCredential: async () => {
+      validations += 1;
+      return new Response(null, { status: 200 });
+    },
+    clearCredential: () => {},
+    finishOAuth: () => {},
+    failOAuth: () => {},
+  });
+
+  await run();
+
+  assert.equal(validations, 0);
+  assert.doesNotMatch(appSource, /tryLocalLogin/);
+});
+
+test('stored web credentials are validated against the Cloud /api/me endpoint', async () => {
+  const calls: string[] = [];
+  const response = await validateWebCredential(
+    'http://localhost:5173/api',
+    { Authorization: 'Bearer cw_key_test' },
+    async (input) => {
+      calls.push(String(input));
+      return new Response(null, { status: 200 });
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(calls, ['http://localhost:5173/api/me']);
+  assert.doesNotMatch(appSource, /\/auth\/me/);
 });
 
 test('CLI OAuth uses the same exact loopback boundary as desktop', () => {

--- a/web/tests/cloud-client.test.ts
+++ b/web/tests/cloud-client.test.ts
@@ -73,6 +73,24 @@ test('typed Cloud requests always carry the injected bearer credential', async (
   }
 });
 
+test('Cloud logout revokes the server credential', async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fakeFetch: CloudFetch = async (input, init) => {
+    calls.push({ url: String(input), init });
+    return new Response(null, { status: 204 });
+  };
+  const client = createCloudClient(
+    { baseUrl: 'https://cloud.cowiki.test', apiKey: 'cw_key_test', userId, userName: 'CoWiki' },
+    fakeFetch,
+  );
+
+  await client.logout();
+
+  assert.equal(calls[0].url, 'https://cloud.cowiki.test/api/auth/logout');
+  assert.equal(calls[0].init?.method, 'POST');
+  assert.equal(new Headers(calls[0].init?.headers).get('authorization'), 'Bearer cw_key_test');
+});
+
 test('Cloud mutations serialize the current contract and surface typed failures', async () => {
   const calls: Array<{ url: string; init?: RequestInit }> = [];
   const fakeFetch: CloudFetch = async (input, init) => {

--- a/web/tests/cloud-client.test.ts
+++ b/web/tests/cloud-client.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   CloudApiError,
   createCloudClient,
+  previewCloudInvitation,
   type CloudFetch,
 } from '../src/cloud/client.ts';
 import {
@@ -124,4 +125,60 @@ test('UUID Space routes round-trip document paths', () => {
     documentPath: 'guides/Shared Context.md',
   });
   assert.equal(parseCloudRoute('/cloud/spaces/not-a-uuid/wiki'), null);
+});
+
+test('Space invitations have a public preview and authenticated lifecycle', async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fakeFetch: CloudFetch = async (input, init) => {
+    calls.push({ url: String(input), init });
+    if (calls.length === 1) {
+      return Response.json({
+        spaceId,
+        spaceName: 'Competition',
+        spaceSlug: 'competition',
+        role: 'editor',
+        expiresAt: '2026-08-01T00:00:00Z',
+      });
+    }
+    if (calls.length === 2) {
+      return Response.json({ id: spaceId, role: 'editor' });
+    }
+    if (calls.length === 3) {
+      return Response.json({
+        id: 'invite-id',
+        spaceId,
+        role: 'editor',
+        expiresAt: '2026-08-01T00:00:00Z',
+        acceptedCount: 0,
+        createdAt: '2026-07-28T00:00:00Z',
+        token: 'cw_invite_test',
+        inviteUrl: 'https://cloud.cowiki.test/invite/cw_invite_test',
+      }, { status: 201 });
+    }
+    if (calls.length === 4) return Response.json([]);
+    return new Response(null, { status: 204 });
+  };
+  const preview = await previewCloudInvitation(
+    'https://cloud.cowiki.test',
+    'cw_invite_test',
+    fakeFetch,
+  );
+  assert.equal(preview.spaceName, 'Competition');
+  const client = createCloudClient(
+    { baseUrl: 'https://cloud.cowiki.test', apiKey: 'key', userId, userName: 'User' },
+    fakeFetch,
+  );
+  await client.acceptInvitation('cw_invite_test');
+  await client.createInvitation(spaceId, 'editor', 168);
+  await client.listInvitations(spaceId);
+  await client.revokeInvitation(spaceId, 'invite-id');
+
+  assert.equal(new Headers(calls[0].init?.headers).has('authorization'), false);
+  assert.equal(calls[1].url, 'https://cloud.cowiki.test/api/invitations/cw_invite_test/accept');
+  assert.equal(new Headers(calls[1].init?.headers).get('authorization'), 'Bearer key');
+  assert.deepEqual(JSON.parse(String(calls[2].init?.body)), {
+    role: 'editor',
+    expiresInHours: 168,
+  });
+  assert.equal(calls[4].init?.method, 'DELETE');
 });

--- a/web/tests/cloud-client.test.ts
+++ b/web/tests/cloud-client.test.ts
@@ -182,3 +182,26 @@ test('Space invitations have a public preview and authenticated lifecycle', asyn
   });
   assert.equal(calls[4].init?.method, 'DELETE');
 });
+
+test('pull request diff is fetched from the reviewed head endpoint', async () => {
+  const calls: string[] = [];
+  const fakeFetch: CloudFetch = async (input) => {
+    calls.push(String(input));
+    return Response.json({
+      baseOid: 'a'.repeat(40),
+      headOid: 'b'.repeat(40),
+      files: [{ path: 'index.md', status: 'modified', additions: 2, deletions: 1 }],
+      patch: 'diff --git a/index.md b/index.md\n-old\n+new',
+    });
+  };
+  const client = createCloudClient(
+    { baseUrl: 'https://cloud.cowiki.test', apiKey: 'key', userId, userName: 'User' },
+    fakeFetch,
+  );
+  const diff = await client.getPullRequestDiff(spaceId, '33333333-3333-4333-8333-333333333333');
+  assert.equal(diff.files[0].additions, 2);
+  assert.equal(
+    calls[0],
+    `https://cloud.cowiki.test/api/spaces/${spaceId}/pull-requests/33333333-3333-4333-8333-333333333333/diff`,
+  );
+});

--- a/web/tests/cloud-shell.test.ts
+++ b/web/tests/cloud-shell.test.ts
@@ -24,6 +24,10 @@ test('browser routing has a focused Cloud shell with no Tauri dependency', () =>
   for (const source of [cloudApp, cloudHome, wiki, reviews, members]) {
     assert.doesNotMatch(source, /@tauri-apps|local-api|invoke\(/);
   }
+  assert.match(cloudApp, /await client\.logout\(\)/);
+  assert.match(cloudHome, /New shared Space/);
+  assert.match(cloudHome, /createSpace/);
+  assert.match(cloudHome, /Owner publish/);
 });
 
 test('Cloud Space navigation exposes read surfaces to every member', () => {

--- a/web/tests/cloud-shell.test.ts
+++ b/web/tests/cloud-shell.test.ts
@@ -80,3 +80,12 @@ test('Owners and Managers administer Space-scoped invitation links', () => {
   assert.match(members, /Seven days/);
   assert.match(members, /mode === 'manage'/);
 });
+
+test('Cloud review loads and renders the exact Markdown diff before merge', () => {
+  assert.match(reviews, /getPullRequestDiff/);
+  assert.match(reviews, /Changed files/);
+  assert.match(reviews, /diff\.patch\.split/);
+  assert.match(reviews, /authorName/);
+  assert.match(reviews, /canMerge\(space\.role\)/);
+  assert.doesNotMatch(reviews, /dangerouslySetInnerHTML/);
+});

--- a/web/tests/cloud-shell.test.ts
+++ b/web/tests/cloud-shell.test.ts
@@ -70,3 +70,13 @@ test('Space invitation route remains readable before sign in and accepts into on
   assert.match(invitation, /cloudSpaceRoute/);
   assert.doesNotMatch(invitation, /@tauri-apps|invoke\(/);
 });
+
+test('Owners and Managers administer Space-scoped invitation links', () => {
+  assert.match(members, /Invite link/);
+  assert.match(members, /createInvitation/);
+  assert.match(members, /listInvitations/);
+  assert.match(members, /revokeInvitation/);
+  assert.match(members, /Copy link/);
+  assert.match(members, /Seven days/);
+  assert.match(members, /mode === 'manage'/);
+});

--- a/web/tests/cloud-shell.test.ts
+++ b/web/tests/cloud-shell.test.ts
@@ -84,7 +84,7 @@ test('Owners and Managers administer Space-scoped invitation links', () => {
 test('Cloud review loads and renders the exact Markdown diff before merge', () => {
   assert.match(reviews, /getPullRequestDiff/);
   assert.match(reviews, /Changed files/);
-  assert.match(reviews, /diff\.patch\.split/);
+  assert.match(reviews, /currentDiff\.patch\.split/);
   assert.match(reviews, /authorName/);
   assert.match(reviews, /canMerge\(space\.role\)/);
   assert.doesNotMatch(reviews, /dangerouslySetInnerHTML/);

--- a/web/tests/cloud-shell.test.ts
+++ b/web/tests/cloud-shell.test.ts
@@ -15,6 +15,7 @@ const cloudHome = readFileSync(new URL('../src/cloud/CloudHome.tsx', import.meta
 const wiki = readFileSync(new URL('../src/cloud/CloudWikiView.tsx', import.meta.url), 'utf8');
 const reviews = readFileSync(new URL('../src/cloud/CloudReviewsView.tsx', import.meta.url), 'utf8');
 const members = readFileSync(new URL('../src/cloud/CloudMembersView.tsx', import.meta.url), 'utf8');
+const invitation = readFileSync(new URL('../src/cloud/CloudInvitationPage.tsx', import.meta.url), 'utf8');
 
 test('browser routing has a focused Cloud shell with no Tauri dependency', () => {
   assert.match(app, /path="\/cloud\/\*"/);
@@ -59,4 +60,13 @@ test('member and PR mutations reload server-authoritative state', () => {
   assert.match(members, /await loadMembers\(\)/);
   assert.match(reviews, /await loadPullRequests\(\)/);
   assert.match(reviews, /expectedHeadOid|headOid/);
+});
+
+test('Space invitation route remains readable before sign in and accepts into one Space', () => {
+  assert.match(app, /path="\/invite\/:token"/);
+  assert.match(invitation, /previewCloudInvitation/);
+  assert.match(invitation, /Sign in with GitHub/);
+  assert.match(invitation, /acceptInvitation/);
+  assert.match(invitation, /cloudSpaceRoute/);
+  assert.doesNotMatch(invitation, /@tauri-apps|invoke\(/);
 });

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+const cloudTarget = 'http://127.0.0.1:8787'
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -15,7 +17,9 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:3000'
+      '/api': cloudTarget,
+      '/git': cloudTarget,
+      '/healthz': cloudTarget,
     }
   }
 })


### PR DESCRIPTION
## Summary
- make the browser the read-only collaboration control plane for shared Space creation, invitations, membership, Markdown PR review, approval, and merge
- add a bundled cross-platform Agent command for browser login, explicit first publish, clone/setup, status, and safe local-first submission
- harden OAuth exchange, credential revocation, Space-scoped permissions, invitation persistence, head-specific review, audit events, and reproducible local Cloud startup

## Verification
- `TEST_DATABASE_URL=postgres://postgres:cowiki@127.0.0.1:55432/postgres cargo test`
- `bash cloud/tests/container_contract.sh`
- `npm test && npm run build` in `web`
- ESLint on every modified frontend file
- `npm test` in `tools/cowiki-cli`
- real HTTP + Git smoke flow for Owner, Manager, Editor, Viewer, and outsider, including invite revocation and credential revocation

## Note
Repository-wide ESLint still reports pre-existing violations in files outside this change; every frontend file modified here passes ESLint.