### PR TITLE
feat: add shared Space creation invites

### DIFF
--- a/web/src/cloud/CloudHome.tsx
+++ b/web/src/cloud/CloudHome.tsx
@@ -12,7 +12,13 @@ import {
   SelectValue,
 } from '../components/ui/select';
 import { TooltipProvider } from '../components/ui/tooltip';
-import type { CloudClient, CloudSpace } from './client';
+import {
+  CloudApiError,
+  type CloudClient,
+  type CloudSpace,
+  type CloudSpaceCreationCapability,
+} from './client';
+import { spaceCreationPanelMode } from './cloud-shell-model';
 import { cloudSpaceRoute } from './routes';
 import type { CloudSession } from './session';
 import type { CloudVisibility } from './session';
@@ -32,6 +38,10 @@ export function CloudHome({ client, session, onSignOut }: CloudHomeProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [creating, setCreating] = useState(false);
+  const [capability, setCapability] = useState<CloudSpaceCreationCapability | null>(null);
+  const [capabilityLoading, setCapabilityLoading] = useState(false);
+  const [inviteCode, setInviteCode] = useState('');
+  const [redeeming, setRedeeming] = useState(false);
   const [name, setName] = useState('');
   const [slug, setSlug] = useState('');
   const [slugEdited, setSlugEdited] = useState(false);
@@ -51,6 +61,22 @@ export function CloudHome({ client, session, onSignOut }: CloudHomeProps) {
     return () => { active = false; };
   }, [client]);
 
+  useEffect(() => {
+    if (panel !== 'create') return undefined;
+    let active = true;
+    setCapabilityLoading(true);
+    setError('');
+    void client.getSpaceCreationCapability()
+      .then((value) => { if (active) setCapability(value); })
+      .catch((cause) => {
+        if (active) {
+          setError(cause instanceof Error ? cause.message : 'Could not check Space creation access.');
+        }
+      })
+      .finally(() => { if (active) setCapabilityLoading(false); });
+    return () => { active = false; };
+  }, [client, panel]);
+
   const openCreatePanel = () => {
     setError('');
     navigate('/cloud?action=create', { replace: true });
@@ -68,9 +94,32 @@ export function CloudHome({ client, session, onSignOut }: CloudHomeProps) {
       const created = await client.createSpace(name.trim(), slug.trim(), visibility);
       navigate(cloudSpaceRoute(created.id));
     } catch (cause) {
+      if (cause instanceof CloudApiError
+        && (cause.code === 'invite_required' || cause.code === 'limit_reached')) {
+        try {
+          setCapability(await client.getSpaceCreationCapability());
+        } catch {
+          // Keep the authoritative creation error when refreshing capability also fails.
+        }
+      }
       setError(cause instanceof Error ? cause.message : 'Could not create this shared Space.');
     } finally {
       setCreating(false);
+    }
+  };
+
+  const redeemInvite = async (event: FormEvent) => {
+    event.preventDefault();
+    setRedeeming(true);
+    setError('');
+    try {
+      const unlocked = await client.redeemSpaceCreationInvite(inviteCode);
+      setCapability(unlocked);
+      setInviteCode('');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not redeem this invite code.');
+    } finally {
+      setRedeeming(false);
     }
   };
 
@@ -122,38 +171,80 @@ export function CloudHome({ client, session, onSignOut }: CloudHomeProps) {
                       Cancel
                     </button>
                   </div>
-                  <form className="space-y-3" onSubmit={(event) => void createSharedSpace(event)}>
-                    <Input
-                      aria-label="Shared Space name"
-                      placeholder="Space name"
-                      value={name}
-                      onChange={(event) => changeName(event.target.value)}
+                  {capabilityLoading || !capability ? (
+                    <div
+                      aria-label="Checking Space creation access"
+                      className="h-24 animate-pulse rounded-lg bg-secondary"
                     />
-                    <Select
-                      value={visibility}
-                      onValueChange={(value) => setVisibility(value as CloudVisibility)}
-                    >
-                      <SelectTrigger aria-label="Space visibility" className="w-full">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="private">Private — members only</SelectItem>
-                        <SelectItem value="public">Public — anyone can read merged pages</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <Input
-                      aria-label="Shared Space slug"
-                      placeholder="space-name"
-                      value={slug}
-                      onChange={(event) => {
-                        setSlug(event.target.value);
-                        setSlugEdited(true);
-                      }}
-                    />
-                    <Button className="w-full" type="submit" disabled={creating || !name.trim() || !slug.trim()}>
-                      {creating ? 'Creating…' : 'Create Space'}
-                    </Button>
-                  </form>
+                  ) : spaceCreationPanelMode(capability) === 'invite' ? (
+                    <div>
+                      <p className="mb-4 text-sm leading-6 text-text-secondary">
+                        Your GitHub account can join existing shared Spaces. Enter a one-time
+                        invite code to unlock creation for this account.
+                      </p>
+                      <form className="space-y-3" onSubmit={(event) => void redeemInvite(event)}>
+                        <Input
+                          aria-label="Space creation invite code"
+                          autoComplete="off"
+                          placeholder="cw_space_…"
+                          value={inviteCode}
+                          onChange={(event) => setInviteCode(event.target.value)}
+                        />
+                        <Button
+                          className="w-full"
+                          type="submit"
+                          disabled={redeeming || !inviteCode.trim()}
+                        >
+                          {redeeming ? 'Unlocking…' : 'Unlock Space creation'}
+                        </Button>
+                      </form>
+                    </div>
+                  ) : spaceCreationPanelMode(capability) === 'limit' ? (
+                    <div className="rounded-lg bg-secondary px-4 py-5 text-sm leading-6 text-text-secondary">
+                      <p className="font-medium text-text">
+                        You have created {capability.createdCount} of {capability.limit} shared Spaces.
+                      </p>
+                      <p className="mt-1.5">
+                        Your creation limit has been reached. You can still join existing shared Spaces.
+                      </p>
+                    </div>
+                  ) : (
+                    <form className="space-y-3" onSubmit={(event) => void createSharedSpace(event)}>
+                      <p className="text-xs text-text-tertiary">
+                        {capability.createdCount} of {capability.limit} shared Spaces created
+                      </p>
+                      <Input
+                        aria-label="Shared Space name"
+                        placeholder="Space name"
+                        value={name}
+                        onChange={(event) => changeName(event.target.value)}
+                      />
+                      <Select
+                        value={visibility}
+                        onValueChange={(value) => setVisibility(value as CloudVisibility)}
+                      >
+                        <SelectTrigger aria-label="Space visibility" className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="private">Private — members only</SelectItem>
+                          <SelectItem value="public">Public — anyone can read merged pages</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Input
+                        aria-label="Shared Space slug"
+                        placeholder="space-name"
+                        value={slug}
+                        onChange={(event) => {
+                          setSlug(event.target.value);
+                          setSlugEdited(true);
+                        }}
+                      />
+                      <Button className="w-full" type="submit" disabled={creating || !name.trim() || !slug.trim()}>
+                        {creating ? 'Creating…' : 'Create Space'}
+                      </Button>
+                    </form>
+                  )}
                 </section>
               ) : loading ? (
                 <div className="mx-auto size-6 animate-pulse rounded-md bg-secondary" aria-label="Loading Spaces" />

--- a/web/src/cloud/client.ts
+++ b/web/src/cloud/client.ts
@@ -28,6 +28,16 @@ export interface CloudSpace {
   publicUrl: string;
 }
 
+export type CloudSpaceCreationReason = 'invite_required' | 'limit_reached' | null;
+
+export interface CloudSpaceCreationCapability {
+  authorized: boolean;
+  createdCount: number;
+  limit: number;
+  canCreate: boolean;
+  reason: CloudSpaceCreationReason;
+}
+
 export interface PublicCloudSpace {
   id: string;
   name: string;
@@ -119,11 +129,13 @@ export interface CloudPullRequestDiff {
 
 export class CloudApiError extends Error {
   readonly status: number;
+  readonly code: string | null;
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, code: string | null = null) {
     super(message);
     this.name = 'CloudApiError';
     this.status = status;
+    this.code = code;
   }
 }
 
@@ -132,6 +144,8 @@ export interface CloudClient {
   currentUser(): Promise<CloudUser>;
   logout(): Promise<void>;
   listSpaces(): Promise<CloudSpace[]>;
+  getSpaceCreationCapability(): Promise<CloudSpaceCreationCapability>;
+  redeemSpaceCreationInvite(code: string): Promise<CloudSpaceCreationCapability>;
   createSpace(name: string, slug: string, visibility?: CloudVisibility): Promise<CloudSpace>;
   updateSpaceVisibility(spaceId: string, visibility: CloudVisibility): Promise<CloudSpace>;
   getSpace(spaceId: string): Promise<CloudSpace>;
@@ -168,8 +182,15 @@ export function createCloudClient(
     if (init.body != null) headers.set('Content-Type', 'application/json');
     const response = await fetchImpl(`${session.baseUrl}${path}`, { ...init, headers });
     if (!response.ok) {
-      const payload = await response.json().catch(() => null) as { error?: string } | null;
-      throw new CloudApiError(response.status, payload?.error || `Cloud request failed (${response.status})`);
+      const payload = await response.json().catch(() => null) as {
+        error?: string;
+        code?: string;
+      } | null;
+      throw new CloudApiError(
+        response.status,
+        payload?.error || `Cloud request failed (${response.status})`,
+        payload?.code ?? null,
+      );
     }
     if (response.status === 204) return undefined as T;
     return response.json() as Promise<T>;
@@ -188,6 +209,11 @@ export function createCloudClient(
     },
     logout: () => request('/api/auth/logout', { method: 'POST' }),
     listSpaces: () => request('/api/spaces'),
+    getSpaceCreationCapability: () => request('/api/space-creation-capability'),
+    redeemSpaceCreationInvite: (code) => request('/api/space-creation-capability/redeem', {
+      method: 'POST',
+      body: JSON.stringify({ code: code.trim() }),
+    }),
     createSpace: (name, slug, visibility = 'private') => request('/api/spaces', {
       method: 'POST',
       body: JSON.stringify({ name, slug, visibility }),

--- a/web/src/cloud/cloud-shell-model.ts
+++ b/web/src/cloud/cloud-shell-model.ts
@@ -1,5 +1,5 @@
 import { canManageMembers, canMerge, type CloudRole } from './session.ts';
-import type { CloudTreeEntry } from './client.ts';
+import type { CloudSpaceCreationCapability, CloudTreeEntry } from './client.ts';
 
 export type CloudNavigationId = 'wiki' | 'reviews' | 'members';
 
@@ -45,4 +45,13 @@ export function routeScopedValue<T>(
   loaded: SpaceScopedResource<T> | null,
 ): T | null {
   return loaded?.spaceId === selectedSpaceId ? loaded.value : null;
+}
+
+export function spaceCreationPanelMode(
+  capability: CloudSpaceCreationCapability,
+): 'invite' | 'create' | 'limit' {
+  if (capability.reason === 'limit_reached' || capability.createdCount >= capability.limit) {
+    return 'limit';
+  }
+  return capability.authorized ? 'create' : 'invite';
 }

--- a/web/tests/cloud-client.test.ts
+++ b/web/tests/cloud-client.test.ts
@@ -149,6 +149,65 @@ test('Space visibility mutations preserve explicit public and private intent', a
   assert.deepEqual(JSON.parse(String(calls[1].init?.body)), { visibility: 'private' });
 });
 
+test('Space creation capability can be read and unlocked with a trimmed invite code', async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const responses = [
+    {
+      authorized: false,
+      createdCount: 0,
+      limit: 2,
+      canCreate: false,
+      reason: 'invite_required',
+    },
+    {
+      authorized: true,
+      createdCount: 0,
+      limit: 2,
+      canCreate: true,
+      reason: null,
+    },
+  ];
+  const fakeFetch: CloudFetch = async (input, init) => {
+    calls.push({ url: String(input), init });
+    return Response.json(responses.shift());
+  };
+  const client = createCloudClient(
+    { baseUrl: 'https://cloud.cowiki.test', apiKey: 'key', userId, userName: 'User' },
+    fakeFetch,
+  );
+
+  const locked = await client.getSpaceCreationCapability();
+  const unlocked = await client.redeemSpaceCreationInvite('  cw_space_test  ');
+
+  assert.equal(locked.reason, 'invite_required');
+  assert.equal(unlocked.canCreate, true);
+  assert.deepEqual(calls.map((call) => call.url), [
+    'https://cloud.cowiki.test/api/space-creation-capability',
+    'https://cloud.cowiki.test/api/space-creation-capability/redeem',
+  ]);
+  assert.equal(calls[1].init?.method, 'POST');
+  assert.deepEqual(JSON.parse(String(calls[1].init?.body)), { code: 'cw_space_test' });
+  assert.equal(new Headers(calls[1].init?.headers).get('authorization'), 'Bearer key');
+});
+
+test('Cloud API failures retain the structured server error code', async () => {
+  const fakeFetch: CloudFetch = async () => Response.json(
+    { error: 'Space creation requires an invite', code: 'invite_required' },
+    { status: 403 },
+  );
+  const client = createCloudClient(
+    { baseUrl: 'https://cloud.cowiki.test', apiKey: 'key', userId, userName: 'User' },
+    fakeFetch,
+  );
+
+  await assert.rejects(
+    client.createSpace('Competition', 'competition'),
+    (error: unknown) => error instanceof CloudApiError
+      && error.status === 403
+      && error.code === 'invite_required',
+  );
+});
+
 test('public Cloud reads never send a bearer credential', async () => {
   const calls: Array<{ url: string; init?: RequestInit }> = [];
   const fakeFetch: CloudFetch = async (input, init) => {

--- a/web/tests/cloud-shell.test.ts
+++ b/web/tests/cloud-shell.test.ts
@@ -8,6 +8,7 @@ import {
   mergeActionVisible,
   resolveInitialCloudPage,
   routeScopedValue,
+  spaceCreationPanelMode,
 } from '../src/cloud/cloud-shell-model.ts';
 
 const app = readFileSync(new URL('../src/App.tsx', import.meta.url), 'utf8');
@@ -56,6 +57,36 @@ test('Cloud reuses the client Space rail and keeps the zero-Space state quiet', 
   assert.doesNotMatch(cloudHome, /Use invitation link/);
   assert.doesNotMatch(cloudHome, />Shared Spaces</);
   assert.doesNotMatch(cloudSpace, /CloudHeader/);
+});
+
+test('shared Space creation switches between invite, creation, and quota states', () => {
+  assert.equal(spaceCreationPanelMode({
+    authorized: false,
+    createdCount: 0,
+    limit: 2,
+    canCreate: false,
+    reason: 'invite_required',
+  }), 'invite');
+  assert.equal(spaceCreationPanelMode({
+    authorized: true,
+    createdCount: 1,
+    limit: 2,
+    canCreate: true,
+    reason: null,
+  }), 'create');
+  assert.equal(spaceCreationPanelMode({
+    authorized: true,
+    createdCount: 2,
+    limit: 2,
+    canCreate: false,
+    reason: 'limit_reached',
+  }), 'limit');
+  assert.match(cloudHome, /getSpaceCreationCapability/);
+  assert.match(cloudHome, /redeemSpaceCreationInvite/);
+  assert.match(cloudHome, /Space creation invite code/);
+  assert.match(cloudHome, /You can still join existing shared Spaces/);
+  assert.match(cloudHome, /createdCount/);
+  assert.match(cloudHome, /limit_reached/);
 });
 
 test('Cloud Space reuses the client panel, knowledge tree, and page reader', () => {


### PR DESCRIPTION
## What changed

- add typed Cloud APIs for checking and redeeming Space-creation capability
- show an invite-code unlock state to signed-in users who can only join existing Spaces
- transition to the normal creation form immediately after a successful redemption
- show the current `created / limit` quota and replace the form with a clear 2-of-2 limit state
- retain structured server error codes so stale clients refresh authoritative capability after a rejected create

## Why

GitHub OAuth registration remains open, but creating a new shared Space is intentionally controlled for the event. New users can still accept invitation links and join Spaces without a creation invite.

Backend contract: https://github.com/wfnuser/cowiki-backend/pull/7

## Validation

- full `npm test`
- `npm run build`
- `npm run lint`
- local browser walkthrough of locked, redeemed, and quota-reached states
