### PR TITLE
feat(desktop): capture web Sources as Markdown

### DIFF
--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "calamine",
  "docx-rs",
  "git2",
+ "htmlmd-core",
  "libc",
  "pdf-extract",
  "percent-encoding",
@@ -804,7 +805,20 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
- "cssparser-macros",
+ "cssparser-macros 0.6.1",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros 0.7.0",
  "dtoa-short",
  "itoa",
  "phf",
@@ -816,6 +830,16 @@ name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -1028,11 +1052,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
- "cssparser",
+ "cssparser 0.36.0",
  "foldhash",
- "html5ever",
+ "html5ever 0.38.0",
  "precomputed-hash",
- "selectors",
+ "selectors 0.36.1",
  "tendril",
 ]
 
@@ -1101,6 +1125,12 @@ checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "embed-resource"
@@ -1821,13 +1851,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "htmd"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a1c7113c831fec68cbd79cd8bf281a84e5b6943f51473dc266b0b88a6a017e"
+dependencies = [
+ "html5ever 0.38.0",
+ "markup5ever_rcdom",
+ "phf",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
+]
+
+[[package]]
+name = "htmlmd-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd5b4fe9c07b7def9969a02f11c070cb8a16b7b9adf3b605bc84fa5f036e05ab"
+dependencies = [
+ "ego-tree",
+ "htmd",
+ "html5ever 0.38.0",
+ "indexmap 2.14.0",
+ "log",
+ "markup5ever 0.39.0",
+ "markup5ever_rcdom",
+ "once_cell",
+ "regex",
+ "scraper",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "unicode-normalization",
+ "url",
 ]
 
 [[package]]
@@ -2448,6 +2522,29 @@ dependencies = [
  "log",
  "tendril",
  "web_atoms",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.38.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
+dependencies = [
+ "html5ever 0.38.0",
+ "markup5ever 0.38.0",
+ "tendril",
+ "xml5ever",
 ]
 
 [[package]]
@@ -3749,13 +3846,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser 0.37.0",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.39.0",
+ "precomputed-hash",
+ "selectors 0.38.0",
+ "tendril",
+]
+
+[[package]]
 name = "selectors"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
  "bitflags 2.13.0",
- "cssparser",
+ "cssparser 0.36.0",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cssparser 0.37.0",
  "derive_more",
  "log",
  "new_debug_unreachable",
@@ -4117,6 +4248,7 @@ dependencies = [
  "parking_lot",
  "phf_shared",
  "precomputed-hash",
+ "serde",
 ]
 
 [[package]]
@@ -5885,6 +6017,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -20,8 +20,9 @@ serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
 tauri = { version = "2", features = [] }
-time = "=0.3.44"
+time = { version = "=0.3.44", features = ["formatting"] }
 url = "2"
+htmlmd-core = "0.1.2"
 git2 = "0.20"
 libc = "0.2"
 portable-pty = "0.9"

--- a/web/src-tauri/src/lib.rs
+++ b/web/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod local_engine;
 mod mcp;
 mod okf;
 mod terminal;
+mod web_source;
 
 use local_engine::{
     AgentChange, BrokenLink, Checkpoint, FileDiff, IngestFileOutcome, LocalEngine, PageFull,
@@ -145,15 +146,20 @@ fn local_get_source(
 }
 
 #[tauri::command]
-fn local_ingest(
+async fn local_ingest(
     engine: State<'_, LocalEngine>,
     space_slug: String,
     source_type: String,
     content: String,
     filename: Option<String>,
 ) -> Result<SourceItem, String> {
-    let _mutation = engine.lock_mutations()?;
-    engine.ingest(&space_slug, &source_type, &content, filename.as_deref())
+    let engine = engine.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let _mutation = engine.lock_mutations()?;
+        engine.ingest(&space_slug, &source_type, &content, filename.as_deref())
+    })
+    .await
+    .map_err(|error| format!("local source import task failed: {error}"))?
 }
 
 #[tauri::command]

--- a/web/src-tauri/src/local_engine.rs
+++ b/web/src-tauri/src/local_engine.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 
 use crate::knowledge_index::{self, SearchHit};
 use crate::okf::{self, DocumentKind};
+use crate::web_source::{self, WebSourceSnapshot};
 
 mod agent_changes;
 pub use crate::knowledge_index::BrokenLink;
@@ -623,20 +624,26 @@ impl LocalEngine {
     ) -> Result<SourceItem, String> {
         let space = self.find_space(space_slug)?;
         okf::ensure_supported_for_write(&space.local_path)?;
-        let fallback = match source_type {
-            "url" => url::Url::parse(content.trim())
-                .ok()
-                .and_then(|value| value.host_str().map(ToOwned::to_owned))
-                .unwrap_or_else(|| "web-source".to_string()),
-            _ => "source".to_string(),
-        };
+        if source_type == "url" {
+            let snapshot = web_source::fetch_markdown_snapshot(content)?;
+            let content_hash = sha256_bytes(snapshot.markdown.as_bytes());
+            let requested = filename.unwrap_or(&snapshot.title);
+            let source = self.write_source_document(
+                &space,
+                requested,
+                &snapshot.title,
+                &snapshot.markdown,
+                Some(&content_hash),
+                Some(&snapshot),
+            )?;
+            self.refresh_source_views(&space)?;
+            return Ok(source);
+        }
+        let fallback = "source".to_string();
         let requested = filename.unwrap_or(&fallback);
-        let title = if source_type == "url" {
-            content.trim()
-        } else {
-            requested.trim()
-        };
-        let source = self.write_source_document(&space, requested, title, content.trim(), None)?;
+        let title = requested.trim();
+        let source =
+            self.write_source_document(&space, requested, title, content.trim(), None, None)?;
         self.refresh_source_views(&space)?;
         Ok(source)
     }
@@ -695,7 +702,14 @@ impl LocalEngine {
             .file_stem()
             .and_then(|stem| stem.to_str())
             .unwrap_or(original_name);
-        self.write_source_document(space, original_name, title, &text, Some(&content_hash))
+        self.write_source_document(
+            space,
+            original_name,
+            title,
+            &text,
+            Some(&content_hash),
+            None,
+        )
     }
 
     /// Shared write path for every ingest flavor: pasted text, a URL
@@ -718,6 +732,7 @@ impl LocalEngine {
         title: &str,
         body_text: &str,
         content_hash: Option<&str>,
+        web_snapshot: Option<&WebSourceSnapshot>,
     ) -> Result<SourceItem, String> {
         let relative = okf::source_storage_path(requested_filename)?;
         let mut candidate = checked_space_path(&space.local_path, &relative)?;
@@ -767,7 +782,17 @@ impl LocalEngine {
         }
 
         let mut frontmatter = format!("title: {}\ntype: Source\n", yaml_string(title));
-        if let Some(hash) = content_hash {
+        if let Some(snapshot) = web_snapshot {
+            frontmatter.push_str(&format!(
+                "source_url: {}\ncaptured_at: {}\nextractor: {}\n",
+                yaml_string(&snapshot.source_url),
+                yaml_string(&snapshot.captured_at),
+                yaml_string(web_source::EXTRACTOR_NAME),
+            ));
+            if let Some(hash) = content_hash {
+                frontmatter.push_str(&format!("content_hash: {}\n", yaml_string(hash)));
+            }
+        } else if let Some(hash) = content_hash {
             frontmatter.push_str(&format!("source_hash: {}\n", yaml_string(hash)));
         }
         let body = format!("---\n{frontmatter}---\n\n{}\n", body_text.trim());
@@ -2097,7 +2122,10 @@ fn sha256_file(path: &Path) -> Result<String, String> {
 fn source_hash_matches(path: &Path, expected_hash: &str) -> bool {
     std::fs::read_to_string(path)
         .ok()
-        .and_then(|existing| frontmatter_field(&existing, "source_hash"))
+        .and_then(|existing| {
+            frontmatter_field(&existing, "source_hash")
+                .or_else(|| frontmatter_field(&existing, "content_hash"))
+        })
         .is_some_and(|existing_hash| existing_hash == expected_hash)
 }
 
@@ -2282,7 +2310,10 @@ pub(crate) fn markdown_title(body: &str) -> Option<String> {
 mod tests {
     use super::{sha256_file, CloudLink, LocalEngine};
     use git2::Repository;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::sync::{mpsc, Arc, Barrier};
+    use std::thread;
     use std::time::Duration;
 
     #[test]
@@ -4167,6 +4198,66 @@ mod tests {
             .any(|diff| diff.path == format!(".cowiki/sources/{}", item.filename)));
         assert!(engine.submit(&space.slug, &[]).unwrap().committed);
         assert!(!engine.has_uncommitted_changes(&space.slug).unwrap());
+    }
+
+    #[test]
+    fn url_ingest_captures_a_markdown_snapshot_with_provenance() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let html = r#"<!doctype html>
+<html>
+  <head><title>CoWiki &amp; Local AI</title></head>
+  <body>
+    <nav>Site navigation</nav>
+    <main>
+      <h1>Knowledge stays yours</h1>
+      <p>Agents can build on <a href="/principles">portable knowledge</a>.</p>
+    </main>
+    <script>window.secret = "must not be stored";</script>
+  </body>
+</html>"#;
+        let html_bytes = html.as_bytes().to_vec();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request).unwrap();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                html_bytes.len()
+            )
+            .unwrap();
+            stream.write_all(&html_bytes).unwrap();
+        });
+
+        let temp = tempfile::tempdir().unwrap();
+        let engine = LocalEngine::open(&temp.path().join("metadata")).unwrap();
+        let folder = temp.path().join("knowledge");
+        std::fs::create_dir_all(&folder).unwrap();
+        let space = engine.add_space("Knowledge", "knowledge", &folder).unwrap();
+        let source_url = format!("http://{address}/article");
+
+        let item = engine
+            .ingest(&space.slug, "url", &source_url, None)
+            .unwrap();
+        assert_eq!(item.title, "CoWiki & Local AI");
+        server.join().unwrap();
+        let source = engine.get_source(&space.slug, &item.filename).unwrap();
+        assert!(source
+            .content
+            .contains(&format!("source_url: \"{source_url}\"")));
+        assert!(source.content.contains("captured_at:"));
+        assert!(source
+            .content
+            .contains("extractor: \"cowiki-html-to-markdown-v1\""));
+        assert!(source.content.contains("content_hash:"));
+        assert!(source.content.contains("# Knowledge stays yours"));
+        assert!(source.content.contains(&format!(
+            "[portable knowledge](http://{address}/principles)"
+        )));
+        assert!(!source.content.contains("Site navigation"));
+        assert!(!source.content.contains("must not be stored"));
+        assert!(!folder.join(".cowiki/sources").join("article.html").exists());
     }
 
     #[test]

--- a/web/src-tauri/src/web_source.rs
+++ b/web/src-tauri/src/web_source.rs
@@ -1,0 +1,115 @@
+use htmlmd_core::{convert, ConversionOptions};
+use std::io::Read;
+use std::time::Duration;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use url::Url;
+
+pub const EXTRACTOR_NAME: &str = "cowiki-html-to-markdown-v1";
+const MAX_HTML_BYTES: u64 = 5 * 1024 * 1024;
+const MAX_MARKDOWN_BYTES: u64 = 2 * 1024 * 1024;
+
+pub struct WebSourceSnapshot {
+    pub title: String,
+    pub source_url: String,
+    pub captured_at: String,
+    pub markdown: String,
+}
+
+pub fn fetch_markdown_snapshot(value: &str) -> Result<WebSourceSnapshot, String> {
+    let requested_url = validate_url(value)?;
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .user_agent("CoWiki/0.1 web-source-ingest")
+        .build()
+        .map_err(|error| format!("cannot prepare web request: {error}"))?;
+    let response = client
+        .get(requested_url)
+        .send()
+        .map_err(|error| format!("cannot fetch web source: {error}"))?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "web source returned HTTP {}",
+            response.status().as_u16()
+        ));
+    }
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_HTML_BYTES)
+    {
+        return Err(format!(
+            "web source is too large (maximum {MAX_HTML_BYTES} bytes)"
+        ));
+    }
+    if let Some(content_type) = response.headers().get(reqwest::header::CONTENT_TYPE) {
+        let content_type = content_type
+            .to_str()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        if !content_type.starts_with("text/html")
+            && !content_type.starts_with("application/xhtml+xml")
+        {
+            return Err("URL does not point to an HTML page".to_string());
+        }
+    }
+
+    let final_url = response.url().clone();
+    let mut html = Vec::new();
+    response
+        .take(MAX_HTML_BYTES + 1)
+        .read_to_end(&mut html)
+        .map_err(|error| format!("cannot read web source: {error}"))?;
+    if html.len() as u64 > MAX_HTML_BYTES {
+        return Err(format!(
+            "web source is too large (maximum {MAX_HTML_BYTES} bytes)"
+        ));
+    }
+
+    let html = String::from_utf8_lossy(&html);
+    let mut options = ConversionOptions::gfm();
+    options.cleanup.metadata.title = true;
+    options.cleanup.base_url = Some(final_url.to_string());
+    options.cleanup.main_content_selector = Some("article, main, [role=main]".to_string());
+    options.cleanup.remove_tags.extend(
+        ["nav", "header", "footer", "aside"]
+            .into_iter()
+            .map(str::to_string),
+    );
+    options.limits.max_input_bytes = MAX_HTML_BYTES;
+    options.limits.max_output_bytes = MAX_MARKDOWN_BYTES;
+    options.limits.max_node_count = 200_000;
+    options.limits.max_attribute_len = 100_000;
+    options.strict = true;
+
+    let converted = convert(&html, &options)
+        .map_err(|error| format!("cannot convert web source to Markdown: {error}"))?;
+    let markdown = converted.markdown.trim().to_string();
+    if markdown.is_empty() {
+        return Err("web source contains no readable content".to_string());
+    }
+    let title = converted
+        .title
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or_else(|| final_url.host_str().unwrap_or("Web source").to_string());
+    let captured_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|error| format!("cannot format capture time: {error}"))?;
+
+    Ok(WebSourceSnapshot {
+        title,
+        source_url: final_url.to_string(),
+        captured_at,
+        markdown,
+    })
+}
+
+fn validate_url(value: &str) -> Result<Url, String> {
+    let url = Url::parse(value.trim()).map_err(|_| "Enter a valid HTTP(S) URL".to_string())?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return Err("Enter a valid HTTP(S) URL without embedded credentials".to_string());
+    }
+    Ok(url)
+}

--- a/web/src/components/AddSourceDialog.tsx
+++ b/web/src/components/AddSourceDialog.tsx
@@ -234,7 +234,7 @@ export function AddSourceDialog({
                 placeholder="https://example.com/article"
               />
               <p className="text-xs text-muted-foreground">
-                The URL is kept as an OKF source. Codex or Claude can read it and organize durable knowledge.
+                The page is captured as Markdown with its URL and capture time. Codex or Claude can then organize durable knowledge.
               </p>
             </TabsContent>
 

--- a/web/src/lib/page-frontmatter.ts
+++ b/web/src/lib/page-frontmatter.ts
@@ -16,3 +16,30 @@ export function splitSystemFrontmatter(document: string): EditablePage {
 export function restoreSystemFrontmatter(systemFrontmatter: string, body: string): string {
   return `${systemFrontmatter}${body}`;
 }
+
+/** Return the safe HTTP(S) origin link recorded for a captured web Source. */
+export function sourceUrlFromDocument(document: string): string | null {
+  const { systemFrontmatter } = splitSystemFrontmatter(document);
+  const line = systemFrontmatter
+    .split(/\r?\n/)
+    .find((candidate) => candidate.startsWith('source_url:'));
+  if (!line) return null;
+
+  const encoded = line.slice('source_url:'.length).trim();
+  let value = encoded.replace(/^['"]|['"]$/g, '');
+  if (encoded.startsWith('"') && encoded.endsWith('"')) {
+    try {
+      value = JSON.parse(encoded) as string;
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    const url = new URL(value);
+    if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}

--- a/web/src/pages/MainLayout.tsx
+++ b/web/src/pages/MainLayout.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Compass,
   Pencil, FolderOpen, PanelLeft, Bot, HardDrive, FolderInput, Cloud, UserPlus, ChevronLeft,
+  ExternalLink,
 } from 'lucide-react';
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle,
@@ -79,9 +80,10 @@ import {
   saveClientSettings,
   type DefaultAgent,
 } from '@/lib/client-settings';
-import { splitSystemFrontmatter } from '@/lib/page-frontmatter';
+import { sourceUrlFromDocument, splitSystemFrontmatter } from '@/lib/page-frontmatter';
 import { sourceOrganizationTask } from '@/lib/source-ingest';
 import { resolveWorkspaceSwitchTarget } from '@/lib/workspace-navigation';
+import { openExternalUrl } from '@/external-links';
 
 type ActiveView =
   | { kind: 'page'; slug: string; path?: string; content: PageFull | null }
@@ -867,6 +869,9 @@ export function MainLayout() {
   // Determine active page/source for panel highlight
   const currentActivePage = activeView?.kind === 'page' ? activeView.slug : null;
   const currentActiveSource = activeView?.kind === 'source' ? activeView.filename : null;
+  const activeSourceUrl = activeView?.kind === 'source' && activeView.content
+    ? sourceUrlFromDocument(activeView.content.content)
+    : null;
   const selectedAgentChange = versionSelection.kind === 'agent'
     ? openAgentChanges.find((change) => change.id === versionSelection.changeId)
     : undefined;
@@ -1282,13 +1287,24 @@ export function MainLayout() {
               /* Source view */
               ) : activeView?.kind === 'source' && activeView.content ? (
                 <div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginBottom: 16 }}>
                     <span style={{
                       padding: '2px 10px', fontSize: 11, borderRadius: 12,
                       background: C.blueSoft, color: C.blue, fontWeight: 500,
                     }}>
                       Source File
                     </span>
+                    {activeSourceUrl && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => { void openExternalUrl(activeSourceUrl); }}
+                      >
+                        <ExternalLink className="size-4" />
+                        View original
+                      </Button>
+                    )}
                   </div>
                   <article>
                     <h1 className="page-title page-title--compact source-title">

--- a/web/tests/page-frontmatter.test.ts
+++ b/web/tests/page-frontmatter.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { restoreSystemFrontmatter, splitSystemFrontmatter } from '../src/lib/page-frontmatter.ts';
+import {
+  restoreSystemFrontmatter,
+  sourceUrlFromDocument,
+  splitSystemFrontmatter,
+} from '../src/lib/page-frontmatter.ts';
 
 test('system frontmatter is hidden from the editable document and restored exactly', () => {
   const original = '---\ntype: Note\ntitle: "Test"\nsummary: ""\n---\n\nEditable text\n- [ ] Task';
@@ -21,4 +25,24 @@ test('read-only Source rendering hides OKF frontmatter', () => {
   );
 
   assert.equal(source.body, 'https://example.com');
+});
+
+test('a captured web Source exposes its original URL without leaking other metadata', () => {
+  const source = [
+    '---',
+    'title: "Example: \\"quoted\\""',
+    'type: Source',
+    'source_url: "https://example.com/article?q=local%20first"',
+    'captured_at: "2026-09-04T12:00:00Z"',
+    '---',
+    '',
+    '# Article',
+  ].join('\n');
+
+  assert.equal(sourceUrlFromDocument(source), 'https://example.com/article?q=local%20first');
+  assert.equal(sourceUrlFromDocument('---\ntype: Source\n---\n\nPlain source'), null);
+  assert.equal(
+    sourceUrlFromDocument('---\nsource_url: "javascript:alert(1)"\n---\n'),
+    null,
+  );
 });


### PR DESCRIPTION
## Summary
- fetch public HTTP(S) pages in the desktop client and convert readable content to Markdown
- store source URL, capture time, extractor identity, and content hash in Source frontmatter
- expose a safe View original action without persisting raw HTML or executing page JavaScript

## Verification
- cargo test --locked --manifest-path web/src-tauri/Cargo.toml --all-targets
- cargo clippy --locked --manifest-path web/src-tauri/Cargo.toml --all-targets
- npm test
- npm run lint
- npm run build
- live smoke capture of https://example.com/